### PR TITLE
fix: inverted set difference in MBNvidiaSmi attribute validation

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -487,8 +487,8 @@ class MBNvidiaSmi:
     def capture_nvidia(self, bm_data):
         if hasattr(self, 'nvidia_attributes'):
             nvidia_attributes = self.nvidia_attributes
-            unknown_attrs = set(self._nvidia_attributes_available).difference(
-                nvidia_attributes
+            unknown_attrs = set(nvidia_attributes).difference(
+                self._nvidia_attributes_available
             )
             if unknown_attrs:
                 raise ValueError(

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -1,5 +1,8 @@
 import subprocess
 import unittest
+from unittest.mock import patch
+
+import pytest
 
 from microbench import MBNvidiaSmi, MicroBench
 
@@ -8,6 +11,9 @@ try:
     nvidia_smi_available = True
 except FileNotFoundError:
     nvidia_smi_available = False
+
+# Fake nvidia-smi CSV output: uuid, gpu_name, memory.total
+_FAKE_NVIDIA_SMI_OUTPUT = b'GPU-abc123, Tesla T4, 16160 MiB\n'
 
 
 @unittest.skipIf(not nvidia_smi_available, 'nvidia-smi command not found')
@@ -26,3 +32,60 @@ def test_nvidia():
     results = bench.get_results()
     assert 'nvidia_gpu_name' in results.columns
     assert 'nvidia_memory.total' in results.columns
+
+
+def test_nvidia_unknown_attribute_raises():
+    """Specifying an unknown nvidia_attribute must raise ValueError."""
+
+    class Bench(MicroBench, MBNvidiaSmi):
+        nvidia_attributes = ('gpu_name', 'nonexistent_attr')
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with pytest.raises(ValueError, match='nonexistent_attr'):
+        noop()
+
+
+def test_nvidia_known_attribute_does_not_raise():
+    """Specifying only known attributes must not raise a ValueError."""
+
+    class Bench(MicroBench, MBNvidiaSmi):
+        nvidia_attributes = ('gpu_name',)
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_SMI_OUTPUT):
+        noop()
+
+    results = bench.get_results()
+    assert 'nvidia_gpu_name' in results.columns
+
+
+def test_nvidia_default_attribute_not_flagged_as_unknown():
+    """Omitting a default attribute (memory.total) must not raise (B2 regression check).
+
+    With the original bug, set(available).difference(user_attrs) would flag
+    'memory.total' as 'unknown' simply because the user didn't include it.
+    """
+
+    class Bench(MicroBench, MBNvidiaSmi):
+        # Only request gpu_name, intentionally omitting memory.total
+        nvidia_attributes = ('gpu_name',)
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    # Should NOT raise; memory.total being absent from user's list is fine
+    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_SMI_OUTPUT):
+        noop()


### PR DESCRIPTION
## Summary
- The validation check `set(_available).difference(user_attrs)` was backwards: it flagged *default* attributes not present in the user's list as "unknown", rather than flagging user-specified attributes that don't exist
- Fixed to `set(user_attrs).difference(_available)` so the error message "Unknown nvidia_attributes" is semantically correct
- Adds tests covering the error case, the valid-subset case, and a regression test for the original bug (omitting a default attribute must not raise)