### PR TITLE
fix: accept integer GPU indexes in nvidia_gpus

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -555,7 +555,7 @@ class MBNvidiaSmi:
                     ' to capture data for all GPUs'
                 )
             for gpu in gpus:
-                if not self._nvidia_gpu_regex.match(gpu):
+                if not self._nvidia_gpu_regex.match(str(gpu)):
                     raise ValueError(
                         'nvidia_gpus must be a list of GPU indexes (zero-based),'
                         ' UUIDs, or PCI bus IDs'
@@ -570,7 +570,7 @@ class MBNvidiaSmi:
             '--query-gpu=uuid,{}'.format(','.join(nvidia_attributes)),
         ]
         if gpus:
-            cmd += ['-i', ','.join(gpus)]
+            cmd += ['-i', ','.join(str(g) for g in gpus)]
 
         # Execute the command
         res = subprocess.check_output(cmd).decode('utf8')

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -121,3 +121,19 @@ def test_nvidia_gpus_invalid_format_raises():
 
     with pytest.raises(ValueError, match='nvidia_gpus must be'):
         noop()
+
+
+def test_nvidia_gpus_integer_accepted():
+    """Integer GPU indexes must be accepted (README documents this usage)."""
+
+    class Bench(MicroBench, MBNvidiaSmi):
+        nvidia_gpus = (0,)
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_SMI_OUTPUT):
+        noop()


### PR DESCRIPTION
## Summary
- `nvidia_gpus` validation used `.match(gpu)` which requires strings, but the README documents integer indexes like `nvidia_gpus = (0, )`
- Convert GPU identifiers to `str()` before regex validation and when joining for the nvidia-smi command
- Added test `test_nvidia_gpus_integer_accepted`

## Test plan
- [x] Existing nvidia tests pass
- [x] New test verifies integer GPU indexes are accepted