### PR TITLE
fix: wrong parameter name in test_multi_iterations; clarify timezone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,20 +478,21 @@ section of this README, above.
 ### Timezones
 
 Microbench captures `start_time` and `finish_time` as ISO-8601 timestamps in the
-UTC timezone by default. UTC is recommended so that results are comparable across
-machines in different geographic locations.
+UTC timezone by default. The timezone is also recorded in the `timestamp_tz` field
+(e.g. `"UTC"` by default).
 
-The timezone used is recorded in the `timestamp_tz` field for reference (e.g.
-`"UTC"` by default). This can be overridden by passing a `tz=...` argument when
-creating a benchmark suite object, where the value is a `datetime.timezone`
-object. For example, to use the local machine's timezone:
+The timezone can be overridden by passing a `tz=...` argument when creating a
+benchmark suite object, where the value is a `datetime.timezone` object. This
+affects both the timestamps themselves and the `timestamp_tz` label. UTC is
+recommended when comparing results across machines in different locations.
+
+For example, to use the local machine's timezone:
 
 ```python
 import datetime
 from microbench import MicroBench
 
-# Use the local machine's timezone
-bench = MicroBench(tz=datetime.timezone(datetime.datetime.now().astimezone().utcoffset()))
+bench = MicroBench(tz=datetime.datetime.now().astimezone().tzinfo)
 ```
 
 ## Feedback

--- a/README.md
+++ b/README.md
@@ -477,9 +477,22 @@ section of this README, above.
 
 ### Timezones
 
-Microbench captures `start_time` and `finish_time` in the UTC timezone by default.
-This can be overriden by passing a `tz=...` argument when creating a benchmark
-class, where the value is a timezone object (e.g. created using the `pytz` library).
+Microbench captures `start_time` and `finish_time` as ISO-8601 timestamps in the
+UTC timezone by default. UTC is recommended so that results are comparable across
+machines in different geographic locations.
+
+The timezone used is recorded in the `timestamp_tz` field for reference (e.g.
+`"UTC"` by default). This can be overridden by passing a `tz=...` argument when
+creating a benchmark suite object, where the value is a `datetime.timezone`
+object. For example, to use the local machine's timezone:
+
+```python
+import datetime
+from microbench import MicroBench
+
+# Use the local machine's timezone
+bench = MicroBench(tz=datetime.timezone(datetime.datetime.now().astimezone().utcoffset()))
+```
 
 ## Feedback
 

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -67,7 +67,14 @@ def test_multi_iterations():
 
 
 def test_local_timezone():
-    """tz=datetime.datetime.now().astimezone().tzinfo (README example) must work."""
+    """Verify README example syntax: tz=datetime.datetime.now().astimezone().tzinfo.
+
+    This is a smoke test that the expression produces a valid timezone accepted
+    by MicroBench, and that the stored offset matches whatever was passed in.
+    On UTC machines the offset is timedelta(0) — identical to the default — so
+    this test does not discriminate between 'tz= applied' and 'tz= ignored'.
+    test_multi_iterations covers the non-UTC case with a hardcoded UTC+10 offset.
+    """
     class MyBench(MicroBench):
         pass
 
@@ -84,6 +91,7 @@ def test_local_timezone():
     expected_offset = datetime.datetime.now().astimezone().utcoffset()
     assert results['start_time'][0].utcoffset() == expected_offset
     assert results['finish_time'][0].utcoffset() == expected_offset
+    assert results['timestamp_tz'][0] == str(local_tz)
 
 
 def test_capture_global_packages():

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -58,9 +58,32 @@ def test_multi_iterations():
     runtimes = results['finish_time'] - results['start_time']
     assert (runtimes >= datetime.timedelta(0)).all()
     assert results['timestamp_tz'][0] == str(tz)
+    # Verify the timezone is actually applied to the timestamps, not just recorded
+    assert results['start_time'][0].utcoffset() == datetime.timedelta(hours=10)
+    assert results['finish_time'][0].utcoffset() == datetime.timedelta(hours=10)
 
     assert len(results['run_durations'][0]) == iterations
     assert all(dur >= 0 for dur in results['run_durations'][0])
+
+
+def test_local_timezone():
+    """tz=datetime.datetime.now().astimezone().tzinfo (README example) must work."""
+    class MyBench(MicroBench):
+        pass
+
+    local_tz = datetime.datetime.now().astimezone().tzinfo
+    benchmark = MyBench(tz=local_tz)
+
+    @benchmark
+    def noop():
+        pass
+
+    noop()
+
+    results = benchmark.get_results()
+    expected_offset = datetime.datetime.now().astimezone().utcoffset()
+    assert results['start_time'][0].utcoffset() == expected_offset
+    assert results['finish_time'][0].utcoffset() == expected_offset
 
 
 def test_capture_global_packages():

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -42,9 +42,9 @@ def test_multi_iterations():
     class MyBench(MicroBench):
         pass
 
-    timezone = datetime.timezone(datetime.timedelta(hours=10))
+    tz = datetime.timezone(datetime.timedelta(hours=10))
     iterations = 3
-    benchmark = MyBench(iterations=iterations, timezone=timezone)
+    benchmark = MyBench(iterations=iterations, tz=tz)
 
     @benchmark
     def my_function():
@@ -57,7 +57,7 @@ def test_multi_iterations():
     assert (results['function_name'] == 'my_function').all()
     runtimes = results['finish_time'] - results['start_time']
     assert (runtimes >= datetime.timedelta(0)).all()
-    assert results['timezone'][0] == str(timezone)
+    assert results['timestamp_tz'][0] == str(tz)
 
     assert len(results['run_durations'][0]) == iterations
     assert all(dur >= 0 for dur in results['run_durations'][0])


### PR DESCRIPTION
## Summary
- `test_multi_iterations` passed `timezone=` to `MicroBench.__init__`, but the parameter is `tz=`. The timezone was silently stored as a static metadata field instead of being applied, so timestamps remained in UTC. The test then checked `results['timezone']` (the static field) rather than `results['timestamp_tz']` (the actual timezone label).
- Fixed to use `tz=` and assert against `results['timestamp_tz']`
- Expanded the Timezones section of the README to clarify that `timestamp_tz` records the timezone for reference, and shows how to use the local machine's timezone