### PR TITLE
docs: security warning for MBLineProfiler.decode_line_profile (pickle.loads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ of each line of Python code. Note that this will slow down your code, so only us
 discovering bottlenecks within a function. Requires the `line_profiler` package to be installed
 (e.g. `pip install line_profiler`).
 
+> **Security note:** Line profiler results are stored using Python's `pickle`
+> format (base64-encoded). `MBLineProfiler.decode_line_profile()` uses
+> `pickle.loads`, which can execute arbitrary code. Only decode line profiler
+> results from trusted sources (e.g. your own benchmark output files).
+
 ```python
 from microbench import MicroBench, MBLineProfiler
 import pandas

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -434,6 +434,13 @@ class MBLineProfiler:
 
     @staticmethod
     def decode_line_profile(line_profile_pickled):
+        """Decode a base64-encoded pickled line profiler result.
+
+        Security note: This uses pickle.loads, which can execute arbitrary
+        code. Only call this on data from a trusted source (e.g. your own
+        benchmark output files). Do not decode line profile data received
+        over a network or from an untrusted file.
+        """
         return pickle.loads(base64.b64decode(line_profile_pickled))
 
     @classmethod


### PR DESCRIPTION
## Summary
- `decode_line_profile` uses `pickle.loads`, which can execute arbitrary code if the input is from an untrusted source
- Added a security note to the docstring and to the Line profiler section of the README
- A JSON-based alternative is theoretically possible but would require stringifying tuple dict keys and reconstructing `LineStats` objects; the pickle approach is retained as the attack surface is low (requires control of benchmark output files)