### PR TITLE
docs: remove outdated setuptools requirement for MBInstalledPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ examine results. However, some mixins (extensions) have specific requirements:
 
 * The [line_profiler](https://github.com/rkern/line_profiler)
   package needs to be installed for line-by-line code benchmarking.
-* `MBInstalledPackages` requires `setuptools`, which is not a part of the
-  standard library, but is usually available.
 * The CPU cores, total RAM, and telemetry extensions require
   [psutil](https://pypi.org/project/psutil/).
 * The NVIDIA GPU plugin requires the


### PR DESCRIPTION
## Summary
- Removed claim that `MBInstalledPackages` requires `setuptools`
- `importlib.metadata` has been part of the standard library since Python 3.8, and microbench requires Python >= 3.10

## Test plan
- Documentation-only change