### PR TITLE
feat: add warmup=N parameter to MicroBench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`warmup` parameter**: pass `warmup=N` to run the function `N` times
+  before timing begins, priming caches or JIT compilation without affecting
+  results. Warmup calls are unrecorded and do not interact with the monitor
+  thread or capture triggers.
+
 - **Multi-sink output architecture** (#52): Results can now be written to
   multiple destinations simultaneously by passing an `outputs` list to
   `MicroBench`. Three classes make up the new output API:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,6 +8,7 @@
 | `json_encoder` | `JSONEncoder` | Custom JSON encoder class. |
 | `tz` | `timezone.utc` | Timezone for `start_time` / `finish_time`. |
 | `iterations` | `1` | Number of times to run the decorated function. |
+| `warmup` | `0` | Number of unrecorded calls before timing begins. Useful for priming caches or JIT compilation. |
 | `duration_counter` | `time.perf_counter` | Callable used for `run_durations`. |
 
 Any additional keyword arguments are stored as extra fields in every record:

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -214,6 +214,7 @@ class MicroBench:
         json_encoder=JSONEncoder,
         tz=timezone.utc,
         iterations=1,
+        warmup=0,
         duration_counter=time.perf_counter,
         outputs=None,
         *args,
@@ -232,6 +233,9 @@ class MicroBench:
                 Defaults to timezone.utc.
             iterations (int, optional): Number of iterations to run function.
                 Defaults to 1.
+            warmup (int, optional): Number of unrecorded calls to make before
+                timing begins. Useful for priming caches or JIT compilation.
+                Defaults to 0.
             duration_counter (callable, optional): Timer function to use for
                 run_durations. Defaults to time.perf_counter.
             outputs (list of Output, optional): One or more :class:`Output`
@@ -258,6 +262,7 @@ class MicroBench:
         self._duration_counter = duration_counter
         self.tz = tz
         self.iterations = iterations
+        self.warmup = warmup
 
         if outputs is not None:
             self._outputs = list(outputs)
@@ -388,6 +393,9 @@ class MicroBench:
                         'This functionality requires the "line_profiler" package'
                     )
                 self._line_profiler = line_profiler.LineProfiler(func)
+
+            for _ in range(self.warmup):
+                func(*args, **kwargs)
 
             self.pre_start_triggers(bm_data)
 

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -87,6 +87,27 @@ def test_multi_iterations():
     assert all(dur >= 0 for dur in results['run_durations'][0])
 
 
+def test_warmup():
+    call_count = 0
+
+    bench = MicroBench(warmup=3, iterations=2)
+
+    @bench
+    def my_function():
+        nonlocal call_count
+        call_count += 1
+
+    my_function()
+
+    # 3 warmup + 2 recorded iterations = 5 total calls
+    assert call_count == 5
+
+    results = bench.get_results()
+    # Only one record (one decorated call), with 2 run_durations
+    assert len(results) == 1
+    assert len(results['run_durations'][0]) == 2
+
+
 def test_local_timezone():
     """Verify README example syntax: tz=datetime.datetime.now().astimezone().tzinfo.
 
@@ -320,10 +341,10 @@ def test_positional_args_raises():
 
     The *args guard is primarily designed for subclasses that forward *args
     via super().__init__(*args, **kwargs). Triggering it directly requires
-    saturating the six named positional parameters first.
+    saturating the seven named positional parameters first.
     """
     with pytest.raises(ValueError, match='keyword'):
-        MicroBench(None, JSONEncoder, datetime.timezone.utc, 1, None, None, 'extra')
+        MicroBench(None, JSONEncoder, datetime.timezone.utc, 1, 0, None, None, 'extra')
 
 
 def test_outfile_and_outputs_raises():


### PR DESCRIPTION
## Summary

Adds a `warmup=N` constructor parameter that runs the decorated function `N` times before timing begins, without recording results. Useful for priming CPU caches or triggering JIT compilation so that the measured iterations reflect steady-state performance.

```python
bench = MicroBench(warmup=3, iterations=10)

@bench
def my_function(n):
    return sum(range(n))

my_function(1_000_000)
# 3 unrecorded warmup calls, then 10 timed iterations -> one record with 10 run_durations
```

## Implementation notes

- Warmup loop runs before `pre_start_triggers`, so the monitor thread is not active during warmup and warmup time does not appear in `start_time` or `run_durations`
- Warmup calls bypass all capture triggers and output sinks entirely
- Default is `warmup=0` (no change to existing behaviour)

## Test plan

- [x] `test_warmup` — verifies total call count (warmup + iterations) and that only one result record is produced with the correct number of `run_durations`
- [x] `test_positional_args_raises` updated for new parameter count
- [x] Full test suite passes (46 passed, 1 skipped)