### PR TITLE
feat: add mb_run_id and mb_version to every record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to microbench are documented here.
+
+## [1.1.0] - unreleased
+
+### New features
+
+- **`mb_run_id` and `mb_version` fields added to every record**: Both fields
+  are included automatically without any configuration.
+  - `mb_run_id` — UUID generated once at import time and shared by all
+    `MicroBench` instances in the same process. Allows records from independent
+    bench suites to be correlated with `groupby('mb_run_id')`.
+  - `mb_version` — version of the `microbench` package that produced the
+    record; essential for long-running studies where the benchmark code evolves.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,18 @@ import pandas as pd
 results = pd.read_json(basic_bench.outfile, lines=True)
 ```
 
-The above example captures the fields `start_time`, `finish_time`,
-`run_durations` (of each function call, in seconds by default), `function_name`,
-`timestamp_tz` (timezone name, see Timezones section of this README), and
-`duration_counter` (the name of the function used to calculate
-durations, see Duration timings section of this README).
+The above example captures the following fields in every record:
+
+| Field | Description |
+|-------|-------------|
+| `mb_run_id` | UUID generated once when `microbench` is imported. The same value appears in every record produced by the same process, so results from independent bench suites can be correlated with `groupby('mb_run_id')`. A new UUID is produced for each fresh process invocation. |
+| `mb_version` | Version of the `microbench` package that produced the record; useful when benchmark results are stored long-term and the code evolves. |
+| `start_time` | Timestamp when the function was first called (ISO-8601, UTC by default). |
+| `finish_time` | Timestamp when the function returned (ISO-8601, UTC by default). |
+| `run_durations` | List of per-iteration durations in seconds (one entry per iteration). |
+| `function_name` | Name of the decorated function. |
+| `timestamp_tz` | Timezone used for `start_time`/`finish_time` (see Timezones section). |
+| `duration_counter` | Name of the timer function used for `run_durations` (see Duration timings section). |
 
 Microbench can capture many
 other types of metadata from the environment, resource usage, and

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import time
 import types
+import uuid
 import warnings
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
@@ -34,6 +35,12 @@ try:
     import pandas
 except ImportError:
     pandas = None
+
+
+# Generated once at import time; shared by all MicroBench instances in this
+# process, allowing records from independent bench suites to be correlated.
+# A new value is produced for each separate process invocation.
+_run_id = str(uuid.uuid4())
 
 
 try:
@@ -139,6 +146,8 @@ class MicroBench:
         self.iterations = iterations
 
     def pre_start_triggers(self, bm_data):
+        bm_data['mb_run_id'] = _run_id
+        bm_data['mb_version'] = __version__
         # Store timezone
         bm_data['timestamp_tz'] = str(self.tz)
         # Store duration counter function name
@@ -577,14 +586,10 @@ class MicroBenchRedis(MicroBench):
 
     def get_results(self):
         if not pandas:
-            raise ImportError(
-                'This functionality requires the "pandas" package'
-            )
+            raise ImportError('This functionality requires the "pandas" package')
         redis_data = self.rclient.lrange(self.redis_key, 0, -1)
         json_data = '\n'.join(r.decode('utf8') for r in redis_data)
-        return pandas.read_json(
-            io.StringIO(json_data), lines=True
-        )
+        return pandas.read_json(io.StringIO(json_data), lines=True)
 
 
 class TelemetryThread(threading.Thread):
@@ -600,7 +605,7 @@ class TelemetryThread(threading.Thread):
                 'benchmark was started from a non-main thread. Telemetry '
                 'will still be collected but may not stop cleanly on '
                 'SIGINT/SIGTERM.',
-                RuntimeWarning
+                RuntimeWarning,
             )
         self._interval = interval
         self._telemetry = slot

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -11,6 +11,7 @@ import numpy
 import pandas
 import pytest
 
+import microbench
 from microbench import (
     _UNENCODABLE_PLACEHOLDER_VALUE,
     JSONEncoder,
@@ -26,6 +27,38 @@ from microbench import (
 from microbench import __version__ as microbench_version
 
 from .globals_capture import globals_bench
+
+
+def test_mb_run_id_and_version():
+    """mb_run_id is consistent across bench suites; mb_version matches package."""
+    bench_a = MicroBench()
+    bench_b = MicroBench()
+
+    @bench_a
+    def noop_a():
+        pass
+
+    @bench_b
+    def noop_b():
+        pass
+
+    noop_a()
+    noop_b()
+
+    res_a = bench_a.get_results()
+    res_b = bench_b.get_results()
+
+    # Both suites in the same process share the same run_id
+    assert res_a['mb_run_id'][0] == res_b['mb_run_id'][0]
+    # run_id looks like a UUID
+    assert len(res_a['mb_run_id'][0]) == 36
+
+    # mb_version matches the installed package version
+    assert res_a['mb_version'][0] == microbench_version
+    assert res_b['mb_version'][0] == microbench_version
+
+    # run_id matches the module-level value directly
+    assert res_a['mb_run_id'][0] == microbench._run_id
 
 
 def test_function():
@@ -419,9 +452,7 @@ def test_redis_get_results():
     mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
         val.encode('utf8') if isinstance(val, str) else val
     )
-    mock_redis_client.lrange.side_effect = (
-        lambda key, start, end: redis_store
-    )
+    mock_redis_client.lrange.side_effect = lambda key, start, end: redis_store
 
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_redis_client
@@ -478,9 +509,7 @@ def test_redis_multiple_results():
     mock_redis_client.rpush.side_effect = lambda key, val: redis_store.append(
         val.encode('utf8') if isinstance(val, str) else val
     )
-    mock_redis_client.lrange.side_effect = (
-        lambda key, start, end: redis_store
-    )
+    mock_redis_client.lrange.side_effect = lambda key, start, end: redis_store
 
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_redis_client


### PR DESCRIPTION
## Summary

- `mb_run_id` — UUID generated once at module import time, shared by all `MicroBench` instances in the same process. Allows records from independent bench suites to be correlated with `groupby('mb_run_id')` without any configuration.
- `mb_version` — microbench package version in every record; useful for long-running studies where benchmark code evolves.

Both fields are added automatically with no opt-in required.

Backport of the same feature shipping in v2.0.

## Test plan

- [x] `test_mb_run_id_and_version` — verifies both suites in the same process share `mb_run_id`, UUID format, and `mb_version` matches installed version
- [x] All existing tests pass (42 passed, 1 skipped)