### PR TITLE
ci: add ruff linter and formatter with pre-commit, replace flake8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,6 +14,15 @@ on:
 permissions: read-all
 
 jobs:
+  lint:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Lint with ruff
+      uses: astral-sh/ruff-action@v3
+
   build:
     permissions:
       contents: read
@@ -32,14 +41,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools-scm flake8 pytest pandas psutil line_profiler
+        python -m pip install setuptools-scm pytest pandas psutil line_profiler
         python -m pip install -e .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -1,22 +1,23 @@
-from datetime import datetime, timezone, timedelta
-import json
-import platform
-import socket
-import sys
-from collections.abc import Iterable
-import os
+import base64
 import importlib
 import inspect
-import types
-import pickle
-import base64
-import re
-import subprocess
 import io
+import json
+import os
+import pickle
+import platform
+import re
+import signal
+import socket
+import subprocess
+import sys
 import threading
 import time
-import signal
+import types
 import warnings
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+
 try:
     import line_profiler
 except ImportError:
@@ -46,6 +47,7 @@ try:
 except ImportError:
     try:
         from importlib.metadata import version as _version
+
         __version__ = _version('microbench')
     except Exception:
         __version__ = 'unknown'
@@ -71,18 +73,25 @@ class JSONEncoder(json.JSONEncoder):
 
 
 class JSONEncodeWarning(Warning):
-    """ Warning used when JSON encoding fails """
+    """Warning used when JSON encoding fails"""
+
     pass
 
 
 _UNENCODABLE_PLACEHOLDER_VALUE = '__unencodable_as_json__'
 
 
