### PR TITLE
fix: drop internal conda API, always use subprocess

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -27,11 +27,6 @@ try:
 except ImportError:
     psutil = None
 try:
-    import conda
-    import conda.testing.conda_cli
-except ImportError:
-    conda = None
-try:
     import numpy
 except ImportError:
     numpy = None
@@ -404,23 +399,15 @@ class MBGlobalPackages:
 
 
 class MBCondaPackages:
-    """Capture conda packages; requires 'conda' package (pip install conda)"""
+    """Capture conda packages using the conda CLI"""
 
     include_builds = True
     include_channels = False
 
     def capture_conda_packages(self, bm_data):
-        if conda is None:
-            # Use subprocess
-            pkg_list = subprocess.check_output(['conda', 'list']).decode('utf8')
-        else:
-            # Use conda API
-            pkg_list, stderr, ret_code = conda.testing.conda_cli.run_command(
-                conda.testing.conda_cli.Commands.LIST
-            )
-
-            if ret_code != 0 or stderr:
-                raise RuntimeError(f'Error running conda list: {stderr}')
+        pkg_list = subprocess.check_output(
+            ['conda', 'list', '--prefix', sys.prefix]
+        ).decode('utf8')
 
         bm_data['conda_versions'] = {}
 

--- a/microbench/tests/test_conda.py
+++ b/microbench/tests/test_conda.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import microbench
 from microbench import MBCondaPackages, MicroBench
 
 SAMPLE_CONDA_LIST = """\
@@ -22,9 +21,9 @@ def _run_conda_bench(**cls_attrs):
     def noop():
         pass
 
-    with (
-        patch('subprocess.check_output', return_value=SAMPLE_CONDA_LIST.encode('utf8')),
-        patch.object(microbench, 'conda', None),
+    with patch(
+        'subprocess.check_output',
+        return_value=SAMPLE_CONDA_LIST.encode('utf8'),
     ):
         noop()
 


### PR DESCRIPTION
## Summary
- Removed `conda.testing.conda_cli` usage — it's an internal testing utility that can break across conda versions
- Always use `subprocess.check_output(['conda', 'list', '--prefix', sys.prefix])` which reliably targets the running Python's conda environment
- Removed the top-level `import conda` / `import conda.testing.conda_cli` block
- Updated conda tests to remove the now-unnecessary `patch.object(microbench, 'conda', None)`

## Test plan
- [x] Conda tests pass with subprocess-only approach
- [x] All other tests unaffected