### PR TITLE
feat: add MBSlurmInfo mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`MBSlurmInfo` mixin**: captures all `SLURM_*` environment variables into
+  a `slurm` dict (keys lowercased, `SLURM_` prefix stripped). Empty dict
+  when running outside a SLURM job. Supersedes the manual
+  `env_vars = ('SLURM_JOB_ID', ...)` pattern.
+
 - **`warmup` parameter**: pass `warmup=N` to run the function `N` times
   before timing begins, priming caches or JIT compilation without affecting
   results. Warmup calls are unrecorded and do not interact with the monitor

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,6 +26,8 @@
 
 ::: microbench.MBHostRamTotal
 
+::: microbench.MBSlurmInfo
+
 ::: microbench.MBGlobalPackages
 
 ::: microbench.MBInstalledPackages

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ import numpy, pandas, time
 class MyBench(MicroBench, MBFunctionCall, MBPythonVersion, MBHostInfo):
     outfile = '/home/user/my-benchmarks.jsonl'
     capture_versions = (numpy, pandas)
-    env_vars = ('SLURM_ARRAY_TASK_ID',)
+    env_vars = ('CUDA_VISIBLE_DEVICES',)
 
 benchmark = MyBench(experiment='run-1', iterations=3,
                     duration_counter=time.monotonic)