-class MicroBench(object):
-    def __init__(self, outfile=None, json_encoder=JSONEncoder,
-                 tz=timezone.utc, iterations=1,
-                 duration_counter=time.perf_counter,
-                 *args, **kwargs):
+class MicroBench:
+    def __init__(
+        self,
+        outfile=None,
+        json_encoder=JSONEncoder,
+        tz=timezone.utc,
+        iterations=1,
+        duration_counter=time.perf_counter,
+        *args,
+        **kwargs,
+    ):
         """Benchmark and metadata capture suite.
 
         Args:
@@ -122,17 +131,20 @@ class MicroBench(object):
         # Capture environment variables
         if hasattr(self, 'env_vars'):
             if not isinstance(self.env_vars, Iterable):
-                raise ValueError('env_vars should be a tuple of environment '
-                                 'variable names')
+                raise ValueError(
+                    'env_vars should be a tuple of environment variable names'
+                )
 
             for env_var in self.env_vars:
-                bm_data['env_{}'.format(env_var)] = os.environ.get(env_var)
+                bm_data[f'env_{env_var}'] = os.environ.get(env_var)
 
         # Capture package versions
         if hasattr(self, 'capture_versions'):
             if not isinstance(self.capture_versions, Iterable):
-                raise ValueError('capture_versions is reserved for a tuple of'
-                                 'package names - please rename this method')
+                raise ValueError(
+                    'capture_versions is reserved for a tuple of package names'
+                    ' - please rename this method'
+                )
 
             for pkg in self.capture_versions:
                 self._capture_package_version(bm_data, pkg)
@@ -149,7 +161,8 @@ class MicroBench(object):
             interval = getattr(self, 'telemetry_interval', 60)
             bm_data['telemetry'] = []
             self._telemetry_thread = TelemetryThread(
-                self.telemetry, interval, bm_data['telemetry'], self.tz)
+                self.telemetry, interval, bm_data['telemetry'], self.tz
+            )
             self._telemetry_thread.start()
 
         bm_data['run_durations'] = []
@@ -175,7 +188,9 @@ class MicroBench(object):
         bm_data['_run_start'] = self._duration_counter()
 
     def post_run_triggers(self, bm_data):
-        bm_data['run_durations'].append(self._duration_counter() - bm_data['_run_start'])
+        bm_data['run_durations'].append(
+            self._duration_counter() - bm_data['_run_start']
+        )
 
     def capture_function_name(self, bm_data):
         bm_data['function_name'] = bm_data['_func'].__name__
@@ -191,13 +206,12 @@ class MicroBench(object):
         bm_data['package_versions'][pkg.__name__] = ver
 
     def to_json(self, bm_data):
-        bm_str = '{}'.format(json.dumps(bm_data,
-                                        cls=self._json_encoder))
+        bm_str = f'{json.dumps(bm_data, cls=self._json_encoder)}'
 
         return bm_str
 
     def output_result(self, bm_data):
-        """ Output result to self.outfile as a line in JSON format """
+        """Output result to self.outfile as a line in JSON format"""
         bm_str = self.to_json(bm_data) + '\n'
 
         # This should guarantee atomic writes on POSIX by setting O_APPEND
@@ -227,8 +241,9 @@ class MicroBench(object):
 
             if isinstance(self, MBLineProfiler):
                 if not line_profiler:
-                    raise ImportError('This functionality requires the '
-                                      '"line_profiler" package')
+                    raise ImportError(
+                        'This functionality requires the "line_profiler" package'
+                    )
                 self._line_profiler = line_profiler.LineProfiler(func)
 
             self.pre_start_triggers(bm_data)
@@ -249,12 +264,15 @@ class MicroBench(object):
                     self.to_json(res)
                     bm_data['return_value'] = res
                 except TypeError:
-                    warnings.warn(f"Return value is not JSON encodable (type: {type(res)}). Extend JSONEncoder class to fix (see README).", JSONEncodeWarning)
+                    warnings.warn(
+                        f'Return value is not JSON encodable (type: {type(res)}). '
+                        'Extend JSONEncoder class to fix (see README).',
+                        JSONEncodeWarning,
+                    )
                     bm_data['return_value'] = _UNENCODABLE_PLACEHOLDER_VALUE
 
             # Delete any underscore-prefixed keys
-            bm_data = {k: v for k, v in bm_data.items()
-                       if not k.startswith('_')}
+            bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
 
             self.output_result(bm_data)
 
@@ -263,8 +281,9 @@ class MicroBench(object):
         return inner
 
 
-class MBFunctionCall(object):
-    """ Capture function arguments and keyword arguments """
+class MBFunctionCall:
+    """Capture function arguments and keyword arguments"""
+
     def capture_function_args_and_kwargs(self, bm_data):
         # Check all args are encodeable as JSON
         bm_data['args'] = []
@@ -272,7 +291,11 @@ class MBFunctionCall(object):
             try:
                 bm_data['args'].append(self.to_json(v))
             except TypeError:
-                warnings.warn(f"Function argument {i} is not JSON encodable (type: {type(v)}). Extend JSONEncoder class to fix (see README).", JSONEncodeWarning)
+                warnings.warn(
+                    f'Function argument {i} is not JSON encodable (type: {type(v)}). '
+                    'Extend JSONEncoder class to fix (see README).',
+                    JSONEncodeWarning,
+                )
                 bm_data['args'].append(_UNENCODABLE_PLACEHOLDER_VALUE)
 
         # Check all kwargs are encodeable as JSON
@@ -281,17 +304,24 @@ class MBFunctionCall(object):
             try:
                 bm_data['kwargs'][k] = self.to_json(v)
             except TypeError:
-                warnings.warn(f"Function keyword argument \"{k}\" is not JSON encodable (type: {type(v)}). Extend JSONEncoder class to fix (see README).", JSONEncodeWarning)
+                warnings.warn(
+                    f'Function keyword argument "{k}" is not JSON encodable'
+                    f' (type: {type(v)}). Extend JSONEncoder class to fix'
+                    ' (see README).',
+                    JSONEncodeWarning,
+                )
                 bm_data['kwargs'][k] = _UNENCODABLE_PLACEHOLDER_VALUE
 
 
-class MBReturnValue(object):
-    """ Capture the decorated function's return value """
+class MBReturnValue:
+    """Capture the decorated function's return value"""
+
     pass
 
 
