### PR TITLE
fix: line_profiler hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ extended example, above.
 
 You can also add functions to your benchmark suite to capture
 extra information at runtime. These functions must be prefixed with `capture_`
-for them to run automatically before the function starts. They take
+for them to run automatically before the function starts, or `capturepost_`
+for them to run automatically when the function completes. They take
 a single argument, `bm_data`, a dictionary to be extended with extra data.
 Care should be taken to avoid overwriting existing key names.
 

--- a/microbench/tests/test_line_profiler.py
+++ b/microbench/tests/test_line_profiler.py
@@ -24,3 +24,4 @@ def test_line_profiler():
     lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])
     assert lp.__class__.__name__ == 'LineStats'
     MBLineProfiler.print_line_profile(results['line_profiler'][0])
+    assert not all(len(v) == 0 for v in lp.timings.values()), "No timings present"


### PR DESCRIPTION
Capture line_profiler data using capturepost_ hook to ensure we collate it after the wrapped function is executed.