### PR TITLE
feat!: multi-sink output architecture (Output, FileOutput, RedisOutput)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,37 @@ All notable changes to microbench are documented here.
   - Result field `bm_data['telemetry']` → `bm_data['monitor']`
   - Internal attribute `self._telemetry_thread` → `self._monitor_thread`
 
+- **`MicroBenchRedis` removed** (#52): Use
+  `MicroBench(outputs=[RedisOutput(...)])` instead.
+
+  Before:
+  ```python
+  from microbench import MicroBenchRedis
+
+  class RedisBench(MicroBenchRedis):
+      redis_connection = {'host': 'localhost', 'port': 6379}
+      redis_key = 'microbench:mykey'
+
+  bench = RedisBench()
+  ```
+
+  After:
+  ```python
+  from microbench import MicroBench, RedisOutput
+
+  bench = MicroBench(outputs=[RedisOutput('microbench:mykey',
+                                           host='localhost', port=6379)])
+  ```
+
 ### New features
 
-- **Multi-sink output architecture**: Results can now be written to multiple
-  destinations simultaneously by passing an `outputs` list to `MicroBench`.
-  Three classes make up the new output API:
+- **Multi-sink output architecture** (#52): Results can now be written to
+  multiple destinations simultaneously by passing an `outputs` list to
+  `MicroBench`. Three classes make up the new output API:
   - `Output` — abstract base class; subclass this to implement custom sinks.
   - `FileOutput` — writes JSONL to a file path or file-like object (wraps the
     previous default behaviour).
-  - `RedisOutput` — writes to a Redis list; extracted from `MicroBenchRedis`.
+  - `RedisOutput` — writes to a Redis list.
 
   The existing `outfile` parameter and class-level `outfile` attribute continue
   to work as shorthand for a single `FileOutput`. Passing both `outfile` and
@@ -40,8 +62,5 @@ All notable changes to microbench are documented here.
   ])
   ```
 
-  `MicroBenchRedis` is now thin sugar for
-  `MicroBench(outputs=[RedisOutput(...)])` and retains its existing interface.
-
-  `get_results()` on `MicroBench` delegates to the first sink that supports
-  reading back results (`FileOutput` and `RedisOutput` both do).
+  `get_results()` delegates to the first sink that supports reading back
+  results (`FileOutput` and `RedisOutput` both do).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to microbench are documented here.
+
+## [2.0.0] - unreleased
+
+### Breaking changes
+
+- **`telemetry` renamed to `monitor`** (#51): The background sampling thread
+  has been renamed throughout the API to better reflect its intent (continuous
+  monitoring, not data transmission).
+  - `TelemetryThread` → `MonitorThread`
+  - Class variable `telemetry_interval` → `monitor_interval`
+  - Class variable `telemetry_timeout` → `monitor_timeout`
+  - Result field `bm_data['telemetry']` → `bm_data['monitor']`
+  - Internal attribute `self._telemetry_thread` → `self._monitor_thread`
+
+### New features
+
+- **Multi-sink output architecture**: Results can now be written to multiple
+  destinations simultaneously by passing an `outputs` list to `MicroBench`.
+  Three classes make up the new output API:
+  - `Output` — abstract base class; subclass this to implement custom sinks.
+  - `FileOutput` — writes JSONL to a file path or file-like object (wraps the
+    previous default behaviour).
+  - `RedisOutput` — writes to a Redis list; extracted from `MicroBenchRedis`.
+
+  The existing `outfile` parameter and class-level `outfile` attribute continue
+  to work as shorthand for a single `FileOutput`. Passing both `outfile` and
+  `outputs` raises `ValueError`.
+
+  Example — write to a file and Redis simultaneously:
+
+  ```python
+  from microbench import MicroBench, FileOutput, RedisOutput
+
+  bench = MicroBench(outputs=[
+      FileOutput('/home/user/results.jsonl'),
+      RedisOutput('microbench:mykey', host='redis-host', port=6379),
+  ])
+  ```
+
+  `MicroBenchRedis` is now thin sugar for
+  `MicroBench(outputs=[RedisOutput(...)])` and retains its existing interface.
+
+  `get_results()` on `MicroBench` delegates to the first sink that supports
+  reading back results (`FileOutput` and `RedisOutput` both do).

--- a/README.md
+++ b/README.md
@@ -68,12 +68,11 @@ def myfunction(arg1, arg2, ...):
 ```
 
 That's it! When `myfunction()` is called, metadata will be captured