-class MBPythonVersion(object):
-    """ Capture the Python version and location of the Python executable """
+class MBPythonVersion:
+    """Capture the Python version and location of the Python executable"""
+
     def capture_python_version(self, bm_data):
         bm_data['python_version'] = platform.python_version()
 
@@ -299,8 +329,9 @@ class MBPythonVersion(object):
         bm_data['python_executable'] = sys.executable
 
 
-class MBHostInfo(object):
-    """ Capture the hostname and operating system """
+class MBHostInfo:
+    """Capture the hostname and operating system"""
+
     def capture_hostname(self, bm_data):
         bm_data['hostname'] = socket.gethostname()
 
@@ -308,8 +339,9 @@ class MBHostInfo(object):
         bm_data['operating_system'] = sys.platform
 
 
-class MBGlobalPackages(object):
-    """ Capture Python packages imported in global environment """
+class MBGlobalPackages:
+    """Capture Python packages imported in global environment"""
+
     def capture_functions(self, bm_data):
         # Get globals of caller
         caller_frame = inspect.currentframe().f_back.f_back.f_back
@@ -324,14 +356,13 @@ class MBGlobalPackages(object):
                     continue
 
                 self._capture_package_version(
-                    bm_data,
-                    sys.modules[module_name.split('.')[0]],
-                    skip_if_none=True
+                    bm_data, sys.modules[module_name.split('.')[0]], skip_if_none=True
                 )
 
 
-class MBCondaPackages(object):
-    """ Capture conda packages; requires 'conda' package (pip install conda) """
+class MBCondaPackages:
+    """Capture conda packages; requires 'conda' package (pip install conda)"""
+
     include_builds = True
     include_channels = False
 
@@ -342,11 +373,11 @@ class MBCondaPackages(object):
         else:
             # Use conda API
             pkg_list, stderr, ret_code = conda.testing.conda_cli.run_command(
-                conda.testing.conda_cli.Commands.LIST)
+                conda.testing.conda_cli.Commands.LIST
+            )
 
             if ret_code != 0 or stderr:
-                raise RuntimeError('Error running conda list: {}'.format(
-                    stderr))
+                raise RuntimeError(f'Error running conda list: {stderr}')
 
         bm_data['conda_versions'] = {}
 
@@ -363,8 +394,9 @@ class MBCondaPackages(object):
             bm_data['conda_versions'][pkg_name] = pkg_version
 
 
-class MBInstalledPackages(object):
-    """ Capture installed Python packages using importlib """
+class MBInstalledPackages:
+    """Capture installed Python packages using importlib"""
+
     capture_paths = False
 
     def capture_packages(self, bm_data):
@@ -381,10 +413,11 @@ class MBInstalledPackages(object):
             bm_data['package_versions'][pkg_name] = pkg.version
             if self.capture_paths:
                 bm_data['package_paths'][pkg_name] = os.path.dirname(
-                    pkg.locate_file(pkg.files[0]))
+                    pkg.locate_file(pkg.files[0])
+                )
 
 
-class MBLineProfiler(object):
+class MBLineProfiler:
     """
     Run the line profiler on the selected function
 
@@ -393,6 +426,7 @@ class MBLineProfiler(object):
     slightly slow down the execution of your function, so it's not recommended
     in production.
     """
