### PR TITLE
fix: correct misleading CI step name

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies except line_profiler
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pandas psutil line_profiler


### PR DESCRIPTION
## Summary
- The install step was named "Install dependencies except line_profiler" but the command actually installs `line_profiler`
- Renamed to "Install dependencies"