-into a `io.StringIO()` buffer, which can be read as follows
+into an in-memory buffer, which can be read as follows
 (using the `pandas` library):
 
 ```python
-import pandas as pd
-results = pd.read_json(basic_bench.outfile, lines=True)
+results = basic_bench.get_results()
 ```
 
 The above example captures the fields `start_time`, `finish_time`,
@@ -418,22 +417,73 @@ def return_a_graph():
 return_a_graph()
 ```
 
-## Redis support
+## Output sinks
 
-By default, microbench appends output to a file, but output can be directed
-elsewhere, e.g. [redis](https://redis.io) - an in-memory, networked data source.
-This option is useful when a shared filesystem is not available.
+By default, microbench writes results to an in-memory buffer. You can direct
+output elsewhere by passing an `outputs` list to the constructor. Each element
+must be an instance of an `Output` subclass.
 
-Redis support requires [redis-py](https://github.com/andymccurdy/redis-py).
+### Saving to a file
 
-To use this feature, inherit from `MicroBenchRedis` instead of `MicroBench`,
-and specify the redis connection and key name as in the following example:
+Pass a file path with `outfile` (shorthand for a single `FileOutput`):
+
+```python
+from microbench import MicroBench
+
+benchmark = MicroBench(outfile='/home/user/my-benchmarks.jsonl')
+```
+
+Or use `FileOutput` directly when combining with other sinks:
+
+```python
+from microbench import MicroBench, FileOutput
+
+benchmark = MicroBench(outputs=[FileOutput('/home/user/my-benchmarks.jsonl')])
+```
+
+### Multiple sinks
+
+Pass a list of sinks to write results to several destinations simultaneously.
+For example, to write to both a local file and a Redis server:
+
+```python
+from microbench import MicroBench, FileOutput, RedisOutput
+
+benchmark = MicroBench(outputs=[
+    FileOutput('/home/user/my-benchmarks.jsonl'),
+    RedisOutput('microbench:mykey', host='redis-host', port=6379),
+])
+```
+
+`get_results()` reads from the first sink that supports it.
+
+### Custom output sinks
+
+Subclass `Output` and implement `write` to send results anywhere:
+
+```python
+from microbench import MicroBench, Output
+
+class MyOutput(Output):
+    def write(self, bm_json_str):
+        send_to_my_system(bm_json_str)
+
+benchmark = MicroBench(outputs=[MyOutput()])
+```
+
+### Redis support
+
+[Redis](https://redis.io) is a useful destination when a shared filesystem is
+not available. Redis support requires
+[redis-py](https://github.com/andymccurdy/redis-py).
+
+Use `RedisOutput` directly (as shown above), or use the `MicroBenchRedis`
+convenience subclass:
 
 ```python
 from microbench import MicroBenchRedis
 
 class RedisBench(MicroBenchRedis):
-    # redis_connection contains arguments for redis.StrictClient()
     redis_connection = {'host': 'localhost', 'port': 6379}
     redis_key = 'microbench:mykey'
 
@@ -450,10 +500,10 @@ results = benchmark.get_results()
 
 The runtime impact varies depending on what information is captured and by platform.
 Broadly, capturing environment variables, Python package versions, and timing
-information for a function has a negligible impact. Capturing telemetry and
+information for a function has a negligible impact. Periodic monitoring and
 invoking external programs (like `nvidia-smi` for GPU information) has a larger impact,
 although the latter is a one-off per invocation and typically less than one second.
