### PR TITLE
fix: typo 'fuctionality' in get_results error message

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -203,7 +203,7 @@ class MicroBench(object):
 
     def get_results(self):
         if not pandas:
-            raise ImportError('This fuctionality requires the "pandas" package')
+            raise ImportError('This functionality requires the "pandas" package')
 
         if hasattr(self.outfile, 'seek'):
             self.outfile.seek(0)


### PR DESCRIPTION
## Summary
- Corrects a typo in the `ImportError` message raised by `get_results()` when pandas is not installed: `'fuctionality'` → `'functionality'`