### PR TITLE
feat: add __all__ to define the public API

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -52,6 +52,27 @@ except ImportError:
     except Exception:
         __version__ = 'unknown'
 
+__all__ = [
+    # Core
+    'MicroBench',
+    'MicroBenchRedis',
+    # Mixins
+    'MBFunctionCall',
+    'MBReturnValue',
+    'MBPythonVersion',
+    'MBHostInfo',
+    'MBHostCpuCores',
+    'MBHostRamTotal',
+    'MBGlobalPackages',
+    'MBInstalledPackages',
+    'MBCondaPackages',
+    'MBLineProfiler',
+    'MBNvidiaSmi',
+    # JSON encoding
+    'JSONEncoder',
+    'JSONEncodeWarning',
+]
+
 
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):


### PR DESCRIPTION
## Summary
- Adds `__all__` to `microbench/__init__.py` listing all public classes
- Makes `from microbench import *` predictable and signals to users (and linters) which names are part of the public API