### PR TITLE
fix: TelemetryThread crashes when benchmark is called from a non-main thread

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -553,8 +553,17 @@ class TelemetryThread(threading.Thread):
     def __init__(self, telem_fn, interval, slot, timezone, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._terminate = threading.Event()
-        signal.signal(signal.SIGINT, self.terminate)
-        signal.signal(signal.SIGTERM, self.terminate)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, self.terminate)
+            signal.signal(signal.SIGTERM, self.terminate)
+        else:
+            warnings.warn(
+                'TelemetryThread: signal handlers not registered because '
+                'benchmark was started from a non-main thread. Telemetry '
+                'will still be collected but may not stop cleanly on '
+                'SIGINT/SIGTERM.',
+                RuntimeWarning
+            )
         self._interval = interval
         self._telemetry = slot
         self._telem_fn = telem_fn

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -1,5 +1,6 @@
 import datetime
 import io
+import threading
 import warnings
 
 import pandas
@@ -157,6 +158,46 @@ def test_telemetry():
     # Check some telemetry was captured
     results = telem_bench.get_results()
     assert len(results['telemetry']) > 0
+
+
+def test_telemetry_from_non_main_thread():
+    """Telemetry must not crash when started from a non-main thread (B6 fix).
+
+    signal.signal() can only be called from the main thread; TelemetryThread
+    should skip signal registration and emit a RuntimeWarning instead.
+    """
+
+    class TelemBench(MicroBench):
+        @staticmethod
+        def telemetry(process):
+            return {'rss': process.memory_info().rss}
+
+    telem_bench = TelemBench()
+
+    @telem_bench
+    def noop():
+        pass
+
+    errors = []
+    caught_warnings = []
+
+    def run_from_thread():
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            try:
+                noop()
+            except Exception as exc:
+                errors.append(exc)
+            caught_warnings.extend(w)
+
+    t = threading.Thread(target=run_from_thread)
+    t.start()
+    t.join()
+
+    assert not errors, f'Unexpected exception from non-main thread: {errors[0]}'
+    assert any(issubclass(w.category, RuntimeWarning) for w in caught_warnings), (
+        'Expected a RuntimeWarning about signal registration being skipped'
+    )
 
 
 def test_unjsonencodable_arg_kwarg_retval():


### PR DESCRIPTION
## Summary
- `signal.signal()` can only be called from the main thread; `TelemetryThread.__init__` called it unconditionally, raising `ValueError` if the benchmark decorator was used from a worker thread
- Fixed by guarding signal registration behind `threading.current_thread() is threading.main_thread()`, with a `RuntimeWarning` when skipped so the user is informed
- Adds `test_telemetry_from_non_main_thread` to verify no crash and that the warning is emitted