### PR TITLE
cleanup: remove dead Python <3.9 fallback in MBInstalledPackages

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -448,14 +448,9 @@ class MBInstalledPackages:
             bm_data['package_paths'] = {}
 
         for pkg in importlib.metadata.distributions():
-            try:
-                pkg_name = pkg.name
-            except AttributeError:
-                # Python <3.9
-                pkg_name = pkg.metadata['Name']
-            bm_data['package_versions'][pkg_name] = pkg.version
+            bm_data['package_versions'][pkg.name] = pkg.version
             if self.capture_paths:
-                bm_data['package_paths'][pkg_name] = os.path.dirname(
+                bm_data['package_paths'][pkg.name] = os.path.dirname(
                     pkg.locate_file(pkg.files[0])
                 )
 


### PR DESCRIPTION
## Summary
- Removed try/except `AttributeError` fallback for `pkg.name` in `MBInstalledPackages.capture_packages`
- This code path could never execute since `requires-python = ">=3.10"` and `pkg.name` has been available since Python 3.9

## Test plan
- [x] `test_capture_packages_importlib` passes