### PR TITLE
feat: add capture_optional class attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`capture_optional` class attribute**: set `capture_optional = True` on
+  a benchmark class to catch exceptions from `capture_` and `capturepost_`
+  methods instead of aborting the benchmark call. Failures are recorded in
+  `mb_capture_errors` (a list of `{"method": ..., "error": ...}` dicts);
+  the field is absent when all captures succeed. Designed for production
+  jobs on heterogeneous cluster nodes where optional dependencies may not
+  be present on every node.
+
 - **`MBSlurmInfo` mixin**: captures all `SLURM_*` environment variables into
   a `slurm` dict (keys lowercased, `SLURM_` prefix stripped). Empty dict
   when running outside a SLURM job. Supersedes the manual

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -1,0 +1,34 @@
+# Advanced usage
+
+## Tolerating capture failures
+
+By default, an exception in any `capture_` or `capturepost_` method
+propagates and aborts the benchmark call. Set `capture_optional = True` as
+a class attribute to catch failures instead and record them in
+`mb_capture_errors`:
+
+```python
+from microbench import MicroBench, MBNvidiaSmi, MBCondaPackages
+
+class MyBench(MicroBench, MBNvidiaSmi, MBCondaPackages):
+    capture_optional = True  # missing nvidia-smi or conda won't abort the run
+```
+
+When one or more captures fail, the record contains:
+
+```json
+{
+  "mb_capture_errors": [
+    {"method": "capture_nvidia", "error": "FileNotFoundError: [Errno 2] No such file or directory: 'nvidia-smi'"}
+  ]
+}
+```
+
+`mb_capture_errors` is absent from the record when all captures succeed,
+keeping the happy-path output clean.
+
+!!! tip "When to use `capture_optional`"
+    Use it in production jobs running across heterogeneous cluster nodes
+    where optional dependencies (e.g. `nvidia-smi`, `conda`) may not be
+    present on every node. Leave it off during development so misconfigured
+    captures surface immediately.

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -306,7 +306,18 @@ class MicroBench:
             if method_name.startswith('capture_'):
                 method = getattr(self, method_name)
                 if callable(method):
-                    method(bm_data)
+                    if getattr(self, 'capture_optional', False):
+                        try:
+                            method(bm_data)
+                        except Exception as e:
+                            bm_data.setdefault('mb_capture_errors', []).append(
+                                {
+                                    'method': method_name,
+                                    'error': f'{type(e).__name__}: {e}',
+                                }
+                            )
+                    else:
+                        method(bm_data)
 
         # Initialise monitor thread
         if hasattr(self, 'monitor'):
@@ -334,7 +345,18 @@ class MicroBench:
             if method_name.startswith('capturepost_'):
                 method = getattr(self, method_name)
                 if callable(method):
-                    method(bm_data)
+                    if getattr(self, 'capture_optional', False):
+                        try:
+                            method(bm_data)
+                        except Exception as e:
+                            bm_data.setdefault('mb_capture_errors', []).append(
+                                {
+                                    'method': method_name,
+                                    'error': f'{type(e).__name__}: {e}',
+                                }
+                            )
+                    else:
+                        method(bm_data)
 
     def pre_run_triggers(self, bm_data):
         bm_data['_run_start'] = self._duration_counter()

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -88,6 +88,88 @@ def test_multi_iterations():
     assert all(dur >= 0 for dur in results['run_durations'][0])
 
 
+def test_capture_optional_records_errors():
+    """capture_optional=True catches failing captures, records in mb_capture_errors."""
+
+    class BrokenCapture(MicroBench):
+        capture_optional = True
+
+        def capture_will_fail(self, bm_data):
+            raise RuntimeError('simulated failure')
+
+    bench = BrokenCapture()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results()
+    errors = results['mb_capture_errors'][0]
+    assert len(errors) == 1
+    assert errors[0]['method'] == 'capture_will_fail'
+    assert 'RuntimeError' in errors[0]['error']
+    assert 'simulated failure' in errors[0]['error']
+
+
+def test_capture_optional_no_errors_no_field():
+    """When no captures fail, mb_capture_errors is absent from the record."""
+
+    class Bench(MicroBench):
+        capture_optional = True
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results()
+    assert 'mb_capture_errors' not in results.columns
+
+
+def test_capture_optional_false_raises():
+    """Without capture_optional, a failing capture propagates the exception."""
+
+    class BrokenCapture(MicroBench):
+        def capture_will_fail(self, bm_data):
+            raise RuntimeError('simulated failure')
+
+    bench = BrokenCapture()
+
+    @bench
+    def noop():
+        pass
+
+    with pytest.raises(RuntimeError, match='simulated failure'):
+        noop()
+
+
+def test_capture_optional_capturepost():
+    """capture_optional also protects capturepost_ methods."""
+
+    class BrokenPost(MicroBench):
+        capture_optional = True
+
+        def capturepost_will_fail(self, bm_data):
+            raise ValueError('post failure')
+
+    bench = BrokenPost()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results()
+    errors = results['mb_capture_errors'][0]
+    assert any(e['method'] == 'capturepost_will_fail' for e in errors)
+
+
 def test_mb_slurm_info():
     class Bench(MicroBench, MBSlurmInfo):
         pass

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,5 +69,6 @@ nav:
     - Periodic monitoring: user-guide/monitoring.md
     - Extending microbench: user-guide/extending.md
     - Configuration: user-guide/configuration.md
+    - Advanced usage: user-guide/advanced.md
   - API reference: api-reference.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

Set `capture_optional = True` on a benchmark class to catch exceptions from `capture_` and `capturepost_` methods instead of aborting the benchmark call. Failures are recorded in `mb_capture_errors`; the field is absent when all captures succeed.

```python
from microbench import MicroBench, MBNvidiaSmi, MBCondaPackages

class MyBench(MicroBench, MBNvidiaSmi, MBCondaPackages):
    capture_optional = True
```

On a node without `nvidia-smi`, the record continues normally and contains:

```json
{
  "mb_capture_errors": [
    {"method": "capture_nvidia", "error": "FileNotFoundError: [Errno 2] No such file or directory: 'nvidia-smi'"}
  ]
}
```

## Design notes

- Class attribute (not constructor arg) — infrastructure config, consistent with `outfile`, `capture_versions`, etc.
- Only wraps `capture_*` and `capturepost_*` dispatch loops; `env_vars`, `capture_versions`, and monitor thread setup are not wrapped (those reflect bugs, not missing deps)
- `mb_capture_errors` absent on clean runs — no field pollution on happy path
- Documented in a new `Advanced usage` page rather than `Extending microbench`

## Test plan

- [x] `test_capture_optional_records_errors` — exception caught, method name and error type/message recorded
- [x] `test_capture_optional_no_errors_no_field` — clean run produces no `mb_capture_errors` column
- [x] `test_capture_optional_false_raises` — without flag, exception propagates as before
- [x] `test_capture_optional_capturepost` — `capturepost_` methods also protected
- [x] Full suite: 52 passed, 1 skipped