### PR TITLE
docs: add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: docs
+
+on:
+  push:
+    branches: [main, v1.x]
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # mike needs full history to manage gh-pages
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install docs dependencies
+        run: pip install -e ".[docs]"
+
+      - name: Configure git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy dev docs (main branch)
+        if: github.ref == 'refs/heads/main'
+        run: mike deploy --push dev
+
+      - name: Deploy versioned docs (tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          MAJOR="${VERSION%%.*}"
+          MINOR="$(echo "$VERSION" | cut -d. -f2)"
+          mike deploy --push --update-aliases "${MAJOR}.${MINOR}" latest
+          mike set-default --push latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.egg-info/
 dist/
 microbench/_version_scm.py
+site/

--- a/README.md
+++ b/README.md
@@ -2,495 +2,58 @@
 
 ![Microbench: Benchmarking and reproducibility metadata capture for Python](https://raw.githubusercontent.com/alubbock/microbench/master/microbench.png)
 
-Microbench is a small Python package for benchmarking Python functions, and
-optionally capturing extra runtime/environment information. It is most useful in
-clustered/distributed environments, where the same function runs under different
-environments, and is designed to be extensible with new
-functionality. In addition to benchmarking, this can help reproducibility by
-e.g. logging the versions of key Python packages, or even all packages loaded
-into the global environment. Other captured metadata can include CPU and RAM
-usage, environment variables, and hardware specifications.
+Microbench is a small Python package for benchmarking Python functions and
+capturing reproducibility metadata — designed for clustered and distributed
+environments where the same code runs across many machines.
 
-## Requirements
+## Key features
 
-Microbench by default has no dependencies outside of the Python standard
-library, although [pandas](https://pandas.pydata.org/) is recommended to
-examine results. However, some mixins (extensions) have specific requirements:
-
-* The [line_profiler](https://github.com/rkern/line_profiler)
-  package needs to be installed for line-by-line code benchmarking.
-* The CPU cores, total RAM, and telemetry extensions require
-  [psutil](https://pypi.org/project/psutil/).
-* The NVIDIA GPU plugin requires the
-  [nvidia-smi](https://developer.nvidia.com/nvidia-system-management-interface)
-  utility, which usually ships with the NVIDIA graphics card drivers. It needs
-  to be on your `PATH`.
+- **Zero-config timing** — decorate a function, get timestamps and run
+  durations immediately, no setup required
+- **Extensible via mixins** — capture Python version, hostname, CPU/RAM
+  specs, conda/pip package versions, NVIDIA GPU info, line-level profiles,
+  and more by adding mixin classes
+- **Cluster and HPC ready** — capture SLURM environment variables, psutil
+  resource metrics, and per-process run IDs for correlating results across
+  nodes
+- **JSONL output** — one JSON object per call; load into pandas with
+  `read_json(..., lines=True)`; no schema lock-in, add any extra fields you
+  need
+- **Flexible output** — write to a local file, in-memory buffer, or Redis;
+  file writes use `O_APPEND` for safe concurrent access on shared filesystems
 
 ## Installation
-
-To install using `pip`:
 
 ```
 pip install microbench
 ```
 
-## Usage
-
-Microbench is designed for benchmarking Python functions. These examples will
-assume you have already defined a Python function `myfunction` that you wish to
-benchmark:
-
-```python
-def myfunction(arg1, arg2, ...):
-    ...
-```
-
-### Minimal example
-
-First, create a benchmark suite, which specifies the configuration and
-information to capture.
-
-Here's a minimal, complete example:
+## Quick start
 
 ```python
 from microbench import MicroBench
 
-basic_bench = MicroBench()
-```
+bench = MicroBench(outfile='/home/user/results.jsonl', experiment='baseline')
 
-To attach the benchmark to your function, simply use `basic_bench` as a
-decorator, like this:
-
-```python
-@basic_bench
-def myfunction(arg1, arg2, ...):
-    ...
-```
-
-That's it! When `myfunction()` is called, metadata will be captured
-into a `io.StringIO()` buffer, which can be read as follows
-(using the `pandas` library):
-
-```python
-import pandas as pd
-results = pd.read_json(basic_bench.outfile, lines=True)
-```
-
-The above example captures the following fields in every record:
-
-| Field | Description |
-|-------|-------------|
-| `mb_run_id` | UUID generated once when `microbench` is imported. The same value appears in every record produced by the same process, so results from independent bench suites can be correlated with `groupby('mb_run_id')`. A new UUID is produced for each fresh process invocation. |
-| `mb_version` | Version of the `microbench` package that produced the record; useful when benchmark results are stored long-term and the code evolves. |
-| `start_time` | Timestamp when the function was first called (ISO-8601, UTC by default). |
-| `finish_time` | Timestamp when the function returned (ISO-8601, UTC by default). |
-| `run_durations` | List of per-iteration durations in seconds (one entry per iteration). |
-| `function_name` | Name of the decorated function. |
-| `timestamp_tz` | Timezone used for `start_time`/`finish_time` (see Timezones section). |
-| `duration_counter` | Name of the timer function used for `run_durations` (see Duration timings section). |
-
-Microbench can capture many
-other types of metadata from the environment, resource usage, and
-hardware, which are covered below.
-
-### Extended examples
-
-Here's a more complete example using mixins (the `MB` prefixed class
-names) to extend functionality. Note that keyword arguments can be supplied
-to the constructor (in this case `some_info=123`) to specify additional
-information to capture. We also specify `iterations=3`, which means that the
-called function with be executed 3 times (the returned result will always
-be from the final run) with timings captured for each run. We specify a custom
-duration counter, `time.monotonic` instead of the default `time.perf_counter`
-(see Duration timings section later in this README for explanation).
-This example also specifies the `outfile` option,
-which appends metadata to a file on disk.
-
-```python
-from microbench import *
-import numpy, pandas, time
-
-class MyBench(MicroBench, MBFunctionCall, MBPythonVersion, MBHostInfo):
-    outfile = '/home/user/my-benchmarks'
-    capture_versions = (numpy, pandas)  # Or use MBGlobalPackages/MBInstalledPackages
-    env_vars = ('SLURM_ARRAY_TASK_ID', )
-
-benchmark = MyBench(some_info=123, iterations=3, duration_counter=time.monotonic)
-```
-
-The `env_vars` option from the example above specifies a list of environment
-variables to capture as `env_<variable name>`. In this example,
-the [slurm](https://slurm.schedmd.com) array task ID will be stored as
-`env_SLURM_ARRAY_TASK_ID`. Where the environment variable is not set, the
-value will be `null`.
-
-To capture package versions, you can either specify them individually (as
-above), or you can capture the versions of every package in the global
-environment. In the following example, we would capture the versions of
-`microbench`, `numpy`, and `pandas` automatically.
-
-```python
-from microbench import *
-import numpy, pandas
-
-class Bench2(MicroBench, MBGlobalPackages):
-    outfile = '/home/user/bench2'
-
-bench2 = Bench2()
-```
-
-If you want to go even further, and capture the version of every package
-available for import, there's a mixin for that:
-
-```python
-from microbench import *
-
-class Bench3(MicroBench, MBInstalledPackages):
-    pass
-
-bench3 = Bench3()
-```
-
- Mixin                 | Fields captured
------------------------|----------------
-*(default)*            | `start_time`<br>`finish_time`<br>`function_name`
-MBGlobalPackages       | `package_versions`, with entry for every package in the global environment
-MBInstalledPackages    | `package_versions`, with entry for every package available for import
-MBCondaPackages        | `conda_versions`, with entry for every conda package in the environment
-MBFunctionCall         | `args` (positional arguments)<br>`kwargs` (keyword arguments)
-MBReturnValue          | Wrapped function's return value
-MBPythonVersion        | `python_version` (e.g. 3.6.0) and `python_executable` (e.g. `/usr/bin/python`, which should indicate any active virtual environment)
-MBHostInfo             | `hostname`<br>`operating_system`
-MBHostCpuCores         | `cpu_cores_logical` and `cpu_cores_physical` (requires `psutil`)
-MBHostRamTotal         | `ram_total` (total RAM in bytes, requires `psutil`)
-MBNvidiaSmi            | Various NVIDIA GPU fields, detailed in a later section
-MBLineProfiler         | `line_profiler` containing line-by-line profile (see section below)
-
-## Examine results
-
-Each result is a [JSON](https://en.wikipedia.org/wiki/JSON) object. When using
-the `outfile` option, a JSON object for each `@benchmark` call is stored on a
-separate line in the file. The output from the minimal example above for a
-single run will look similar to the following:
-
-```json
-{"start_time": "2018-08-06T10:28:24.806493+00:00", "finish_time": "2018-08-06T10:28:24.867456+00:00", "run_durations": [0.60857599999999999], "function_name": "my_function", "timestamp_tz": "UTC", "duration_counter": "perf_counter"}
-```
-
-Start and finish times are given as timestamps in ISO-8601 format, in the UTC
-timezone by default (see Timezones section of this README).
-
-Run_durations are given in seconds, captured using the `time.perf_counter`
-function by default, but this can be overridden (see Duration timings section
-of this README).
-
-The simplest way to examine results in detail is to load them into a
-[pandas](https://pandas.pydata.org/) dataframe:
-
-```python
-# Read results directly from active benchmark suite
-benchmark.get_results()
-
-# Or, equivalently when using a file, read it using pandas directly
-import pandas
-results = pandas.read_json('/home/user/my-benchmarks', lines=True)
-```
-
-Pandas has powerful data manipulation capabilities. For example, to calculate
-the average runtime by Python version:
-
-```python
-# Calculate overall runtime
-results['runtime'] = results['finish_time'] - results['start_time']
-
-# Average overall runtime by Python version
-results.groupby('python_version')['runtime'].mean()
-```
-
-Many more advanced operations are available. The
-[pandas tutorial](https://pandas.pydata.org/pandas-docs/stable/tutorials.html)
-is recommended.
-
-## Line profiler support
-
-Microbench also has support for [line_profiler](https://github.com/rkern/line_profiler), which shows the execution time
-of each line of Python code. Note that this will slow down your code, so only use it if needed, but it's useful for
-discovering bottlenecks within a function. Requires the `line_profiler` package to be installed
-(e.g. `pip install line_profiler`).
-
-> **Security note:** Line profiler results are stored using Python's `pickle`
-> format (base64-encoded). `MBLineProfiler.decode_line_profile()` uses
-> `pickle.loads`, which can execute arbitrary code. Only decode line profiler
-> results from trusted sources (e.g. your own benchmark output files).
-
-```python
-from microbench import MicroBench, MBLineProfiler
-import pandas
-
-# Create our benchmark suite using the MBLineProfiler mixin
-class LineProfilerBench(MicroBench, MBLineProfiler):
-    pass
-
-lpbench = LineProfilerBench()
-
-# Decorate our function with the benchmark suite
-@lpbench
-def my_function():
-    """ Inefficient function for line profiler """
-    acc = 0
-    for i in range(1000000):
-        acc += i
-
-    return acc
-
-# Call the function as normal
-my_function()
-
-# Read the results into a Pandas DataFrame
-results = lpbench.get_results()
-
-# Get the line profiler report as an object
-lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])
-
-# Print the line profiler report
-MBLineProfiler.print_line_profile(results['line_profiler'][0])
-```
-
-The last line of the previous example will print the line profiler report, showing the execution time of each line of
-code. Example:
-
-```
-Timer unit: 1e-06 s
-
-Total time: 0.476723 s
-File: /home/user/my_test.py
-Function: my_function at line 12
-
-Line #      Hits         Time  Per Hit   % Time  Line Contents
-==============================================================
-    12                                               @lpbench
-    13                                               def my_function():
-    14                                                   """ Inefficient function for line profiler """
-    15         1          2.0      2.0      0.0          acc = 0
-    16   1000001     217874.0      0.2     45.7          for i in range(1000000):
-    17   1000000     258846.0      0.3     54.3              acc += i
-    18
-    19         1          1.0      1.0      0.0          return acc
-```
-
-## NVIDIA GPU support
-
-Attributes about NVIDIA GPUs can be captured using the `MBNvidiaSmi` plugin.
-This requires the `nvidia-smi` utility to be available in the current `PATH`.
-
-By default, the `gpu_name` (model number) and `memory.total` attributes are
-captured. Extra attributes can be specified using the class or object-level
-variable `nvidia_attributes`. To see which attributes are available, run
-`nvidia-smi --help-query-gpu`.
-
-By default, all installed GPUs will be polled. To limit to a specific GPU,
-specify the `nvidia_gpus` attribute as a tuple of GPU IDs, which can be
-zero-based GPU indexes (can change between reboots, not recommended),
-GPU UUIDs, or PCI bus IDs. You can find out GPU UUIDs by running
-`nvidia-smi -L`.
-
-Here's an example specifying the optional `nvidia_attributes` and
-`nvidia_gpus` fields:
-
-```python
-from microbench import MicroBench, MBNvidiaSmi
-
-class GpuBench(MicroBench, MBNvidiaSmi):
-    outfile = '/home/user/gpu-benchmarks'
-    nvidia_attributes = ('gpu_name', 'memory.total', 'pcie.link.width.max')
-    nvidia_gpus = (0, )  # Usually better to specify GPU UUIDs here instead
-
-gpu_bench = GpuBench()
-```
-
-## Telemetry support
-
-We use the term "telemetry" to refer to metadata which is captured periodically
-during the execution of a function by a thread which runs in parallel. For
-example, this may be useful to see how memory usage changes over time.
-
-Telemetry support requires the `psutil` library.
-
-Microbench launches and cleans up the monitoring thread automatically.
-The end user only needs to define a `telemetry` static method, which accepts
-a [psutil.Process](https://psutil.readthedocs.io/en/latest/#psutil.Process)
-object and returns the telemetry data as a dictionary.
-
-The default telemetry collection interval is every 60 seconds, which can be
-customized if needed using the `telemetry_interval` class variable.
-
-A minimal example to capture memory usage every 90 seconds is shown below:
-
-```python
-from microbench import MicroBench
-
-class TelemBench(MicroBench):
-    telemetry_interval = 90
-
-    @staticmethod
-    def telemetry(process):
-        return process.memory_full_info()._asdict()
-
-telem_bench = TelemBench()
-```
-
-## Extending microbench
-
-Microbench includes a few mixins for basic functionality as described in the
-extended example, above.
-
-You can also add functions to your benchmark suite to capture
-extra information at runtime. These functions must be prefixed with `capture_`
-for them to run automatically before the function starts, or `capturepost_`
-for them to run automatically when the function completes. They take
-a single argument, `bm_data`, a dictionary to be extended with extra data.
-Care should be taken to avoid overwriting existing key names.
-
-Here's an example to capture the machine type (`i386`, `x86_64` etc.):
-
-```python
-from microbench import MicroBench
-import platform
-
-class Bench(MicroBench):
-    outfile = '/home/user/my-benchmarks'
-
-    def capture_machine_platform(self, bm_data):
-        bm_data['platform'] = platform.machine()
-
-benchmark = Bench()
-```
-
-## Extending JSONEncoder
-
-Microbench encodes data in JSON, but sometimes Microbench will
-encounter data types (like custom objects or classes)
-that are not encodable as JSON by default (usually meaning they
-don't have a way to be represented as a string, list, or
-dictionary). For example, when using the `MBFunctionCall` and
-`MBReturnValue`, a warning will be shown if any argument or
-return value (respectively) is not encodable as JSON, and the
-value will be replaced with a placeholder to allow the metadata
-capture to continue, and a warning will be shown.
-
-If you wish to actually capture those values, you will need to
-specify a way to convert the object to JSON. This is done using
-by extending `microbench.JSONEncoder` with a test for the object
-type and implementing a conversion to a string, list, or dict.
-
-For example, to capture a `Graph` object from the `igraph`
-package using `str(graph)` as the representation, we could
-do the following (note that we could use any representation
-we want, e.g. if we wanted to capture the object in a more
-or less detailed way):
-
-```
-import microbench as mb
-from igraph import Graph
-
-# Extend the JSONEncoder to encode Graph objects
-class CustomJSONEncoder(mb.JSONEncoder):
-    def default(self, o):
-        # Encode igraph.Graph objects as strings
-        if isinstance(o, Graph):
-            return str(o)
-
-        # Add further isinstance(o, ...) cases here
-        # if needed
-
-        # Make sure to call super() to handle
-        # default cases
-        return super().default(o)
-
-# Define your benchmark class as normal
-class Bench(mb.MicroBench, mb.MBReturnValue):
-    pass
-
-# Create a benchmark suite with the custom JSON
-# encoder from above
-bench = Bench(json_encoder=CustomJSONEncoder)
-
-# Attach the benchmark suite to our function
 @bench
-def return_a_graph():
-    return Graph(2, ((0, 1), (0, 2)))
+def my_function(n):
+    return sum(range(n))
 
-# This should now work without warnings or errors
-return_a_graph()
+my_function(1_000_000)
+results = bench.get_results()
 ```
 
-## Redis support
+Each call produces one record. `results` is a pandas DataFrame:
 
-By default, microbench appends output to a file, but output can be directed
-elsewhere, e.g. [redis](https://redis.io) - an in-memory, networked data source.
-This option is useful when a shared filesystem is not available.
-
-Redis support requires [redis-py](https://github.com/andymccurdy/redis-py).
-
-To use this feature, inherit from `MicroBenchRedis` instead of `MicroBench`,
-and specify the redis connection and key name as in the following example:
-
-```python
-from microbench import MicroBenchRedis
-
-class RedisBench(MicroBenchRedis):
-    # redis_connection contains arguments for redis.StrictClient()
-    redis_connection = {'host': 'localhost', 'port': 6379}
-    redis_key = 'microbench:mykey'
-
-benchmark = RedisBench()
+```
+   mb_run_id                             mb_version  function_name  run_durations  experiment
+0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  1.1.0      my_function    [0.049823]     baseline
 ```
 
-To retrieve results, use `get_results()` just like the base class:
+## Documentation
 
-```python
-results = benchmark.get_results()
-```
-
-## Runtime impact considerations
-
-The runtime impact varies depending on what information is captured and by platform.
-Broadly, capturing environment variables, Python package versions, and timing
-information for a function has a negligible impact. Capturing telemetry and
-invoking external programs (like `nvidia-smi` for GPU information) has a larger impact,
-although the latter is a one-off per invocation and typically less than one second.
-Telemetry capture intervals should be kept relatively infrequent (e.g., every minute
-or two, rather than every second) to avoid significant runtime impacts.
-
-### Duration timings
-
-By default, `run_durations` are given in seconds using the `time.perf_counter` function,
-which should be sufficient for most use cases. You can use any function that
-returns a float or integer number for time. Some examples would be `time.perf_counter_ns`
-if you want time in nanoseconds, or `time.monotonic` for a monotonic clock impervious
-to clock adjustments (ideal for very long-running code). Use the `duration_counter=...`
-argument when creating a benchmark suite object, as seen in the Extended examples
-section of this README, above.
-
-### Timezones
-
-Microbench captures `start_time` and `finish_time` as ISO-8601 timestamps in the
-UTC timezone by default. The timezone is also recorded in the `timestamp_tz` field
-(e.g. `"UTC"` by default).
-
-The timezone can be overridden by passing a `tz=...` argument when creating a
-benchmark suite object, where the value is a `datetime.timezone` object. This
-affects both the timestamps themselves and the `timestamp_tz` label. UTC is
-recommended when comparing results across machines in different locations.
-
-For example, to use the local machine's timezone:
-
-```python
-import datetime
-from microbench import MicroBench
-
-bench = MicroBench(tz=datetime.datetime.now().astimezone().tzinfo)
-```
+Full documentation, including a getting-started guide, mixin reference, and
+API docs, is at **https://alubbock.github.io/microbench/**.
 
 ## Feedback
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,37 @@
+# API reference
+
+## Core
+
+::: microbench.MicroBench
+
+::: microbench.MicroBenchRedis
+
+## Mixins
+
+::: microbench.MBFunctionCall
+
+::: microbench.MBReturnValue
+
+::: microbench.MBPythonVersion
+
+::: microbench.MBHostInfo
+
+::: microbench.MBHostCpuCores
+
+::: microbench.MBHostRamTotal
+
+::: microbench.MBGlobalPackages
+
+::: microbench.MBInstalledPackages
+
+::: microbench.MBCondaPackages
+
+::: microbench.MBNvidiaSmi
+
+::: microbench.MBLineProfiler
+
+## JSON encoding
+
+::: microbench.JSONEncoder
+
+::: microbench.JSONEncodeWarning

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,123 @@
+# Getting started
+
+## Minimal example
+
+Create a benchmark suite, attach it to a function as a decorator, then call
+the function as normal:
+
+```python
+from microbench import MicroBench
+
+bench = MicroBench()
+
+@bench
+def my_function(x):
+    return x ** 2
+
+my_function(42)
+```
+
+By default results are captured into an in-memory buffer. Read them back as
+a pandas DataFrame:
+
+```python
+results = bench.get_results()
+```
+
+Every record contains these fields automatically:
+
+| Field | Description |
+|---|---|
+| `mb_run_id` | UUID generated once when `microbench` is imported. Identical across all bench suites in the same process — use `groupby('mb_run_id')` to correlate records from independent suites. |
+| `mb_version` | Version of the `microbench` package that produced the record. |
+| `start_time` | ISO-8601 timestamp when the function was called (UTC by default). |
+| `finish_time` | ISO-8601 timestamp when the function returned. |
+| `run_durations` | List of per-iteration durations in seconds. |
+| `function_name` | Name of the decorated function. |
+| `timestamp_tz` | Timezone used for `start_time`/`finish_time`. |
+| `duration_counter` | Name of the timer function used for `run_durations`. |
+
+## Extended example
+
+Subclass `MicroBench` when you want to add [mixins](user-guide/mixins.md)
+or set reusable configuration. Pass keyword arguments to the constructor to
+attach experiment metadata to every record:
+
+```python
+from microbench import MicroBench, MBFunctionCall, MBPythonVersion, MBHostInfo
+import numpy, pandas, time
+
+class MyBench(MicroBench, MBFunctionCall, MBPythonVersion, MBHostInfo):
+    outfile = '/home/user/my-benchmarks.jsonl'
+    capture_versions = (numpy, pandas)
+    env_vars = ('SLURM_ARRAY_TASK_ID',)
+
+benchmark = MyBench(experiment='run-1', iterations=3,
+                    duration_counter=time.monotonic)
+```
+
+- `outfile` saves results to a file (one JSON object per line).
+- `capture_versions` records the versions of specified packages.
+- `env_vars` captures environment variables as `env_<NAME>` fields — see [Environment variables](user-guide/configuration.md#environment-variables) for a SLURM example.
+- `iterations=3` runs the function three times, recording all three durations.
+- `duration_counter` overrides the timer (see [Configuration](user-guide/configuration.md)).
+- `experiment='run-1'` adds a custom `experiment` field to every record.
+
+!!! tip "Class attributes vs constructor arguments"
+    **Class attributes** configure microbench's own behaviour — `outfile`,
+    `capture_versions`, `env_vars`, mixin-specific settings like
+    `nvidia_attributes`. They are shared across all instances of the class.
+
+    **Constructor keyword arguments** attach experiment metadata to every
+    record — use them for labels like `experiment=`, `trial=`, `node=`.
+    They are stored verbatim in each JSON record.
+
+    If you don't need mixins, skip the class entirely:
+
+    ```python
+    bench = MicroBench(outfile='/home/user/results.jsonl')
+    ```
+
+## Saving results to a file
+
+Pass `outfile` as a constructor argument or set it as a class attribute:
+
+```python
+bench = MicroBench(outfile='/home/user/results.jsonl')
+```
+
+Results are appended in [JSONL](https://jsonlines.org/) format (one JSON
+object per line). Read them back with pandas:
+
+```python
+import pandas
+results = pandas.read_json('/home/user/results.jsonl', lines=True)
+```
+
+Or via `get_results()`, which works regardless of the output sink:
+
+```python
+results = bench.get_results()
+```
+
+## Analysing results
+
+Load results into a pandas DataFrame and use its full range of aggregation
+and filtering capabilities:
+
+```python
+import pandas
+
+results = pandas.read_json('/home/user/my-benchmarks.jsonl', lines=True)
+
+# Total elapsed time per call
+results['elapsed'] = results['finish_time'] - results['start_time']
+
+# Average runtime by Python version
+results.groupby('python_version')['elapsed'].mean()
+
+# Correlate all records from the same process run
+results.groupby('mb_run_id')['elapsed'].describe()
+```
+
+See the [pandas documentation](https://pandas.pydata.org/docs/) for more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+# microbench
+
+![Microbench: Benchmarking and reproducibility metadata capture for Python](https://raw.githubusercontent.com/alubbock/microbench/master/microbench.png)
+
+Microbench is a small Python package for benchmarking Python functions and
+capturing reproducibility metadata. It is most useful in clustered and
+distributed environments where the same function runs across different
+machines, and is designed to be extended with new functionality through
+mixins.
+
+## Key features
+
+- **Zero-config timing** — decorate a function and get start/finish timestamps and run durations immediately, with no setup
+- **Extensible via mixins** — mix in exactly what you need: Python version, hostname, CPU/RAM specs, conda/pip packages, NVIDIA GPU info, line-level profiling, and more
+- **Cluster and HPC ready** — capture SLURM environment variables, psutil resource metrics, and run IDs for correlating results across nodes
+- **JSONL output** — one JSON object per call; load directly into pandas with `read_json(..., lines=True)`; no schema lock-in
+- **Automatic run correlation** — `mb_run_id` is a UUID generated once per process; all bench suites in the same run share it, enabling `groupby('mb_run_id')` across independent suites
+- **Flexible output** — write to a local file, an in-memory buffer, or Redis; concurrent writers safe via `O_APPEND`
+
+## Installation
+
+```
+pip install microbench
+```
+
+## Requirements
+
+Microbench has no required dependencies outside the Python standard library.
+[pandas](https://pandas.pydata.org/) is recommended for analysing results.
+Some mixins have optional requirements:
+
+| Mixin / feature | Requires |
+|---|---|
+| `MBHostCpuCores`, `MBHostRamTotal`, telemetry | [psutil](https://pypi.org/project/psutil/) |
+| `MBLineProfiler` | [line_profiler](https://github.com/rkern/line_profiler) |
+| `MBNvidiaSmi` | `nvidia-smi` on `PATH` (ships with NVIDIA drivers) |
+| `MBCondaPackages` | `conda` on `PATH` |
+| `MicroBenchRedis` | [redis-py](https://github.com/andymccurdy/redis-py) |
+
+## Quick example
+
+```python
+from microbench import MicroBench
+
+bench = MicroBench(outfile='/home/user/results.jsonl', experiment='baseline')
+
+@bench
+def my_function(n):
+    return sum(range(n))
+
+my_function(1_000_000)
+
+results = bench.get_results()
+```
+
+Each call produces one record. `results` is a pandas DataFrame:
+
+```
+   mb_run_id                             mb_version  function_name  run_durations  experiment
+0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  1.1.0      my_function    [0.049823]     baseline
+```
+
+The underlying JSON for a single record looks like:
+
+```json
+{
+  "mb_run_id": "3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9",
+  "mb_version": "1.1.0",
+  "start_time": "2024-01-15T10:30:00.123456+00:00",
+  "finish_time": "2024-01-15T10:30:00.172279+00:00",
+  "run_durations": [0.049823],
+  "function_name": "my_function",
+  "timestamp_tz": "UTC",
+  "duration_counter": "perf_counter",
+  "experiment": "baseline"
+}
+```
+
+See [Getting started](getting-started.md) for a full walkthrough.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,20 @@
+/* Match the deep maroon from the microbench logo (#690900) */
+:root,
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #690900;
+  --md-primary-fg-color--light: #8a1200;
+  --md-primary-fg-color--dark: #4a0700;
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
+  --md-accent-fg-color: #690900;
+  --md-accent-fg-color--transparent: rgba(105, 9, 0, 0.1);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #8a1200;
+  --md-primary-fg-color--light: #a81800;
+  --md-primary-fg-color--dark: #690900;
+  --md-accent-fg-color: #c94a3a;
+  --md-accent-fg-color--transparent: rgba(201, 74, 58, 0.1);
+  --md-typeset-a-color: #c94a3a;
+}

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,0 +1,109 @@
+# Configuration
+
+## Constructor parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `outfile` | `None` | File path or file-like object to write results to. |
+| `json_encoder` | `JSONEncoder` | Custom JSON encoder class. |
+| `tz` | `timezone.utc` | Timezone for `start_time` / `finish_time`. |
+| `iterations` | `1` | Number of times to run the decorated function. |
+| `duration_counter` | `time.perf_counter` | Callable used for `run_durations`. |
+
+Any additional keyword arguments are stored as extra fields in every record:
+
+```python
+bench = MicroBench(experiment='run-42', node='gpu-node-03')
+```
+
+## Environment variables
+
+Set `env_vars` as a class attribute to capture specific environment
+variables into every record. Each variable is stored as `env_<NAME>`; if
+the variable is unset it is recorded as `null`:
+
+```python
+from microbench import MicroBench
+
+class MyBench(MicroBench):
+    env_vars = ('MY_VAR', 'ANOTHER_VAR')
+```
+
+### HPC / SLURM
+
+In SLURM environments, capture job and task identifiers automatically:
+
+```python
+class SlurmBench(MicroBench):
+    env_vars = (
+        'SLURM_JOB_ID',
+        'SLURM_ARRAY_TASK_ID',
+        'SLURM_NODELIST',
+        'SLURM_CPUS_PER_TASK',
+    )
+```
+
+Fields are stored as `env_SLURM_JOB_ID`, `env_SLURM_ARRAY_TASK_ID`, etc.
+Combined with `mb_run_id`, this lets you group and compare results across
+all tasks in a job array:
+
+```python
+results.groupby(['mb_run_id', 'env_SLURM_ARRAY_TASK_ID'])['run_durations'].mean()
+```
+
+Run `env | grep SLURM` inside a job to see which variables are available
+in your cluster's environment.
+
+## Duration timings
+
+`run_durations` are measured using `time.perf_counter` by default, which
+gives wall-clock time in fractional seconds. Override with any callable that
+returns a numeric value:
+
+```python
+import time
+from microbench import MicroBench
+
+# Nanosecond precision
+bench = MicroBench(duration_counter=time.perf_counter_ns)
+
+# Monotonic clock (unaffected by NTP adjustments)
+bench = MicroBench(duration_counter=time.monotonic)
+```
+
+The name of the counter function is recorded in the `duration_counter` field
+so results remain interpretable after the code changes.
+
+When `iterations > 1`, `run_durations` is a list with one entry per
+iteration. The function's return value is always taken from the final
+iteration.
+
+## Timezones
+
+`start_time` and `finish_time` are ISO-8601 timestamps in UTC by default.
+Override with any `datetime.timezone`:
+
+```python
+import datetime
+from microbench import MicroBench
+
+# Local machine timezone
+bench = MicroBench(tz=datetime.datetime.now().astimezone().tzinfo)
+```
+
+UTC is recommended when comparing results across machines in different
+locations. The timezone is also recorded in the `timestamp_tz` field.
+
+## Runtime impact
+
+Capturing environment variables, package versions, and timing has negligible
+overhead. Things with measurable cost:
+
+- **`MBNvidiaSmi`** — spawns a subprocess per invocation; typically < 1 s.
+- **`MBInstalledPackages` / `MBCondaPackages`** — enumerates all installed
+  packages; can take several seconds on large environments. Consider running
+  once and storing the output separately rather than capturing on every call.
+- **Periodic telemetry** — background thread with configurable interval.
+  Keep `telemetry_interval` at 60 s or more to avoid meaningful overhead.
+- **`MBLineProfiler`** — instruments every line; expect 2–5× slowdown on
+  typical Python code. Only use for profiling runs, not production timing.

--- a/docs/user-guide/extending.md
+++ b/docs/user-guide/extending.md
@@ -1,0 +1,78 @@
+# Extending microbench
+
+## Custom capture methods
+
+Add methods prefixed with `capture_` to run before the function starts, or
+`capturepost_` to run after it returns. Each receives `bm_data`, the
+dictionary that will be serialised as the result record.
+
+```python
+from microbench import MicroBench
+import platform
+
+class MyBench(MicroBench):
+    def capture_machine_type(self, bm_data):
+        bm_data['machine'] = platform.machine()  # e.g. 'x86_64'
+
+    def capturepost_slow_call(self, bm_data):
+        # run_durations and finish_time are available in capturepost_ methods
+        if sum(bm_data['run_durations']) > 1.0:
+            bm_data['slow_call'] = True
+```
+
+Avoid key names that clash with built-in fields (e.g. `start_time`,
+`function_name`). The `mb_` prefix is reserved for microbench internals.
+
+## Custom JSON encoding
+
+Microbench serialises records as JSON. If a captured value is not
+JSON-serialisable (e.g. a custom object), microbench replaces it with a
+placeholder and emits a `JSONEncodeWarning`.
+
+To handle custom types, subclass `JSONEncoder`:
+
+```python
+import microbench as mb
+from igraph import Graph
+
+class MyEncoder(mb.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, Graph):
+            return str(o)
+        return super().default(o)
+
+class MyBench(mb.MicroBench, mb.MBReturnValue):
+    pass
+
+bench = MyBench(json_encoder=MyEncoder)
+
+@bench
+def make_graph():
+    return Graph(2, ((0, 1), (0, 2)))
+
+make_graph()  # no warning
+```
+
+`JSONEncoder` already handles `datetime`, `timedelta`, `timezone`, and
+numpy scalar/array types by default.
+
+## Writing a mixin
+
+A mixin is simply a class with one or more `capture_` or `capturepost_`
+methods. Define it as a standalone class, then include it in benchmark suite
+definitions via multiple inheritance:
+
+```python
+class MBMachineType:
+    """Capture the machine architecture (e.g. x86_64, arm64)."""
+
+    def capture_machine_type(self, bm_data):
+        import platform
+        bm_data['machine_type'] = platform.machine()
+
+
+class MyBench(MicroBench, MBMachineType, MBPythonVersion):
+    pass
+```
+
+Mixins have no required base class — they rely entirely on Python's MRO.

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -1,0 +1,190 @@
+# Mixins
+
+Mixins are classes that add metadata capture to a benchmark suite via
+multiple inheritance. Combine any number of mixins with `MicroBench`:
+
+```python
+from microbench import MicroBench, MBPythonVersion, MBHostInfo, MBHostCpuCores
+
+class MyBench(MicroBench, MBPythonVersion, MBHostInfo, MBHostCpuCores):
+    pass
+```
+
+Python resolves method calls across multiple base classes using the **Method
+Resolution Order (MRO)** — a deterministic left-to-right search that ensures
+each class in the hierarchy is visited exactly once. This means you can
+combine any number of microbench mixins without conflicts, and their
+`capture_*` methods will all be called.
+
+## Reference
+
+| Mixin | Fields captured | Extra requirements |
+|---|---|---|
+| *(none)* | `mb_run_id`, `mb_version`, `start_time`, `finish_time`, `run_durations`, `function_name`, `timestamp_tz`, `duration_counter` | — |
+| `MBFunctionCall` | `args`, `kwargs` | — |
+| `MBReturnValue` | `return_value` | — |
+| `MBPythonVersion` | `python_version`, `python_executable` | — |
+| `MBHostInfo` | `hostname`, `operating_system` | — |
+| `MBHostCpuCores` | `cpu_cores_logical`, `cpu_cores_physical` | psutil |
+| `MBHostRamTotal` | `ram_total` (bytes) | psutil |
+| `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
+| `MBInstalledPackages` | `package_versions` for every installed package | — |
+| `MBCondaPackages` | `conda_versions` for every package in the active conda environment | `conda` on PATH |
+| `MBNvidiaSmi` | `nvidia_<attr>` per GPU (see below) | `nvidia-smi` on PATH |
+| `MBLineProfiler` | `line_profiler` (base64-encoded profile, see below) | line_profiler |
+
+## Function calls and return values
+
+### `MBFunctionCall`
+
+Captures the positional and keyword arguments passed to the decorated
+function as `args` (list) and `kwargs` (dict):
+
+```python
+from microbench import MicroBench, MBFunctionCall
+
+class Bench(MicroBench, MBFunctionCall):
+    pass
+
+bench = Bench()
+
+@bench
+def add(a, b):
+    return a + b
+
+add(1, b=2)
+# record contains: {"args": [1], "kwargs": {"b": 2}, ...}
+```
+
+### `MBReturnValue`
+
+Captures the return value of the decorated function as `return_value`:
+
+```python
+from microbench import MicroBench, MBReturnValue
+
+class Bench(MicroBench, MBReturnValue):
+    pass
+
+bench = Bench()
+
+@bench
+def compute(n):
+    return sum(range(n))
+
+compute(100)
+# record contains: {"return_value": 4950, ...}
+```
+
+The return value must be JSON-serialisable. If it is not, a
+`JSONEncodeWarning` is issued and a placeholder is stored. See
+[Custom JSON encoding](extending.md#custom-json-encoding) to handle
+custom types.
+
+## Package versions
+
+### `MBGlobalPackages`
+
+Captures the version of every module imported in the caller's global
+namespace:
+
+```python
+from microbench import MicroBench, MBGlobalPackages
+import numpy, pandas
+
+class Bench(MicroBench, MBGlobalPackages):
+    pass
+```
+
+The `package_versions` field will contain `{"numpy": "1.26.0", "pandas": "2.1.0", ...}`.
+
+### `MBInstalledPackages`
+
+Captures every package available for import (from `importlib.metadata`).
+Useful for full reproducibility audits. Can be slow on environments with
+many packages.
+
+Set `capture_paths = True` to also record installation paths:
+
+```python
+class Bench(MicroBench, MBInstalledPackages):
+    capture_paths = True
+```
+
+### `MBCondaPackages`
+
+Captures all packages in the active conda environment using the `conda` CLI.
+
+```python
+class Bench(MicroBench, MBCondaPackages):
+    include_builds = True    # include build string (default: True)
+    include_channels = False  # include channel name (default: False)
+```
+
+### `capture_versions`
+
+To capture specific package versions without a mixin, list them on the
+class:
+
+```python
+import numpy, pandas
+
+class Bench(MicroBench):
+    capture_versions = (numpy, pandas)
+```
+
+## NVIDIA GPU — `MBNvidiaSmi`
+
+Captures attributes for each installed GPU via `nvidia-smi`.
+
+By default captures `gpu_name` and `memory.total`. Customise with
+`nvidia_attributes`:
+
+```python
+from microbench import MicroBench, MBNvidiaSmi
+
+class GpuBench(MicroBench, MBNvidiaSmi):
+    nvidia_attributes = ('gpu_name', 'memory.total', 'pcie.link.width.max')
+    nvidia_gpus = ('GPU-abc123',)  # UUIDs preferred; omit to capture all
+```
+
+Results are stored as `nvidia_<attr>` dicts keyed by GPU UUID, e.g.
+`nvidia_gpu_name: {"GPU-abc123": "NVIDIA A100"}`.
+
+Run `nvidia-smi --help-query-gpu` for the full list of available attributes.
+Run `nvidia-smi -L` to list GPU UUIDs.
+
+## Line profiler — `MBLineProfiler`
+
+Captures a line-by-line timing profile of the decorated function using
+[line_profiler](https://github.com/rkern/line_profiler).
+
+```python
+from microbench import MicroBench, MBLineProfiler
+
+class Bench(MicroBench, MBLineProfiler):
+    pass
+
+bench = Bench()
+
+@bench
+def my_function():
+    acc = 0
+    for i in range(1000000):
+        acc += i
+    return acc
+
+my_function()
+
+results = bench.get_results()
+MBLineProfiler.print_line_profile(results['line_profiler'][0])
+```
+
+The profile is stored as a base64-encoded pickle in the `line_profiler` field.
+Use `MBLineProfiler.decode_line_profile()` to deserialise it, or
+`MBLineProfiler.print_line_profile()` to print it directly.
+
+!!! warning "Security"
+    `decode_line_profile()` uses `pickle.loads`. Only decode profiles from
+    trusted sources (your own benchmark output). Never decode data received
+    over a network or from an untrusted file.

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -1,0 +1,80 @@
+# Periodic telemetry
+
+!!! note "Renamed in v2"
+    In v2.0, `telemetry` is renamed to `monitor` throughout the API
+    (`telemetry_interval` → `monitor_interval`, `telemetry_timeout` →
+    `monitor_timeout`, result field `telemetry` → `monitor`).
+    The v1.x names documented here continue to work in v1.x releases.
+
+Microbench can sample resource usage in a background thread throughout the
+execution of a benchmarked function. This is useful for tracking how memory
+or CPU usage changes over time during a long-running computation.
+
+Requires [psutil](https://pypi.org/project/psutil/).
+
+## Basic setup
+
+Define a `telemetry` static method on your benchmark class. It receives a
+[`psutil.Process`](https://psutil.readthedocs.io/en/latest/#psutil.Process)
+object and should return a dictionary of sample data. Microbench handles
+launching and cleaning up the background thread automatically.
+
+```python
+from microbench import MicroBench
+
+class MyBench(MicroBench):
+    telemetry_interval = 90  # seconds between samples (default: 60)
+
+    @staticmethod
+    def telemetry(process):
+        mem = process.memory_full_info()
+        return {'rss': mem.rss, 'vms': mem.vms}
+
+bench = MyBench()
+
+@bench
+def my_function():
+    # ... long-running work ...
+    pass
+```
+
+Samples are stored as a list in the `telemetry` field of each result record,
+each entry including a `timestamp` and whatever your `telemetry` method
+returns:
+
+```json
+{
+  "telemetry": [
+    {"timestamp": "2024-01-01T00:00:00+00:00", "rss": 104857600, "vms": 536870912},
+    {"timestamp": "2024-01-01T00:01:30+00:00", "rss": 209715200, "vms": 536870912}
+  ]
+}
+```
+
+## Configuration
+
+| Class variable | Default | Description |
+|---|---|---|
+| `telemetry_interval` | `60` | Seconds between samples |
+| `telemetry_timeout` | `30` | Seconds to wait for the telemetry thread to stop cleanly |
+
+## Sampling all available process info
+
+```python
+class MyBench(MicroBench):
+    @staticmethod
+    def telemetry(process):
+        return process.as_dict(attrs=[
+            'cpu_percent', 'memory_info', 'num_threads'
+        ])
+```
+
+## Notes
+
+- The telemetry thread takes an initial sample immediately when the function
+  starts, then repeats at `telemetry_interval` seconds.
+- Signal handlers (`SIGINT`/`SIGTERM`) are registered to stop the thread
+  cleanly. If the benchmark is started from a non-main thread, a
+  `RuntimeWarning` is issued and signal handlers are skipped.
+- Telemetry results are stored with the record regardless of whether the
+  function raises an exception.

--- a/docs/user-guide/output.md
+++ b/docs/user-guide/output.md
@@ -1,0 +1,83 @@
+# Output
+
+## Saving to a file
+
+Pass `outfile` as a constructor argument or set it as a class attribute:
+
+```python
+from microbench import MicroBench
+
+# As a constructor argument
+bench = MicroBench(outfile='/home/user/results.jsonl')
+
+# Or as a class attribute
+class MyBench(MicroBench):
+    outfile = '/home/user/results.jsonl'
+```
+
+Results are written in [JSONL](https://jsonlines.org/) format (one JSON
+object per line). When `outfile` is a path string, each write opens the
+file with `O_APPEND`, which guarantees atomic appends on POSIX filesystems.
+Multiple processes can safely write to the same file simultaneously — a
+common pattern when running benchmark jobs across cluster nodes.
+
+Read results back with pandas:
+
+```python
+import pandas
+results = pandas.read_json('/home/user/results.jsonl', lines=True)
+```
+
+Or via `get_results()`:
+
+```python
+results = bench.get_results()
+```
+
+## In-memory buffer
+
+If no `outfile` is specified, results are written to an in-memory
+`io.StringIO` buffer. This is the default and is useful for interactive
+sessions or testing:
+
+```python
+bench = MicroBench()
+
+@bench
+def my_function():
+    pass
+
+my_function()
+
+results = bench.get_results()
+```
+
+## Redis output
+
+[Redis](https://redis.io) is useful when a shared filesystem is not
+available, such as on cloud or HPC clusters. Requires
+[redis-py](https://github.com/andymccurdy/redis-py).
+
+Inherit from `MicroBenchRedis` and set `redis_connection` and `redis_key`
+as class attributes:
+
+```python
+from microbench import MicroBenchRedis
+
+class RedisBench(MicroBenchRedis):
+    redis_connection = {'host': 'redis-host', 'port': 6379}
+    redis_key = 'microbench:mykey'
+
+bench = RedisBench()
+
+@bench
+def my_function():
+    pass
+
+my_function()
+
+results = bench.get_results()
+```
+
+Results are appended to a Redis list using `RPUSH` and read back with
+`LRANGE`.

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -408,7 +408,17 @@ class MBGlobalPackages:
 
 
 class MBCondaPackages:
-    """Capture conda packages using the conda CLI"""
+    """Capture conda packages using the conda CLI.
+
+    Requires ``conda`` to be available on ``PATH``. Captures all packages
+    in the active conda environment (determined by ``sys.prefix``).
+
+    Attributes:
+        include_builds (bool): Include the build string in the version.
+            Defaults to ``True``.
+        include_channels (bool): Include the channel name in the version.
+            Defaults to ``False``.
+    """
 
     include_builds = True
     include_channels = False
@@ -434,7 +444,15 @@ class MBCondaPackages:
 
 
 class MBInstalledPackages:
-    """Capture installed Python packages using importlib"""
+    """Capture installed Python packages using importlib.
+
+    Records the name and version of every distribution available in the
+    current Python environment via ``importlib.metadata``.
+
+    Attributes:
+        capture_paths (bool): Also record the installation path of each
+            package under ``package_paths``. Defaults to ``False``.
+    """
 
     capture_paths = False
 
@@ -508,21 +526,21 @@ class MBHostRamTotal(_NeedsPsUtil):
 
 
 class MBNvidiaSmi:
-    """
-    Capture attributes on installed NVIDIA GPUs using nvidia-smi
+    """Capture attributes on installed NVIDIA GPUs using nvidia-smi.
 
-    Requires the nvidia-smi utility to be available in the current PATH.
+    Requires the ``nvidia-smi`` utility to be available on ``PATH``
+    (bundled with NVIDIA drivers).
 
-    By default, the gpu_name and memory.total attributes are captured.
-    Any attribute supported by ``nvidia-smi --query-gpu`` can be
-    specified using the class or object-level variable
-    nvidia_attributes (run ``nvidia-smi --help-query-gpu`` for the
-    full list).
+    Results are stored as ``nvidia_<attr>`` fields, each a dict keyed by
+    GPU UUID. Run ``nvidia-smi --help-query-gpu`` for all available
+    attribute names. Run ``nvidia-smi -L`` to list GPU UUIDs.
 
-    By default, all installed GPUs will be polled. To limit to a specific GPU,
-    specify the nvidia_gpus attribute as a tuple of GPU IDs, which can be
-    zero-based GPU indexes (can change between reboots, not recommended),
-    GPU UUIDs, or PCI bus IDs.
+    Attributes:
+        nvidia_attributes (tuple[str]): Attributes to query. Defaults to
+            ``('gpu_name', 'memory.total')``.
+        nvidia_gpus (tuple): GPU IDs to poll — zero-based indexes, UUIDs,
+            or PCI bus IDs. GPU UUIDs are recommended (indexes can change
+            after a reboot). Omit to poll all installed GPUs.
     """
 
     _nvidia_default_attributes = ('gpu_name', 'memory.total')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,73 @@
+site_name: microbench
+site_description: Micro-benchmarking and reproducibility metadata capture for Python
+site_url: https://alubbock.github.io/microbench/
+repo_url: https://github.com/alubbock/microbench
+repo_name: alubbock/microbench
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - toc.follow
+    - content.code.copy
+
+markdown_extensions:
+  - pymdownx.snippets
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - admonition
+  - tables
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_if_no_docstring: false
+            show_attribute_values: true
+            filters:
+              - "!^_"
+  - mike:
+      alias_type: symlink
+      canonical_version: latest
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  version:
+    provider: mike
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - User guide:
+    - Mixins: user-guide/mixins.md
+    - Output: user-guide/output.md
+    - Periodic telemetry: user-guide/monitoring.md
+    - Extending microbench: user-guide/extending.md
+    - Configuration: user-guide/configuration.md
+  - API reference: api-reference.md
+  - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ Homepage = "https://github.com/alubbock/microbench"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "pandas", "numpy", "line_profiler", "psutil"]
+docs = ["mkdocs-material", "mkdocstrings[python]", "mike", "pymdown-extensions"]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

- Adds a full MkDocs Material documentation site with versioning via `mike` and auto-deployment via GitHub Actions
- User guide covers mixins, output, periodic telemetry (v1.x terminology), extending microbench, and configuration
- API reference rendered from docstrings using `mkdocstrings[python]`
- Colour scheme matches the microbench logo (#690900 maroon, via primary: custom)
- README updated with key features section and concise quick start with example output

## Key documentation decisions

- v1.x terminology throughout: telemetry / telemetry_interval / telemetry_timeout; admonition notes the v2.0 rename to monitor
- Config principle documented: class attributes = MB infrastructure config (outfile, capture_versions, env_vars); constructor kwargs = experiment metadata (experiment=, trial=)
- Simpler path emphasised: bench = MicroBench(outfile=..., experiment=...) shown as the primary example; subclassing only introduced when mixins are needed

## Notable fixes found during review

- capturepost_ example in extending.md incorrectly claimed bm_data['_result'] exists — corrected to a real example using run_durations
- MBFunctionCall and MBReturnValue had no usage examples — added
- O_APPEND guarantee documented explicitly in output.md
- SLURM / HPC env_vars section added to configuration.md with groupby usage pattern

## Test plan

- [x] Enable GitHub Pages on the repository (Settings -> Pages -> deploy from gh-pages branch) — required once before the Actions workflow can publish
- [ ] Merge this PR, then run mike deploy --push --update-aliases 1.1 latest locally (or trigger via a tag) to publish the versioned docs
- [ ] Verify the live site renders correctly at https://alubbock.github.io/microbench/