### PR TITLE
fix: CSS syntax error in diff.py _html_sidebyside

### DIFF
--- a/microbench/diff.py
+++ b/microbench/diff.py
@@ -55,7 +55,7 @@ def _html_sidebyside(a, b):
     out += '<p></p><p></p>'
     for left, right in zip_longest(a, b, fillvalue=''):
         out += '<pre style="margin-top:0;padding:0">{}</pre>'.format(left)
-        out += '<pre style="margin-top:0";padding:0>{}</pre>'.format(right)
+        out += '<pre style="margin-top:0;padding:0">{}</pre>'.format(right)
     out += '</div>'
     return out
 


### PR DESCRIPTION
## Summary
- Fixes a misplaced closing quote in `_html_sidebyside` that produced invalid CSS: `"margin-top:0";padding:0>` → `"margin-top:0;padding:0">`
- The right-hand `<pre>` element in side-by-side diffs had no padding applied