### PR TITLE
fix: add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,8 +11,12 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: read-all
+
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -42,6 +46,8 @@ jobs:
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Fixes CodeQL alerts #1 and #2 ("Workflow does not contain permissions").

- Adds `permissions: read-all` at the workflow level to lock down the default token permissions for all jobs
- Adds explicit `permissions: contents: read` to both the `build` and `release` jobs — the minimum needed to check out the repository
- The `release` job publishes to PyPI via `secrets.PYPI_API_TOKEN` (token-based), so no additional permissions are required

## Test plan
- [x] Confirm CodeQL alerts 1 and 2 are resolved after merge