### PR TITLE
feat!: rename telemetry → monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,35 +301,36 @@ class GpuBench(MicroBench, MBNvidiaSmi):
 gpu_bench = GpuBench()
 ```
 
-## Telemetry support
+## Periodic monitoring support
 
-We use the term "telemetry" to refer to metadata which is captured periodically
-during the execution of a function by a thread which runs in parallel. For
-example, this may be useful to see how memory usage changes over time.
+Microbench can periodically sample resource usage during the execution of a
+function using a background thread. For example, this is useful to track how
+memory usage changes over time during a long-running computation.
 
-Telemetry support requires the `psutil` library.
+Periodic monitoring requires the `psutil` library.
 
 Microbench launches and cleans up the monitoring thread automatically.
-The end user only needs to define a `telemetry` static method, which accepts
+Define a `monitor` static method on your benchmark class, which accepts
 a [psutil.Process](https://psutil.readthedocs.io/en/latest/#psutil.Process)
-object and returns the telemetry data as a dictionary.
+object and returns the sample data as a dictionary. Samples are stored as a
+list in the `monitor` field of each result record.
 
-The default telemetry collection interval is every 60 seconds, which can be
-customized if needed using the `telemetry_interval` class variable.
+The default sampling interval is every 60 seconds, which can be customized
+using the `monitor_interval` class variable.
 
 A minimal example to capture memory usage every 90 seconds is shown below:
 
 ```python
 from microbench import MicroBench
 
-class TelemBench(MicroBench):
-    telemetry_interval = 90
+class MonitorBench(MicroBench):
+    monitor_interval = 90
 
     @staticmethod
-    def telemetry(process):
+    def monitor(process):
         return process.memory_full_info()._asdict()
 
