### PR TITLE
fix: LiveStream tail loop ran forever with no way to stop it

### DIFF
--- a/microbench/livestream.py
+++ b/microbench/livestream.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import threading
+
+import dateutil.parser
+
+
+class LiveStream:
+    """Tail a benchmark output file and process records as they arrive.
+
+    Usage::
+
+        stream = MyStream('/path/to/benchmark.jsonl')
+        # ... runs in background ...
+        stream.stop()
+        stream.join()
+    """
+
+    def __init__(self, filename, sleeptime=0.5):
+        self._log = self._setup_logger(filename)
+        self._stop = threading.Event()
+
+        process_fxns = []
+        for method_name in dir(self):
+            if method_name.startswith('process_'):
+                method = getattr(self, method_name)
+                if callable(method):
+                    process_fxns.append(method)
+
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(filename, process_fxns, sleeptime),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(self, filename, process_fxns, sleeptime):
+        try:
+            for line in self._getlines(filename, self._stop, sleeptime):
+                data = json.loads(line)
+                if self.filter(data):
+                    for fxn in process_fxns:
+                        fxn(data)
+                    self.display(data)
+        except Exception:
+            self._log.exception('Error processing benchmark record')
+
+    def stop(self):
+        """Signal the background thread to stop tailing the file."""
+        self._stop.set()
+
+    def join(self, timeout=None):
+        """Wait for the background thread to finish."""
+        self._thread.join(timeout=timeout)
+
+    def _setup_logger(self, filename):
+        logger = logging.getLogger(f"LiveStream('{filename}')")
+        logger.setLevel(logging.INFO)
+
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.INFO)
+
+        fmt = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+        ch.setFormatter(fmt)
+        logger.addHandler(ch)
+
+        return logger
+
+    @staticmethod
+    def _getlines(fn, stop_event, sleeptime=0.5):
+        with open(fn) as fp:
+            while not stop_event.is_set():
+                line = fp.readline()
+
+                if line:
+                    yield line
+                else:
+                    stop_event.wait(sleeptime)
+
+    def filter(self, data):
+        # Function to filter whether to display line, should return boolean
+        # True = process and display, False = ignore
+        return True
+
+    def process_runtime(self, data):
+        data['runtime'] = dateutil.parser.parse(
+            data['finish_time']
+        ) - dateutil.parser.parse(data['start_time'])
+
+    def display(self, data):
+        self._log.info(
+            '{}() on {} took {}'.format(
+                data['function_name'],
+                data.get('hostname', '<unknown>'),
+                data['runtime'],
+            )
+        )

--- a/microbench/tests/test_livestream.py
+++ b/microbench/tests/test_livestream.py
@@ -1,0 +1,84 @@
+import json
+import os
+import tempfile
+import time
+
+from microbench.livestream import LiveStream
+
+
+def _write_record(fp, record):
+    fp.write(json.dumps(record) + '\n')
+    fp.flush()
+
+
+def _make_record(**kwargs):
+    base = {
+        'function_name': 'test_fn',
+        'hostname': 'localhost',
+        'start_time': '2024-01-01T00:00:00+00:00',
+        'finish_time': '2024-01-01T00:00:01+00:00',
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_livestream_processes_existing_lines():
+    """LiveStream must process lines already in the file before tailing."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        fname = f.name
+        for i in range(3):
+            _write_record(f, _make_record(function_name=f'fn_{i}'))
+
+    seen = []
+
+    class TestStream(LiveStream):
+        def display(self, data):
+            seen.append(data['function_name'])
+
+    try:
+        stream = TestStream(fname)
+        time.sleep(0.4)
+        stream.stop()
+        stream.join(timeout=3)
+
+        assert not stream._thread.is_alive(), 'LiveStream thread did not stop'
+        assert seen == ['fn_0', 'fn_1', 'fn_2']
+    finally:
+        os.unlink(fname)
+
+
+def test_livestream_stop_terminates_tail():
+    """LiveStream.stop() must cause the background thread to exit (Q6 fix)."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        fname = f.name
+        _write_record(f, _make_record())
+
+    seen = []
+
+    class TestStream(LiveStream):
+        def display(self, data):
+            seen.append(data['function_name'])
+
+    try:
+        stream = TestStream(fname)
+        time.sleep(0.2)
+
+        # Write a second record while the stream is running
+        with open(fname, 'a') as f:
+            _write_record(f, _make_record(function_name='test_fn2'))
+
+        # Poll until both records are seen, then stop
+        deadline = time.time() + 5
+        while len(seen) < 2 and time.time() < deadline:
+            time.sleep(0.05)
+
+        stream.stop()
+        stream.join(timeout=3)
+
+        assert not stream._thread.is_alive(), (
+            'LiveStream thread did not stop after stop()'
+        )
+        assert 'test_fn' in seen
+        assert 'test_fn2' in seen
+    finally:
+        os.unlink(fname)


### PR DESCRIPTION
## Summary
- `LiveStream.__init__` ran the file-tailing loop inline, blocking forever. Because the constructor never returned, `stop()` was unreachable from outside — making it useless.
- Redesigned to run the loop in a background daemon thread so `__init__` returns immediately with a usable object
- Added `stop()` to signal termination and `join()` to wait for the thread to finish
- Replaced `time.sleep()` with `threading.Event.wait()` so `stop()` responds promptly rather than waiting out a full sleep interval
- Exceptions in the processing loop are now caught and logged rather than silently killing the thread
- Adds `microbench/tests/test_livestream.py` with two tests covering normal processing and `stop()` termination