### PR TITLE
fix: remove overly restrictive nvidia attribute allowlist

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -521,9 +521,11 @@ class MBNvidiaSmi:
 
     Requires the nvidia-smi utility to be available in the current PATH.
 
-    By default, the gpu_name and memory.total attributes are captured. Extra
-    attributes can be specified using the class or object-level variable
-    nvidia_attributes.
+    By default, the gpu_name and memory.total attributes are captured.
+    Any attribute supported by ``nvidia-smi --query-gpu`` can be
+    specified using the class or object-level variable
+    nvidia_attributes (run ``nvidia-smi --help-query-gpu`` for the
+    full list).
 
     By default, all installed GPUs will be polled. To limit to a specific GPU,
     specify the nvidia_gpus attribute as a tuple of GPU IDs, which can be
@@ -531,21 +533,13 @@ class MBNvidiaSmi:
     GPU UUIDs, or PCI bus IDs.
     """
 
-    _nvidia_attributes_available = ('gpu_name', 'memory.total')
+    _nvidia_default_attributes = ('gpu_name', 'memory.total')
     _nvidia_gpu_regex = re.compile(r'^[0-9A-Za-z\-:]+$')
 
     def capture_nvidia(self, bm_data):
-        if hasattr(self, 'nvidia_attributes'):
-            nvidia_attributes = self.nvidia_attributes
-            unknown_attrs = set(nvidia_attributes).difference(
-                self._nvidia_attributes_available
-            )
-            if unknown_attrs:
-                raise ValueError(
-                    'Unknown nvidia_attributes: {}'.format(', '.join(unknown_attrs))
-                )
-        else:
-            nvidia_attributes = self._nvidia_attributes_available
+        nvidia_attributes = getattr(
+            self, 'nvidia_attributes', self._nvidia_default_attributes
+        )
 
         if hasattr(self, 'nvidia_gpus'):
             gpus = self.nvidia_gpus

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -34,24 +34,8 @@ def test_nvidia():
     assert 'nvidia_memory.total' in results.columns
 
 
-def test_nvidia_unknown_attribute_raises():
-    """Specifying an unknown nvidia_attribute must raise ValueError."""
-
-    class Bench(MicroBench, MBNvidiaSmi):
-        nvidia_attributes = ('gpu_name', 'nonexistent_attr')
-
-    bench = Bench()
-
-    @bench
-    def noop():
-        pass
-
-    with pytest.raises(ValueError, match='nonexistent_attr'):
-        noop()
-
-
-def test_nvidia_known_attribute_does_not_raise():
-    """Specifying only known attributes must not raise a ValueError."""
+def test_nvidia_custom_attributes():
+    """Custom nvidia_attributes are passed through to nvidia-smi."""
 
     class Bench(MicroBench, MBNvidiaSmi):
         nvidia_attributes = ('gpu_name',)
@@ -67,28 +51,6 @@ def test_nvidia_known_attribute_does_not_raise():
 
     results = bench.get_results()
     assert 'nvidia_gpu_name' in results.columns
-
-
-def test_nvidia_default_attribute_not_flagged_as_unknown():
-    """Omitting a default attribute (memory.total) must not raise (B2 regression check).
-
-    With the original bug, set(available).difference(user_attrs) would flag
-    'memory.total' as 'unknown' simply because the user didn't include it.
-    """
-
-    class Bench(MicroBench, MBNvidiaSmi):
-        # Only request gpu_name, intentionally omitting memory.total
-        nvidia_attributes = ('gpu_name',)
-
-    bench = Bench()
-
-    @bench
-    def noop():
-        pass
-
-    # Should NOT raise; memory.total being absent from user's list is fine
-    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_SMI_OUTPUT):
-        noop()
 
 
 def test_nvidia_gpus_empty_raises():


### PR DESCRIPTION
## Summary
- Removed the hardcoded `_nvidia_attributes_available` allowlist that only permitted `gpu_name` and `memory.total`
- nvidia-smi supports dozens of attributes (`temperature.gpu`, `utilization.gpu`, `power.draw`, etc.) — users trying to capture any of those got a `ValueError`
- Now any attribute is passed through to nvidia-smi, which provides its own clear error message for truly invalid attributes
- Updated docstring to reference `nvidia-smi --help-query-gpu`
- Removed tests for the allowlist validation; kept GPU ID validation tests

## Test plan
- [x] `test_nvidia_custom_attributes` verifies custom attributes work
- [x] GPU validation tests unchanged and passing