@@ -58,7 +58,7 @@ benchmark = MyBench(experiment='run-1', iterations=3,
 
 - `outfile` saves results to a file (one JSON object per line).
 - `capture_versions` records the versions of specified packages.
-- `env_vars` captures environment variables as `env_<NAME>` fields — see [Environment variables](user-guide/configuration.md#environment-variables) for a SLURM example.
+- `env_vars` captures environment variables as `env_<NAME>` fields — see [Environment variables](user-guide/configuration.md#environment-variables) for more. For SLURM jobs, use `MBSlurmInfo` instead.
 - `iterations=3` runs the function three times, recording all three durations.
 - `duration_counter` overrides the timer (see [Configuration](user-guide/configuration.md)).
 - `experiment='run-1'` adds a custom `experiment` field to every record.

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -27,6 +27,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBHostInfo` | `hostname`, `operating_system` | — |
 | `MBHostCpuCores` | `cpu_cores_logical`, `cpu_cores_physical` | psutil |
 | `MBHostRamTotal` | `ram_total` (bytes) | psutil |
+| `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `package_versions` for every installed package | — |
 | `MBCondaPackages` | `conda_versions` for every package in the active conda environment | `conda` on PATH |
@@ -80,6 +81,48 @@ The return value must be JSON-serialisable. If it is not, a
 `JSONEncodeWarning` is issued and a placeholder is stored. See
 [Custom JSON encoding](extending.md#custom-json-encoding) to handle
 custom types.
+
+## HPC / SLURM
+
+### `MBSlurmInfo`
+
+Captures all `SLURM_*` environment variables into a `slurm` dict. Keys are
+lowercased with the `SLURM_` prefix stripped, so `SLURM_JOB_ID` becomes
+`slurm['job_id']`. If the benchmark runs outside a SLURM job, `slurm` is
+an empty dict.
+
+```python
+from microbench import MicroBench, MBSlurmInfo
+
+class Bench(MicroBench, MBSlurmInfo):
+    pass
+
+bench = Bench()
+```
+
+Each record will contain:
+
+```json
+{
+  "slurm": {
+    "job_id": "12345",
+    "array_task_id": "3",
+    "nodelist": "gpu-node-[01-04]",
+    "cpus_per_task": "4"
+  }
+}
+```
+
+Access individual values in pandas with:
+
+```python
+results['slurm'].apply(lambda s: s.get('job_id'))
+```
+
+!!! tip
+    `MBSlurmInfo` supersedes the manual `env_vars = ('SLURM_JOB_ID', ...)`
+    pattern — it captures every `SLURM_*` variable automatically with no
+    configuration.
 
 ## Package versions
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     'MBHostInfo',
     'MBHostCpuCores',
     'MBHostRamTotal',
+    'MBSlurmInfo',
     'MBGlobalPackages',
     'MBInstalledPackages',
     'MBCondaPackages',
@@ -502,6 +503,31 @@ def _is_microbench_internal(filename):
     if abs_file.startswith(_microbench_tests_dir + os.sep):
         return False
     return abs_file == _microbench_dir or abs_file.startswith(_microbench_dir + os.sep)
+
+
+class MBSlurmInfo:
+    """Capture all SLURM_* environment variables.
+
+    Results are stored in the ``slurm`` field as a dict, with keys
+    lowercased and the ``SLURM_`` prefix stripped. If no SLURM environment
+    variables are set (e.g. running locally), ``slurm`` is an empty dict.
+
+    Example output::
+
+        {
+            "slurm": {
+                "job_id": "12345",
+                "array_task_id": "3",
+                "nodelist": "gpu-node-[01-04]",
+                "cpus_per_task": "4"
+            }
+        }
+    """
+
+    def capture_slurm(self, bm_data):
+        bm_data['slurm'] = {
+            k[6:].lower(): v for k, v in os.environ.items() if k.startswith('SLURM_')
+        }
 
 
 class MBGlobalPackages:

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -21,6 +21,7 @@ from microbench import (
     MBInstalledPackages,
     MBPythonVersion,
     MBReturnValue,
+    MBSlurmInfo,
     MicroBench,
     Output,
     RedisOutput,
@@ -85,6 +86,55 @@ def test_multi_iterations():
 
     assert len(results['run_durations'][0]) == iterations
     assert all(dur >= 0 for dur in results['run_durations'][0])
+
+
+def test_mb_slurm_info():
+    class Bench(MicroBench, MBSlurmInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    slurm_env = {
+        'SLURM_JOB_ID': '12345',
+        'SLURM_ARRAY_TASK_ID': '3',
+        'SLURM_NODELIST': 'gpu-node-01',
+        'NOT_SLURM': 'ignored',
+    }
+
+    with patch.dict(os.environ, slurm_env, clear=False):
+        noop()
+
+    results = bench.get_results()
+    slurm = results['slurm'][0]
+    assert slurm['job_id'] == '12345'
+    assert slurm['array_task_id'] == '3'
+    assert slurm['nodelist'] == 'gpu-node-01'
+    assert 'not_slurm' not in slurm
+
+
+def test_mb_slurm_info_empty():
+    """slurm field is an empty dict when no SLURM_* vars are set."""
+
+    class Bench(MicroBench, MBSlurmInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    # Strip any real SLURM vars that might be in the test environment
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith('SLURM_')}
+    with patch.dict(os.environ, clean_env, clear=True):
+        noop()
+
+    results = bench.get_results()
+    assert results['slurm'][0] == {}
 
 
 def test_warmup():


### PR DESCRIPTION
## Summary

Adds `MBSlurmInfo`, a zero-config mixin that captures all `SLURM_*` environment variables into a `slurm` dict. Keys are lowercased with the `SLURM_` prefix stripped. Empty dict when running outside a SLURM job.

```python
from microbench import MicroBench, MBSlurmInfo

class Bench(MicroBench, MBSlurmInfo):
    pass
```

Record output:

```json
{
  "slurm": {
    "job_id": "12345",
    "array_task_id": "3",
    "nodelist": "gpu-node-[01-04]",
    "cpus_per_task": "4"
  }
}
```

Access in pandas: `results['slurm'].apply(lambda s: s.get('job_id'))`

Supersedes the manual `env_vars = ('SLURM_JOB_ID', ...)` pattern. Getting-started extended example updated to use `CUDA_VISIBLE_DEVICES` instead of a SLURM var to avoid confusion.

## Test plan

- [x] `test_mb_slurm_info` — mocked SLURM env, verifies key transformation and non-SLURM vars excluded
- [x] `test_mb_slurm_info_empty` — no SLURM vars, verifies empty dict
- [x] Full test suite passes (48 passed, 1 skipped)