-telem_bench = TelemBench()
+monitor_bench = MonitorBench()
 ```
 
 ## Extending microbench

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -172,14 +172,14 @@ class MicroBench:
                 if callable(method):
                     method(bm_data)
 
-        # Initialise telemetry thread
-        if hasattr(self, 'telemetry'):
-            interval = getattr(self, 'telemetry_interval', 60)
-            bm_data['telemetry'] = []
-            self._telemetry_thread = TelemetryThread(
-                self.telemetry, interval, bm_data['telemetry'], self.tz
+        # Initialise monitor thread
+        if hasattr(self, 'monitor'):
+            interval = getattr(self, 'monitor_interval', 60)
+            bm_data['monitor'] = []
+            self._monitor_thread = MonitorThread(
+                self.monitor, interval, bm_data['monitor'], self.tz
             )
-            self._telemetry_thread.start()
+            self._monitor_thread.start()
 
         bm_data['run_durations'] = []
         bm_data['start_time'] = datetime.now(self.tz)
@@ -187,11 +187,11 @@ class MicroBench:
     def post_finish_triggers(self, bm_data):
         bm_data['finish_time'] = datetime.now(self.tz)
 
-        # Terminate telemetry thread and gather results
-        if hasattr(self, '_telemetry_thread'):
-            self._telemetry_thread.terminate()
-            timeout = getattr(self, 'telemetry_timeout', 30)
-            self._telemetry_thread.join(timeout)
+        # Terminate monitor thread and gather results
+        if hasattr(self, '_monitor_thread'):
+            self._monitor_thread.terminate()
+            timeout = getattr(self, 'monitor_timeout', 30)
+            self._monitor_thread.join(timeout)
 
         # Run capturepost triggers
         for method_name in dir(self):
@@ -587,7 +587,7 @@ class MicroBenchRedis(MicroBench):
         )
 
 
-class TelemetryThread(threading.Thread):
+class MonitorThread(threading.Thread):
     def __init__(self, telem_fn, interval, slot, timezone, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._terminate = threading.Event()
@@ -596,29 +596,29 @@ class TelemetryThread(threading.Thread):
             signal.signal(signal.SIGTERM, self.terminate)
         else:
             warnings.warn(
-                'TelemetryThread: signal handlers not registered because '
-                'benchmark was started from a non-main thread. Telemetry '
+                'MonitorThread: signal handlers not registered because '
+                'benchmark was started from a non-main thread. Monitoring '
                 'will still be collected but may not stop cleanly on '
                 'SIGINT/SIGTERM.',
                 RuntimeWarning
             )
         self._interval = interval
-        self._telemetry = slot
-        self._telem_fn = telem_fn
+        self._monitor_data = slot
+        self._monitor_fn = telem_fn
         self._tz = timezone
         if not psutil:
-            raise ImportError('Telemetry requires the "psutil" package')
+            raise ImportError('Monitoring requires the "psutil" package')
         self.process = psutil.Process()
 
     def terminate(self, signum=None, frame=None):
         self._terminate.set()
 
-    def _get_telemetry(self):
-        telem = {'timestamp': datetime.now(self._tz)}
-        telem.update(self._telem_fn(self.process))
-        self._telemetry.append(telem)
+    def _get_sample(self):
+        sample = {'timestamp': datetime.now(self._tz)}
+        sample.update(self._monitor_fn(self.process))
+        self._monitor_data.append(sample)
 
     def run(self):
-        self._get_telemetry()
+        self._get_sample()
         while not self._terminate.wait(self._interval):
-            self._get_telemetry()
+            self._get_sample()

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -145,43 +145,43 @@ def test_capture_packages_importlib():
     assert pandas.__version__ == results['package_versions'][0]['pandas']
 
 
-def test_telemetry():
-    class TelemBench(MicroBench):
+def test_monitor():
+    class MonitorBench(MicroBench):
         @staticmethod
-        def telemetry(process):
+        def monitor(process):
             return process.memory_full_info()._asdict()
 
-    telem_bench = TelemBench()
+    monitor_bench = MonitorBench()
 
-    @telem_bench
+    @monitor_bench
     def noop():
         pass
 
     noop()
 
-    # Check telemetry thread completed
-    assert not telem_bench._telemetry_thread.is_alive()
+    # Check monitor thread completed
+    assert not monitor_bench._monitor_thread.is_alive()
 
-    # Check some telemetry was captured
-    results = telem_bench.get_results()
-    assert len(results['telemetry']) > 0
+    # Check some monitor data was captured
+    results = monitor_bench.get_results()
+    assert len(results['monitor']) > 0
 
 
-def test_telemetry_from_non_main_thread():
-    """Telemetry must not crash when started from a non-main thread (B6 fix).
+def test_monitor_from_non_main_thread():
+    """Monitor must not crash when started from a non-main thread (B6 fix).
 
-    signal.signal() can only be called from the main thread; TelemetryThread
+    signal.signal() can only be called from the main thread; MonitorThread
     should skip signal registration and emit a RuntimeWarning instead.
     """
 
-    class TelemBench(MicroBench):
+    class MonitorBench(MicroBench):
         @staticmethod
-        def telemetry(process):
+        def monitor(process):
             return {'rss': process.memory_info().rss}
 
-    telem_bench = TelemBench()
+    monitor_bench = MonitorBench()
 
-    @telem_bench
+    @monitor_bench
     def noop():
         pass
 
@@ -388,26 +388,26 @@ def test_get_results_without_pandas():
             bench.get_results()
 
 
-def test_telemetry_multiple_samples():
-    """TelemetryThread collects more than one sample for a long-running function."""
+def test_monitor_multiple_samples():
+    """MonitorThread collects more than one sample for a long-running function."""
 
-    class TelemBench(MicroBench):
-        telemetry_interval = 0.05
+    class MonitorBench(MicroBench):
+        monitor_interval = 0.05
 
         @staticmethod
-        def telemetry(process):
+        def monitor(process):
             return {'rss': process.memory_info().rss}
 
-    telem_bench = TelemBench()
+    monitor_bench = MonitorBench()
 
-    @telem_bench
+    @monitor_bench
     def slow_function():
         time.sleep(0.25)
 
     slow_function()
 
-    results = telem_bench.get_results()
-    assert len(results['telemetry'][0]) >= 2, 'Expected at least 2 telemetry samples'
+    results = monitor_bench.get_results()
+    assert len(results['monitor'][0]) >= 2, 'Expected at least 2 monitor samples'
 
 
 def test_redis_get_results():


### PR DESCRIPTION
## Summary

Breaking change for v2.0.

`telemetry` implies data transmission to a remote party, which is misleading and off-putting for privacy-conscious users. The feature is in-process periodic resource sampling — `monitor` is accurate and unambiguous.

## Breaking changes

| v1.x | v2.0 |
|------|------|
| `def telemetry(self, process):` | `def monitor(self, process):` |
| `telemetry_interval = 60` | `monitor_interval = 60` |
| `telemetry_timeout = 30` | `monitor_timeout = 30` |
| `results['telemetry']` | `results['monitor']` |
| `TelemetryThread` (internal) | `MonitorThread` (internal) |

## Migration

```python
# v1.x
class MyBench(MicroBench):
    telemetry_interval = 30
    @staticmethod
    def telemetry(process):
        return {'rss': process.memory_info().rss}

# v2.0
class MyBench(MicroBench):
    monitor_interval = 30
    @staticmethod
    def monitor(process):
        return {'rss': process.memory_info().rss}
```

## Test plan
- [x] All 41 tests pass