### PR TITLE
feat: implement get_results() for MicroBenchRedis

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,23 +441,10 @@ class RedisBench(MicroBenchRedis):
 benchmark = RedisBench()
 ```
 
-To retrieve results, the `redis` package can be used directly:
+To retrieve results, use `get_results()` just like the base class:
 
 ```python
-import redis
-import pandas
-
-# Establish the connection to redis
-rconn = redis.StrictRedis(host=..., port=...)
-
-# Read the redis data from 'myrediskey' into a list of byte arrays
-redis_data = redis.lrange('myrediskey', 0, -1)
-
-# Convert the list into a single string
-json_data = '\n'.join(r.decode('utf8') for r in redis_data)
-
-# Read the string into a pandas dataframe
-results = pandas.read_json(json_data, lines=True)
+results = benchmark.get_results()
 ```
 
 ## Runtime impact considerations

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -598,6 +598,17 @@ class MicroBenchRedis(MicroBench):
     def output_result(self, bm_data):
         self.rclient.rpush(self.redis_key, self.to_json(bm_data))
 
+    def get_results(self):
+        if not pandas:
+            raise ImportError(
+                'This functionality requires the "pandas" package'
+            )
+        redis_data = self.rclient.lrange(self.redis_key, 0, -1)
+        json_data = '\n'.join(r.decode('utf8') for r in redis_data)
+        return pandas.read_json(
+            io.StringIO(json_data), lines=True
+        )
+
 
 class TelemetryThread(threading.Thread):
     def __init__(self, telem_fn, interval, slot, timezone, *args, **kwargs):

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -5,7 +5,7 @@ import tempfile
 import threading
 import time
 import warnings
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy
 import pandas
@@ -21,6 +21,7 @@ from microbench import (
     MBPythonVersion,
     MBReturnValue,
     MicroBench,
+    MicroBenchRedis,
 )
 from microbench import __version__ as microbench_version
 
@@ -407,3 +408,102 @@ def test_telemetry_multiple_samples():
 
     results = telem_bench.get_results()
     assert len(results['telemetry'][0]) >= 2, 'Expected at least 2 telemetry samples'
+
+
+def test_redis_get_results():
+    """MicroBenchRedis.get_results() reads results back from Redis."""
+    # Mock redis.StrictRedis so we don't need a real server
+    redis_store = []
+
+    mock_redis_client = MagicMock()
+    mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
+        val.encode('utf8') if isinstance(val, str) else val
+    )
+    mock_redis_client.lrange.side_effect = (
+        lambda key, start, end: redis_store
+    )
+
+    mock_redis = MagicMock()
+    mock_redis.StrictRedis.return_value = mock_redis_client
+
+    with patch.dict('sys.modules', {'redis': mock_redis}):
+
+        class RedisBench(MicroBenchRedis):
+            redis_connection = {}
+            redis_key = 'test:bench'
+
+        bench = RedisBench()
+
+        @bench
+        def noop():
+            pass
+
+        noop()
+
+        results = bench.get_results()
+        assert results['function_name'][0] == 'noop'
+        assert 'start_time' in results.columns
+        assert 'finish_time' in results.columns
+
+        # Verify rpush was called with the correct key
+        mock_redis_client.rpush.assert_called_once()
+        assert mock_redis_client.rpush.call_args[0][0] == 'test:bench'
+
+
+def test_redis_get_results_without_pandas():
+    """MicroBenchRedis.get_results() raises ImportError without pandas."""
+    import microbench
+
+    mock_redis = MagicMock()
+    mock_redis.StrictRedis.return_value = MagicMock()
+
+    with patch.dict('sys.modules', {'redis': mock_redis}):
+
+        class RedisBench(MicroBenchRedis):
+            redis_connection = {}
+            redis_key = 'test:bench'
+
+        bench = RedisBench()
+
+        with patch.object(microbench, 'pandas', None):
+            with pytest.raises(ImportError, match='pandas'):
+                bench.get_results()
+
+
+def test_redis_multiple_results():
+    """MicroBenchRedis.get_results() returns all stored results."""
+    redis_store = []
+
+    mock_redis_client = MagicMock()
+    mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
+        val.encode('utf8') if isinstance(val, str) else val
+    )
+    mock_redis_client.lrange.side_effect = (
+        lambda key, start, end: redis_store
+    )
+
+    mock_redis = MagicMock()
+    mock_redis.StrictRedis.return_value = mock_redis_client
+
+    with patch.dict('sys.modules', {'redis': mock_redis}):
+
+        class RedisBench(MicroBenchRedis):
+            redis_connection = {}
+            redis_key = 'test:bench'
+
+        bench = RedisBench()
+
+        @bench
+        def func_a():
+            pass
+
+        @bench
+        def func_b():
+            pass
+
+        func_a()
+        func_b()
+
+        results = bench.get_results()
+        assert len(results) == 2
+        assert list(results['function_name']) == ['func_a', 'func_b']


### PR DESCRIPTION
## Summary
- `MicroBenchRedis.get_results()` now reads results back from the Redis list and returns a pandas DataFrame, matching the base class API
- Previously it inherited the base `get_results()` which read from a StringIO that was never written to, silently returning an empty DataFrame
- Updated README to show the simpler `get_results()` usage instead of the manual redis client approach

## Test plan
- [x] `test_redis_get_results` — verifies basic roundtrip (write + read back)
- [x] `test_redis_get_results_without_pandas` — verifies ImportError when pandas unavailable
- [x] `test_redis_multiple_results` — verifies multiple benchmark runs are all returned