### PR TITLE
JSONEncoder warnings and better docs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,8 @@ name: Python package
 on:
   push:
     branches: [ master ]
+    tags:
+      - v*
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
* `JSONEncoder` not outputs a warning instead of an error when encountering a value it can't encode as a function argument, keyword argument, or return value
* Add documentation on how to extend the `JSONEncoder` class to capture custom data types and classes in a benchmark suite

Fixes: #2 