### PR TITLE
fix: update pandas.read_json syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ into a `io.StringIO()` buffer, which can be read as follows
 
 ```python
 import pandas as pd
-results = pd.read_json(basic_bench.outfile.getvalue(), lines=True)
+results = pd.read_json(basic_bench.outfile, lines=True)
 ```
 
 The above example captures the fields `start_time`, `finish_time`,
@@ -169,6 +169,10 @@ The simplest way to examine results in detail is to load them into a
 [pandas](https://pandas.pydata.org/) dataframe:
 
 ```python
+# Read results directly from active benchmark suite
+benchmark.get_results()
+
+# Or, equivalently when using a file, read it using pandas directly
 import pandas
 results = pandas.read_json('/home/user/my-benchmarks', lines=True)
 ```
@@ -219,7 +223,7 @@ def my_function():
 my_function()
 
 # Read the results into a Pandas DataFrame
-results = pandas.read_json(lpbench.outfile.getvalue(), lines=True)
+results = lpbench.get_results()
 
 # Get the line profiler report as an object
 lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -33,6 +33,10 @@ try:
     import numpy
 except ImportError:
     numpy = None
+try:
+    import pandas
+except ImportError:
+    pandas = None
 from .diff import envdiff
 
 
@@ -175,6 +179,15 @@ class MicroBench(object):
         else:
             # Assume file-like object
             self.outfile.write(bm_str)
+
+    def get_results(self):
+        if not pandas:
+            raise ImportError('This fuctionality requires the "pandas" package')
+
+        if hasattr(self.outfile, 'seek'):
+            self.outfile.seek(0)
+
+        return pandas.read_json(self.outfile, lines=True)
 
     def __call__(self, func):
         def inner(*args, **kwargs):
@@ -353,13 +366,13 @@ class MBLineProfiler(object):
     in production.
     """
     def capturepost_line_profile(self, bm_data):
-        bm_data['line_profiler'] = base64.encodebytes(
+        bm_data['line_profiler'] = base64.b64encode(
             pickle.dumps(self._line_profiler.get_stats())
         ).decode('utf8')
 
     @staticmethod
     def decode_line_profile(line_profile_pickled):
-        return pickle.loads(base64.decodebytes(line_profile_pickled.encode()))
+        return pickle.loads(base64.b64decode(line_profile_pickled))
 
     @classmethod
     def print_line_profile(self, line_profile_pickled, **kwargs):

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -28,7 +28,7 @@ def test_function():
     for _ in range(3):
         assert my_function() == 499999500000
 
-    results = pandas.read_json(benchmark.outfile.getvalue(), lines=True)
+    results = benchmark.get_results()
     assert (results['function_name'] == 'my_function').all()
     assert results['package_versions'][0]['pandas'] == pandas.__version__
     runtimes = results['finish_time'] - results['start_time']
@@ -50,7 +50,7 @@ def test_multi_iterations():
     # call the function
     my_function()
 
-    results = pandas.read_json(benchmark.outfile.getvalue(), lines=True)
+    results = benchmark.get_results()
     assert (results['function_name'] == 'my_function').all()
     runtimes = results['finish_time'] - results['start_time']
     assert (runtimes >= datetime.timedelta(0)).all()
@@ -68,7 +68,7 @@ def test_capture_global_packages():
 
     noop()
 
-    results = pandas.read_json(globals_bench.outfile.getvalue(), lines=True)
+    results = globals_bench.get_results()
 
     # We should've captured microbench and pandas versions from top level
     # imports in this file
@@ -89,7 +89,7 @@ def test_capture_packages_importlib():
 
     noop()
 
-    results = pandas.read_json(pkg_bench.outfile.getvalue(), lines=True)
+    results = pkg_bench.get_results()
     assert pandas.__version__ == results['package_versions'][0]['pandas']
 
 
@@ -111,7 +111,7 @@ def test_telemetry():
     assert not telem_bench._telemetry_thread.is_alive()
 
     # Check some telemetry was captured
-    results = pandas.read_json(telem_bench.outfile.getvalue(), lines=True)
+    results = telem_bench.get_results()
     assert len(results['telemetry']) > 0
 
 
@@ -135,7 +135,7 @@ def test_unjsonencodable_arg_kwarg_retval():
         assert all(issubclass(w_.category, JSONEncodeWarning) for w_ in w)
 
 
-    results = pandas.read_json(bench.outfile.getvalue(), lines=True)
+    results =bench.get_results()
     assert results['args'][0] == [_UNENCODABLE_PLACEHOLDER_VALUE]
     assert results['kwargs'][0] == {'arg2': _UNENCODABLE_PLACEHOLDER_VALUE}
     assert results['return_value'][0] == _UNENCODABLE_PLACEHOLDER_VALUE
@@ -173,5 +173,5 @@ def test_custom_jsonencoder():
 
     dummy()
 
-    results = pandas.read_json(bench.outfile.getvalue(), lines=True)
+    results = bench.get_results()
     assert results['return_value'][0] == str(obj)

--- a/microbench/tests/test_line_profiler.py
+++ b/microbench/tests/test_line_profiler.py
@@ -1,5 +1,6 @@
 from microbench import MicroBench, MBLineProfiler
 import pandas
+import io
 
 
 def test_line_profiler():
@@ -20,7 +21,7 @@ def test_line_profiler():
     for _ in range(3):
         assert my_function() == 499999500000
 
-    results = pandas.read_json(lpbench.outfile.getvalue(), lines=True)
+    results = lpbench.get_results()
     lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])
     assert lp.__class__.__name__ == 'LineStats'
     MBLineProfiler.print_line_profile(results['line_profiler'][0])

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -23,6 +23,6 @@ def test_nvidia():
 
     test()
 
-    results = pandas.read_json(bench.outfile.getvalue(), lines=True)
+    results = bench.get_results()
     assert 'nvidia_gpu_name' in results.columns
     assert 'nvidia_memory.total' in results.columns

--- a/microbench/tests/test_psutil.py
+++ b/microbench/tests/test_psutil.py
@@ -14,6 +14,6 @@ def test_psutil():
 
     test_func()
 
-    results = pandas.read_json(mybench.outfile.getvalue(), lines=True)
+    results = mybench.get_results()
     assert results['cpu_cores_logical'][0] >= 1
     assert results['ram_total'][0] > 0


### PR DESCRIPTION
Pandas has deprecated read_json(string), so we now use read_json(StringIO) instead. README has been updated with new syntax.