-Telemetry capture intervals should be kept relatively infrequent (e.g., every minute
+Monitor sampling intervals should be kept relatively infrequent (e.g., every minute
 or two, rather than every second) to avoid significant runtime impacts.
 
 ### Duration timings

--- a/README.md
+++ b/README.md
@@ -477,20 +477,14 @@ benchmark = MicroBench(outputs=[MyOutput()])
 not available. Redis support requires
 [redis-py](https://github.com/andymccurdy/redis-py).
 
-Use `RedisOutput` directly (as shown above), or use the `MicroBenchRedis`
-convenience subclass:
-
 ```python
-from microbench import MicroBenchRedis
+from microbench import MicroBench, RedisOutput
 
-class RedisBench(MicroBenchRedis):
-    redis_connection = {'host': 'localhost', 'port': 6379}
-    redis_key = 'microbench:mykey'
-
-benchmark = RedisBench()
+benchmark = MicroBench(outputs=[RedisOutput('microbench:mykey',
+                                             host='localhost', port=6379)])
 ```
 
-To retrieve results, use `get_results()` just like the base class:
+Results are retrieved with `get_results()` as usual:
 
 ```python
 results = benchmark.get_results()

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -50,7 +50,6 @@ except ImportError:
 __all__ = [
     # Core
     'MicroBench',
-    'MicroBenchRedis',
     # Output sinks
     'Output',
     'FileOutput',
@@ -193,6 +192,7 @@ class RedisOutput(Output):
 
     def __init__(self, redis_key, **redis_connection):
         import redis as _redis
+
         self.rclient = _redis.StrictRedis(**redis_connection)
         self.redis_key = redis_key
 
@@ -691,27 +691,6 @@ class MBNvidiaSmi:
                 ]
 
 
-class MicroBenchRedis(MicroBench):
-    """MicroBench subclass that defaults to Redis output.
-
-    Equivalent to ``MicroBench(outputs=[RedisOutput(redis_key, **redis_connection)])``.
-    Specify ``redis_connection`` and ``redis_key`` as class attributes.
-
-    Example::
-
-        class RedisBench(MicroBenchRedis):
-            redis_connection = {'host': 'localhost', 'port': 6379}
-            redis_key = 'microbench:mykey'
-
-        benchmark = RedisBench()
-    """
-
-    def __init__(self, *args, **kwargs):
-        if 'outputs' not in kwargs and 'outfile' not in kwargs:
-            kwargs['outputs'] = [RedisOutput(self.redis_key, **self.redis_connection)]
-        super().__init__(*args, **kwargs)
-
-
 class MonitorThread(threading.Thread):
     def __init__(self, telem_fn, interval, slot, timezone, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -725,7 +704,7 @@ class MonitorThread(threading.Thread):
                 'benchmark was started from a non-main thread. Monitoring '
                 'will still be collected but may not stop cleanly on '
                 'SIGINT/SIGTERM.',
-                RuntimeWarning
+                RuntimeWarning,
             )
         self._interval = interval
         self._monitor_data = slot

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -51,6 +51,10 @@ __all__ = [
     # Core
     'MicroBench',
     'MicroBenchRedis',
+    # Output sinks
+    'Output',
+    'FileOutput',
+    'RedisOutput',
     # Mixins
     'MBFunctionCall',
     'MBReturnValue',
@@ -97,6 +101,112 @@ class JSONEncodeWarning(Warning):
 _UNENCODABLE_PLACEHOLDER_VALUE = '__unencodable_as_json__'
 
 
+class Output:
+    """Abstract base class for benchmark output sinks.
+
+    Subclass this to implement custom output destinations.
+    Must implement :meth:`write`. May optionally implement
+    :meth:`get_results` to allow reading back stored results.
+
+    Example::
+
+        class MyOutput(Output):
+            def write(self, bm_json_str):
+                send_somewhere(bm_json_str)
+    """
+
+    def write(self, bm_json_str):
+        """Write a single JSON-encoded benchmark result.
+
+        Args:
+            bm_json_str (str): JSON string (without trailing newline).
+        """
+        raise NotImplementedError
+
+    def get_results(self):
+        """Return all stored results as a pandas DataFrame.
+
+        Raises:
+            NotImplementedError: If this sink does not support reading results.
+            ImportError: If pandas is not installed.
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support get_results()'
+        )
+
+
+class FileOutput(Output):
+    """Write benchmark results to a file path or file-like object (JSONL format).
+
+    Each result is written as a single JSON line. When *outfile* is a path
+    string, each write opens the file in append mode (POSIX ``O_APPEND``),
+    which is safe for concurrent writers on the same filesystem. When
+    *outfile* is a file-like object it is written to directly.
+
+    When no *outfile* is given an :class:`io.StringIO` buffer is used,
+    which allows results to be read back via :meth:`get_results`.
+
+    Args:
+        outfile (str or file-like, optional): Destination file path or
+            file-like object. Defaults to a fresh :class:`io.StringIO`.
+    """
+
+    def __init__(self, outfile=None):
+        if outfile is None:
+            outfile = io.StringIO()
+        self.outfile = outfile
+
+    def write(self, bm_json_str):
+        bm_str = bm_json_str + '\n'
+        if isinstance(self.outfile, str):
+            with open(self.outfile, 'a') as f:
+                f.write(bm_str)
+        else:
+            self.outfile.write(bm_str)
+
+    def get_results(self):
+        if not pandas:
+            raise ImportError('This functionality requires the "pandas" package')
+        if hasattr(self.outfile, 'seek'):
+            self.outfile.seek(0)
+        return pandas.read_json(self.outfile, lines=True)
+
+
+class RedisOutput(Output):
+    """Write benchmark results to a Redis list (one JSON string per record).
+
+    Results are appended using ``RPUSH`` and can be read back via
+    :meth:`get_results` using ``LRANGE``.
+
+    Args:
+        redis_key (str): Redis key for the result list.
+        **redis_connection: Keyword arguments forwarded to
+            ``redis.StrictRedis()`` (e.g. ``host``, ``port``).
+
+    Example::
+
+        from microbench import MicroBench, RedisOutput
+
+        bench = MicroBench(outputs=[RedisOutput('microbench:mykey',
+                                                host='localhost', port=6379)])
+    """
+
+    def __init__(self, redis_key, **redis_connection):
+        import redis as _redis
+        self.rclient = _redis.StrictRedis(**redis_connection)
+        self.redis_key = redis_key
+
+    def write(self, bm_json_str):
+        self.rclient.rpush(self.redis_key, bm_json_str)
+
+    def get_results(self):
+        if not pandas:
+            raise ImportError('This functionality requires the "pandas" package')
+        redis_data = self.rclient.lrange(self.redis_key, 0, -1)
+        json_data = '\n'.join(r.decode('utf8') for r in redis_data)
+        return pandas.read_json(io.StringIO(json_data), lines=True)
+
+
 class MicroBench:
     def __init__(
         self,
@@ -105,38 +215,58 @@ class MicroBench:
         tz=timezone.utc,
         iterations=1,
         duration_counter=time.perf_counter,
+        outputs=None,
         *args,
         **kwargs,
     ):
         """Benchmark and metadata capture suite.
 
         Args:
-            outfile (file or buf, optional): Output file or buffer.
-                Defaults to None, which captures data using a StringIO
-                buffer.
+            outfile (str or file-like, optional): Shorthand for a single
+                :class:`FileOutput` destination. Mutually exclusive with
+                *outputs*. Defaults to None (an in-memory
+                :class:`io.StringIO` buffer when no *outputs* are given).
             json_encoder (json.JSONEncoder, optional): JSONEncoder for
                 benchmark results. Defaults to JSONEncoder.
             tz (timezone, optional): Timezone for start_time and finish_time.
                 Defaults to timezone.utc.
             iterations (int, optional): Number of iterations to run function.
                 Defaults to 1.
-            duration_counter (_type_, optional): Timer function to use for
+            duration_counter (callable, optional): Timer function to use for
                 run_durations. Defaults to time.perf_counter.
+            outputs (list of Output, optional): One or more :class:`Output`
+                sinks that receive each benchmark result. Mutually exclusive
+                with *outfile*. Defaults to a single :class:`FileOutput`
+                (using *outfile* if given, otherwise the class-level
+                ``outfile`` attribute, otherwise an in-memory
+                :class:`io.StringIO`).
 
         Raises:
-            ValueError: If unknown position arguments are used.
+            ValueError: If both *outfile* and *outputs* are provided, or if
+                extra positional arguments are passed.
         """
         if args:
             raise ValueError('Only keyword arguments are allowed')
+        if outfile is not None and outputs is not None:
+            raise ValueError(
+                'outfile and outputs are mutually exclusive; '
+                'use outputs=[FileOutput(...)] to combine file output with '
+                'other sinks'
+            )
         self._bm_static = kwargs
-        if outfile is not None:
-            self.outfile = outfile
-        elif not hasattr(self, 'outfile'):
-            self.outfile = io.StringIO()
         self._json_encoder = json_encoder
         self._duration_counter = duration_counter
         self.tz = tz
         self.iterations = iterations
+
+        if outputs is not None:
+            self._outputs = list(outputs)
+        elif outfile is not None:
+            self._outputs = [FileOutput(outfile)]
+        elif hasattr(self, 'outfile'):
+            self._outputs = [FileOutput(self.outfile)]
+        else:
+            self._outputs = [FileOutput()]
 
     def pre_start_triggers(self, bm_data):
         # Store timezone
@@ -227,25 +357,22 @@ class MicroBench:
         return bm_str
 
     def output_result(self, bm_data):
-        """Output result to self.outfile as a line in JSON format"""
-        bm_str = self.to_json(bm_data) + '\n'
-
-        # This should guarantee atomic writes on POSIX by setting O_APPEND
-        if isinstance(self.outfile, str):
-            with open(self.outfile, 'a') as f:
-                f.write(bm_str)
-        else:
-            # Assume file-like object
-            self.outfile.write(bm_str)
+        """Fan out the JSON-encoded result to all configured output sinks."""
+        bm_str = self.to_json(bm_data)
+        for output in self._outputs:
+            output.write(bm_str)
 
     def get_results(self):
-        if not pandas:
-            raise ImportError('This functionality requires the "pandas" package')
-
-        if hasattr(self.outfile, 'seek'):
-            self.outfile.seek(0)
-
-        return pandas.read_json(self.outfile, lines=True)
+        """Return results from the first output sink that supports it."""
+        for output in self._outputs:
+            try:
+                return output.get_results()
+            except NotImplementedError:
+                continue
+        raise RuntimeError(
+            'None of the configured output sinks support get_results(). '
+            'Use FileOutput or RedisOutput.'
+        )
 
     def __call__(self, func):
         def inner(*args, **kwargs):
@@ -565,26 +692,24 @@ class MBNvidiaSmi:
 
 
 class MicroBenchRedis(MicroBench):
+    """MicroBench subclass that defaults to Redis output.
+
+    Equivalent to ``MicroBench(outputs=[RedisOutput(redis_key, **redis_connection)])``.
+    Specify ``redis_connection`` and ``redis_key`` as class attributes.
+
+    Example::
+
+        class RedisBench(MicroBenchRedis):
+            redis_connection = {'host': 'localhost', 'port': 6379}
+            redis_key = 'microbench:mykey'
+
+        benchmark = RedisBench()
+    """
+
     def __init__(self, *args, **kwargs):
+        if 'outputs' not in kwargs and 'outfile' not in kwargs:
+            kwargs['outputs'] = [RedisOutput(self.redis_key, **self.redis_connection)]
         super().__init__(*args, **kwargs)
-
-        import redis
-
-        self.rclient = redis.StrictRedis(**self.redis_connection)
-
-    def output_result(self, bm_data):
-        self.rclient.rpush(self.redis_key, self.to_json(bm_data))
-
-    def get_results(self):
-        if not pandas:
-            raise ImportError(
-                'This functionality requires the "pandas" package'
-            )
-        redis_data = self.rclient.lrange(self.redis_key, 0, -1)
-        json_data = '\n'.join(r.decode('utf8') for r in redis_data)
-        return pandas.read_json(
-            io.StringIO(json_data), lines=True
-        )
 
 
 class MonitorThread(threading.Thread):

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -13,6 +13,7 @@ import pytest
 
 from microbench import (
     _UNENCODABLE_PLACEHOLDER_VALUE,
+    FileOutput,
     JSONEncoder,
     JSONEncodeWarning,
     MBFunctionCall,
@@ -22,6 +23,8 @@ from microbench import (
     MBReturnValue,
     MicroBench,
     MicroBenchRedis,
+    Output,
+    RedisOutput,
 )
 from microbench import __version__ as microbench_version
 
@@ -318,10 +321,16 @@ def test_positional_args_raises():
 
     The *args guard is primarily designed for subclasses that forward *args
     via super().__init__(*args, **kwargs). Triggering it directly requires
-    saturating the five named positional parameters first.
+    saturating the six named positional parameters first.
     """
     with pytest.raises(ValueError, match='keyword'):
-        MicroBench(None, JSONEncoder, datetime.timezone.utc, 1, None, 'extra')
+        MicroBench(None, JSONEncoder, datetime.timezone.utc, 1, None, None, 'extra')
+
+
+def test_outfile_and_outputs_raises():
+    """Passing both outfile and outputs raises ValueError."""
+    with pytest.raises(ValueError, match='mutually exclusive'):
+        MicroBench(outfile='/tmp/x.json', outputs=[FileOutput()])
 
 
 def test_outfile_string_path():
@@ -408,6 +417,59 @@ def test_monitor_multiple_samples():
 
     results = monitor_bench.get_results()
     assert len(results['monitor'][0]) >= 2, 'Expected at least 2 monitor samples'
+
+
+def test_multi_sink_output():
+    """Results are written to all configured output sinks."""
+
+    class RecordingOutput(Output):
+        def __init__(self):
+            self.records = []
+
+        def write(self, bm_json_str):
+            self.records.append(bm_json_str)
+
+    sink_a = RecordingOutput()
+    sink_b = FileOutput()
+
+    bench = MicroBench(outputs=[sink_a, sink_b])
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+    noop()
+
+    assert len(sink_a.records) == 2
+    results = sink_b.get_results()
+    assert len(results) == 2
+    assert (results['function_name'] == 'noop').all()
+
+
+def test_output_base_get_results_raises():
+    """Output.get_results() raises NotImplementedError by default."""
+    with pytest.raises(NotImplementedError):
+        Output().get_results()
+
+
+def test_no_supporting_sink_raises():
+    """get_results() raises RuntimeError when no sink supports it."""
+
+    class SinkOnly(Output):
+        def write(self, bm_json_str):
+            pass
+
+    bench = MicroBench(outputs=[SinkOnly()])
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    with pytest.raises(RuntimeError, match='get_results'):
+        bench.get_results()
 
 
 def test_redis_get_results():

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -22,8 +22,8 @@ from microbench import (
     MBPythonVersion,
     MBReturnValue,
     MicroBench,
-    MicroBenchRedis,
     Output,
+    RedisOutput,
 )
 from microbench import __version__ as microbench_version
 
@@ -471,27 +471,25 @@ def test_no_supporting_sink_raises():
         bench.get_results()
 
 
-def test_redis_get_results():
-    """MicroBenchRedis.get_results() reads results back from Redis."""
-    # Mock redis.StrictRedis so we don't need a real server
-    redis_store = []
-
+def _make_mock_redis(redis_store):
+    """Return a mock redis module wired to the given list as a backing store."""
     mock_redis_client = MagicMock()
     mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
         val.encode('utf8') if isinstance(val, str) else val
     )
     mock_redis_client.lrange.side_effect = lambda key, start, end: redis_store
-
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_redis_client
+    return mock_redis, mock_redis_client
+
+
+def test_redis_output_get_results():
+    """RedisOutput.get_results() reads results back from Redis."""
+    redis_store = []
+    mock_redis, mock_redis_client = _make_mock_redis(redis_store)
 
     with patch.dict('sys.modules', {'redis': mock_redis}):
-
-        class RedisBench(MicroBenchRedis):
-            redis_connection = {}
-            redis_key = 'test:bench'
-
-        bench = RedisBench()
+        bench = MicroBench(outputs=[RedisOutput('test:bench')])
 
         @bench
         def noop():
@@ -504,51 +502,32 @@ def test_redis_get_results():
         assert 'start_time' in results.columns
         assert 'finish_time' in results.columns
 
-        # Verify rpush was called with the correct key
         mock_redis_client.rpush.assert_called_once()
         assert mock_redis_client.rpush.call_args[0][0] == 'test:bench'
 
 
-def test_redis_get_results_without_pandas():
-    """MicroBenchRedis.get_results() raises ImportError without pandas."""
+def test_redis_output_get_results_without_pandas():
+    """RedisOutput.get_results() raises ImportError without pandas."""
     import microbench
 
-    mock_redis = MagicMock()
-    mock_redis.StrictRedis.return_value = MagicMock()
+    redis_store = []
+    mock_redis, _ = _make_mock_redis(redis_store)
 
     with patch.dict('sys.modules', {'redis': mock_redis}):
-
-        class RedisBench(MicroBenchRedis):
-            redis_connection = {}
-            redis_key = 'test:bench'
-
-        bench = RedisBench()
+        bench = MicroBench(outputs=[RedisOutput('test:bench')])
 
         with patch.object(microbench, 'pandas', None):
             with pytest.raises(ImportError, match='pandas'):
                 bench.get_results()
 
 
-def test_redis_multiple_results():
-    """MicroBenchRedis.get_results() returns all stored results."""
+def test_redis_output_multiple_results():
+    """RedisOutput.get_results() returns all stored results."""
     redis_store = []
-
-    mock_redis_client = MagicMock()
-    mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
-        val.encode('utf8') if isinstance(val, str) else val
-    )
-    mock_redis_client.lrange.side_effect = lambda key, start, end: redis_store
-
-    mock_redis = MagicMock()
-    mock_redis.StrictRedis.return_value = mock_redis_client
+    mock_redis, _ = _make_mock_redis(redis_store)
 
     with patch.dict('sys.modules', {'redis': mock_redis}):
-
-        class RedisBench(MicroBenchRedis):
-            redis_connection = {}
-            redis_key = 'test:bench'
-
-        bench = RedisBench()
+        bench = MicroBench(outputs=[RedisOutput('test:bench')])
 
         @bench
         def func_a():

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -24,7 +24,6 @@ from microbench import (
     MicroBench,
     MicroBenchRedis,
     Output,
-    RedisOutput,
 )
 from microbench import __version__ as microbench_version
 
@@ -481,9 +480,7 @@ def test_redis_get_results():
     mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
         val.encode('utf8') if isinstance(val, str) else val
     )
-    mock_redis_client.lrange.side_effect = (
-        lambda key, start, end: redis_store
-    )
+    mock_redis_client.lrange.side_effect = lambda key, start, end: redis_store
 
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_redis_client
@@ -540,9 +537,7 @@ def test_redis_multiple_results():
     mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
         val.encode('utf8') if isinstance(val, str) else val
     )
-    mock_redis_client.lrange.side_effect = (
-        lambda key, start, end: redis_store
-    )
+    mock_redis_client.lrange.side_effect = lambda key, start, end: redis_store
 
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_redis_client


### PR DESCRIPTION
## Summary

- Adds `Output` abstract base class, `FileOutput`, and `RedisOutput` concrete implementations
- `MicroBench` now accepts an `outputs=` list; results fan out to all configured sinks
- `outfile=` remains as backwards-compatible shorthand for a single `FileOutput`; passing both `outfile` and `outputs` raises `ValueError`
- `MicroBenchRedis` is refactored to use `RedisOutput` internally (no interface change)
- `get_results()` delegates to the first sink that supports reading back results
- Starts `CHANGELOG.md` documenting this feature and the v2.0 `telemetry` → `monitor` rename (#51)

## Test plan

- [x] `test_multi_sink_output` — results written to all sinks
- [x] `test_output_base_get_results_raises` — `Output.get_results()` raises `NotImplementedError`
- [x] `test_no_supporting_sink_raises` — `get_results()` raises `RuntimeError` when no sink supports it
- [x] `test_outfile_and_outputs_raises` — mutual exclusion enforced
- [x] All existing Redis, file, and base tests continue to pass (45 passed, 1 skipped)