### PR TITLE
fix: replace fragile hardcoded stack-frame depth in MBGlobalPackages

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -339,12 +339,32 @@ class MBHostInfo:
         bm_data['operating_system'] = sys.platform
 
 
+_microbench_dir = os.path.dirname(os.path.abspath(__file__))
+_microbench_tests_dir = os.path.join(_microbench_dir, 'tests')
+
+
+def _is_microbench_internal(filename):
+    """True for source files inside the microbench package, excluding tests/."""
+    abs_file = os.path.abspath(filename)
+    if abs_file.startswith(_microbench_tests_dir + os.sep):
+        return False
+    return abs_file == _microbench_dir or abs_file.startswith(_microbench_dir + os.sep)
+
+
 class MBGlobalPackages:
     """Capture Python packages imported in global environment"""
 
     def capture_functions(self, bm_data):
-        # Get globals of caller
-        caller_frame = inspect.currentframe().f_back.f_back.f_back
+        # Walk up the call stack to the first frame outside the microbench
+        # package (excluding tests/) — that is the user's module whose globals
+        # we want to inspect.
+        caller_frame = inspect.currentframe()
+        while caller_frame is not None:
+            if not _is_microbench_internal(caller_frame.f_code.co_filename):
+                break
+            caller_frame = caller_frame.f_back
+        if caller_frame is None:
+            return
         caller_globals = caller_frame.f_globals
         for g in caller_globals.values():
             if isinstance(g, types.ModuleType):


### PR DESCRIPTION
## Summary
- `capture_functions` previously walked exactly 3 frames up the call stack to find the caller's globals. This would silently capture the wrong scope if any internal call chain changed.
- Replaced with a path-based search that walks up until the first frame whose source file is outside the microbench package directory (excluding `tests/` so existing tests still work)
- The existing `test_capture_global_packages` test covers this