### PR TITLE
fix: use cls instead of self in MBLineProfiler.print_line_profile classmethod

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -396,8 +396,8 @@ class MBLineProfiler(object):
         return pickle.loads(base64.b64decode(line_profile_pickled))
 
     @classmethod
-    def print_line_profile(self, line_profile_pickled, **kwargs):
-        lp_data = self.decode_line_profile(line_profile_pickled)
+    def print_line_profile(cls, line_profile_pickled, **kwargs):
+        lp_data = cls.decode_line_profile(line_profile_pickled)
         line_profiler.show_text(lp_data.timings, lp_data.unit, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- `print_line_profile` was decorated with `@classmethod` but used `self` as the first parameter instead of `cls`
- Works by accident (Python binds the class to whichever name is used) but is misleading and non-conventional