+
     def capturepost_line_profile(self, bm_data):
         bm_data['line_profiler'] = base64.b64encode(
             pickle.dumps(self._line_profiler.get_stats())
@@ -408,7 +442,7 @@ class MBLineProfiler(object):
         line_profiler.show_text(lp_data.timings, lp_data.unit, **kwargs)
 
 
-class _NeedsPsUtil(object):
+class _NeedsPsUtil:
     @classmethod
     def _check_psutil(cls):
         if not psutil:
@@ -416,20 +450,22 @@ class _NeedsPsUtil(object):
 
 
 class MBHostCpuCores(_NeedsPsUtil):
-    """ Capture the number of logical CPU cores """
+    """Capture the number of logical CPU cores"""
+
     def capture_cpu_cores(self, bm_data):
         self._check_psutil()
         bm_data['cpu_cores_logical'] = psutil.cpu_count()
 
 
 class MBHostRamTotal(_NeedsPsUtil):
-    """ Capture the total host RAM in bytes """
+    """Capture the total host RAM in bytes"""
+
     def capture_total_ram(self, bm_data):
         self._check_psutil()
         bm_data['ram_total'] = psutil.virtual_memory().total
 
 
-class MBNvidiaSmi(object):
+class MBNvidiaSmi:
     """
     Capture attributes on installed NVIDIA GPUs using nvidia-smi
 
@@ -455,27 +491,34 @@ class MBNvidiaSmi(object):
                 nvidia_attributes
             )
             if unknown_attrs:
-                raise ValueError("Unknown nvidia_attributes: {}".format(
-                    ', '.join(unknown_attrs)
-                ))
+                raise ValueError(
+                    'Unknown nvidia_attributes: {}'.format(', '.join(unknown_attrs))
+                )
         else:
             nvidia_attributes = self._nvidia_attributes_available
 
         if hasattr(self, 'nvidia_gpus'):
             gpus = self.nvidia_gpus
             if not gpus:
-                raise ValueError('nvidia_gpus cannot be empty. Leave the '
-                                 'attribute out to capture data for all GPUs')
+                raise ValueError(
+                    'nvidia_gpus cannot be empty. Leave the attribute out'
+                    ' to capture data for all GPUs'
+                )
             for gpu in gpus:
                 if not self._nvidia_gpu_regex.match(gpu):
-                    raise ValueError('nvidia_gpus must be a list of GPU indexes'
-                                     '(zero-based), UUIDs, or PCI bus IDs')
+                    raise ValueError(
+                        'nvidia_gpus must be a list of GPU indexes (zero-based),'
+                        ' UUIDs, or PCI bus IDs'
+                    )
         else:
             gpus = None
 
         # Construct the command
-        cmd = ['nvidia-smi', '--format=csv,noheader',
-               '--query-gpu=uuid,{}'.format(','.join(nvidia_attributes))]
+        cmd = [
+            'nvidia-smi',
+            '--format=csv,noheader',
+            '--query-gpu=uuid,{}'.format(','.join(nvidia_attributes)),
+        ]
         if gpus:
             cmd += ['-i', ','.join(gpus)]
 
@@ -489,15 +532,17 @@ class MBNvidiaSmi(object):
             gpu_res = gpu_line.split(', ')
             for attr_idx, attr in enumerate(nvidia_attributes):
                 gpu_uuid = gpu_res[0]
-                bm_data.setdefault('nvidia_{}'.format(attr), {})[gpu_uuid] = \
-                    gpu_res[attr_idx + 1]
+                bm_data.setdefault(f'nvidia_{attr}', {})[gpu_uuid] = gpu_res[
+                    attr_idx + 1
+                ]
 
 
 class MicroBenchRedis(MicroBench):
     def __init__(self, *args, **kwargs):
-        super(MicroBenchRedis, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         import redis
+
         self.rclient = redis.StrictRedis(**self.redis_connection)
 
     def output_result(self, bm_data):
@@ -506,7 +551,7 @@ class MicroBenchRedis(MicroBench):
 
 class TelemetryThread(threading.Thread):
     def __init__(self, telem_fn, interval, slot, timezone, *args, **kwargs):
-        super(TelemetryThread, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._terminate = threading.Event()
         signal.signal(signal.SIGINT, self.terminate)
         signal.signal(signal.SIGTERM, self.terminate)

--- a/microbench/diff.py
+++ b/microbench/diff.py
@@ -1,7 +1,7 @@
 import difflib
 import json
-import re
 from itertools import zip_longest
+
 try:
     import html
 except ImportError:
@@ -9,18 +9,14 @@ except ImportError:
 
 
 def _mark_text(text):
-    return '<span style="color: red;">{}</span>'.format(text)
+    return f'<span style="color: red;">{text}</span>'
 
 
 def _mark_span(text):
     return [_mark_text(token) for token in text]
 
 
-def _markup_diff(a,
-                 b,
-                 mark=_mark_span,
-                 default_mark=lambda x: x,
-                 isjunk=None):
+def _markup_diff(a, b, mark=_mark_span, default_mark=lambda x: x, isjunk=None):
     """Returns a and b with any differences processed by mark
 
     Junk is ignored by the differ
@@ -54,8 +50,8 @@ def _html_sidebyside(a, b):
     # This is a workaround
     out += '<p></p><p></p>'
     for left, right in zip_longest(a, b, fillvalue=''):
-        out += '<pre style="margin-top:0;padding:0">{}</pre>'.format(left)
-        out += '<pre style="margin-top:0;padding:0">{}</pre>'.format(right)
+        out += f'<pre style="margin-top:0;padding:0">{left}</pre>'
+        out += f'<pre style="margin-top:0;padding:0">{right}</pre>'
     out += '</div>'
     return out
 
@@ -77,11 +73,12 @@ def _html_diffs(a, b):
 
 def _show_diffs(a, b):
     from IPython.display import HTML, display
+
     display(HTML(_html_diffs(a, b)))
 
 
 def envdiff(a, b):
-    """ Compare 2 JSON environments using visual diff
+    """Compare 2 JSON environments using visual diff
 
     a and b should be either pandas Series or strings of JSON objects
     """
@@ -94,5 +91,6 @@ def envdiff(a, b):
             a = a.to_json()
         if isinstance(b, pandas.Series):
             b = b.to_json()
-    return _show_diffs(json.dumps(json.loads(a), indent=2),
-                       json.dumps(json.loads(b), indent=2))
+    return _show_diffs(
+        json.dumps(json.loads(a), indent=2), json.dumps(json.loads(b), indent=2)
+    )

--- a/microbench/tests/globals_capture.py
+++ b/microbench/tests/globals_capture.py
@@ -1,5 +1,6 @@
-from microbench import MicroBench, MBGlobalPackages
 import pandas  # Imported just to test capturing the version
+
+from microbench import MBGlobalPackages, MicroBench
 
 # Define this in a separate file to make sure we are capturing globals when
 # globals_bench is called, not here

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -1,11 +1,22 @@
-from microbench import MicroBench, MBFunctionCall, MBPythonVersion, \
-    MBReturnValue, MBHostInfo, MBInstalledPackages, \
-    JSONEncodeWarning, JSONEncoder, _UNENCODABLE_PLACEHOLDER_VALUE
-from microbench import __version__ as microbench_version
-import io
-import pandas
 import datetime
+import io
 import warnings
+
+import pandas
+
+from microbench import (
+    _UNENCODABLE_PLACEHOLDER_VALUE,
+    JSONEncoder,
+    JSONEncodeWarning,
+    MBFunctionCall,
+    MBHostInfo,
+    MBInstalledPackages,
+    MBPythonVersion,
+    MBReturnValue,
+    MicroBench,
+)
+from microbench import __version__ as microbench_version
+
 from .globals_capture import globals_bench
 
 
@@ -18,7 +29,7 @@ def test_function():
 
     @benchmark
     def my_function():
-        """ Inefficient function for testing """
+        """Inefficient function for testing"""
         acc = 0
         for i in range(1000000):
             acc += i
@@ -74,8 +85,7 @@ def test_capture_global_packages():
 
     # We should've captured microbench and pandas versions from top level
     # imports in this file
-    assert results['package_versions'][0]['microbench'] == \
-           str(microbench_version)
+    assert results['package_versions'][0]['microbench'] == str(microbench_version)
     assert results['package_versions'][0]['pandas'] == pandas.__version__
 
 
@@ -136,8 +146,7 @@ def test_unjsonencodable_arg_kwarg_retval():
         assert len(w) == 3
         assert all(issubclass(w_.category, JSONEncodeWarning) for w_ in w)
 
-
-    results =bench.get_results()
+    results = bench.get_results()
     assert results['args'][0] == [_UNENCODABLE_PLACEHOLDER_VALUE]
     assert results['kwargs'][0] == {'arg2': _UNENCODABLE_PLACEHOLDER_VALUE}
     assert results['return_value'][0] == _UNENCODABLE_PLACEHOLDER_VALUE
@@ -145,7 +154,7 @@ def test_unjsonencodable_arg_kwarg_retval():
 
 def test_custom_jsonencoder():
     # A custom class which can't be encoded to JSON by default
-    class MyCustomClass(object):
+    class MyCustomClass:
         def __init__(self, message):
             self.message = message
 

--- a/microbench/tests/test_line_profiler.py
+++ b/microbench/tests/test_line_profiler.py
@@ -1,6 +1,4 @@
-from microbench import MicroBench, MBLineProfiler
-import pandas
-import io
+from microbench import MBLineProfiler, MicroBench
 
 
 def test_line_profiler():
@@ -11,7 +9,7 @@ def test_line_profiler():
 
     @lpbench
     def my_function():
-        """ Inefficient function for line profiler """
+        """Inefficient function for line profiler"""
         acc = 0
         for i in range(1000000):
             acc += i
@@ -25,4 +23,4 @@ def test_line_profiler():
     lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])
     assert lp.__class__.__name__ == 'LineStats'
     MBLineProfiler.print_line_profile(results['line_profiler'][0])
-    assert not all(len(v) == 0 for v in lp.timings.values()), "No timings present"
+    assert not all(len(v) == 0 for v in lp.timings.values()), 'No timings present'

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -1,7 +1,7 @@
-from microbench import MicroBench, MBNvidiaSmi
 import subprocess
 import unittest
-import pandas
+
+from microbench import MBNvidiaSmi, MicroBench
 
 try:
     subprocess.call(['nvidia-smi'])

--- a/microbench/tests/test_psutil.py
+++ b/microbench/tests/test_psutil.py
@@ -1,5 +1,4 @@
-from microbench import MicroBench, MBHostCpuCores, MBHostRamTotal
-import pandas
+from microbench import MBHostCpuCores, MBHostRamTotal, MicroBench
 
 
 def test_psutil():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,19 @@ version_file = "microbench/_version_scm.py"
 
 [tool.pytest.ini_options]
 testpaths = ["microbench/tests"]
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "Q"]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+
+[tool.ruff.lint.per-file-ignores]
+# pandas is imported to test that its version is captured in global packages
+"microbench/tests/globals_capture.py" = ["F401"]


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with `ruff-pre-commit` hooks (lint + format) so contributors get instant feedback locally
- Adds `[tool.ruff]` configuration to `pyproject.toml` (line-length=88, single-quote strings, rules: E/F/W/I/UP/Q)
- Replaces the flake8 lint step in CI with a dedicated `astral-sh/ruff-action` job that runs once on ubuntu (not duplicated across the full OS/Python matrix)
- Fixes all ruff-identified issues in the codebase:
  - **F401**: removed unused imports (`re` in `diff.py`; `pandas`/`io` in several test files)
  - **I001**: sorted import blocks throughout
  - **UP004**: removed `(object)` base class from class definitions
  - **UP008/UP032**: replaced `super(Class, self)` with `super()` and `.format()` calls with f-strings
  - **E501**: wrapped long `warnings.warn` and `ValueError` messages
- Applied `ruff format` (single-quote style) to all files

## Test plan

- [x] All existing tests pass (`pytest`)
- [x] `ruff check .` reports no errors
- [x] `ruff format --check .` reports no files to reformat
- [x] CI lint job (ruff) passes on PR