### PR TITLE
fix: MBFunctionCall stored JSON strings instead of raw values (double-encoding)

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -285,11 +285,12 @@ class MBFunctionCall:
     """Capture function arguments and keyword arguments"""
 
     def capture_function_args_and_kwargs(self, bm_data):
-        # Check all args are encodeable as JSON
+        # Check all args are encodeable as JSON, then store the raw value
         bm_data['args'] = []
         for i, v in enumerate(bm_data['_args']):
             try:
-                bm_data['args'].append(self.to_json(v))
+                self.to_json(v)
+                bm_data['args'].append(v)
             except TypeError:
                 warnings.warn(
                     f'Function argument {i} is not JSON encodable (type: {type(v)}). '
@@ -298,11 +299,12 @@ class MBFunctionCall:
                 )
                 bm_data['args'].append(_UNENCODABLE_PLACEHOLDER_VALUE)
 
-        # Check all kwargs are encodeable as JSON
+        # Check all kwargs are encodeable as JSON, then store the raw value
         bm_data['kwargs'] = {}
         for k, v in bm_data['_kwargs'].items():
             try:
-                bm_data['kwargs'][k] = self.to_json(v)
+                self.to_json(v)
+                bm_data['kwargs'][k] = v
             except TypeError:
                 warnings.warn(
                     f'Function keyword argument "{k}" is not JSON encodable'

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -159,6 +159,34 @@ def test_telemetry():
     assert len(results['telemetry']) > 0
 
 
+def test_functioncall_args_not_double_encoded():
+    """MBFunctionCall must store raw values, not JSON strings (B5 fix).
+
+    Before the fix, self.to_json(v) stored a JSON string which then got
+    re-serialized, turning e.g. {'k': 1} into the string '{"k": 1}'.
+    """
+
+    class Bench(MicroBench, MBFunctionCall):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def dummy(pos_int, pos_dict, kw_str='default'):
+        pass
+
+    dummy(42, {'key': 'value'}, kw_str='hello')
+
+    results = bench.get_results()
+    args = results['args'][0]
+    kwargs = results['kwargs'][0]
+
+    # Values must be their native Python types, not JSON-encoded strings
+    assert args[0] == 42, f'Expected int 42, got {args[0]!r}'
+    assert args[1] == {'key': 'value'}, f'Expected dict, got {args[1]!r}'
+    assert kwargs['kw_str'] == 'hello', f'Expected str hello, got {kwargs["kw_str"]!r}'
+
+
 def test_unjsonencodable_arg_kwarg_retval():
     class Bench(MicroBench, MBFunctionCall, MBReturnValue):
         pass


### PR DESCRIPTION
## Summary
- `capture_function_args_and_kwargs` called `self.to_json(v)` and stored the resulting JSON *string* in `bm_data['args']`/`bm_data['kwargs']`. When `output_result` later serialised `bm_data`, these strings were serialised again, turning e.g. `{'k': 1}` into the escaped string `"{\"k\": 1}"` in the output.
- Fixed to call `self.to_json(v)` only as an encodability check, then store the raw value `v` — matching how `MBReturnValue` handles return values
- Adds `test_functioncall_args_not_double_encoded` to verify args/kwargs round-trip as their native Python types