### PR TITLE
docs: restructure user guide and document LiveStream/envdiff

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ Some mixins have optional requirements:
 | `MBNvidiaSmi` | `nvidia-smi` on `PATH` (ships with NVIDIA drivers) |
 | `MBCondaPackages` | `conda` on `PATH` |
 | `RedisOutput` | [redis-py](https://github.com/andymccurdy/redis-py) |
+| `LiveStream` | [python-dateutil](https://pypi.org/project/python-dateutil/) |
+| `envdiff` | [IPython](https://ipython.org/) |
 
 ## Quick example
 

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -32,3 +32,142 @@ keeping the happy-path output clean.
     where optional dependencies (e.g. `nvidia-smi`, `conda`) may not be
     present on every node. Leave it off during development so misconfigured
     captures surface immediately.
+
+## Custom JSON encoding
+
+Microbench serialises records as JSON. If a captured value is not
+JSON-serialisable (e.g. a custom object), microbench replaces it with a
+placeholder and emits a `JSONEncodeWarning`.
+
+To handle custom types, subclass `JSONEncoder`:
+
+```python
+import microbench as mb
+from igraph import Graph
+
+class MyEncoder(mb.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, Graph):
+            return str(o)
+        return super().default(o)
+
+class MyBench(mb.MicroBench, mb.MBReturnValue):
+    pass
+
+bench = MyBench(json_encoder=MyEncoder)
+
+@bench
+def make_graph():
+    return Graph(2, ((0, 1), (0, 2)))
+
+make_graph()  # no warning
+```
+
+`JSONEncoder` already handles `datetime`, `timedelta`, `timezone`, and
+numpy scalar/array types by default.
+
+## Writing a mixin
+
+A mixin is simply a class with one or more `capture_` or `capturepost_`
+methods. Define it as a standalone class, then combine it with `MicroBench`
+via multiple inheritance:
+
+```python
+class MBMachineType:
+    """Capture the machine architecture (e.g. x86_64, arm64)."""
+
+    def capture_machine_type(self, bm_data):
+        import platform
+        bm_data['machine_type'] = platform.machine()
+
+
+class MyBench(MicroBench, MBMachineType, MBPythonVersion):
+    pass
+```
+
+Mixins have no required base class. Python's **Method Resolution Order
+(MRO)** determines the order in which base classes are searched for
+methods — a deterministic left-to-right traversal that visits each class
+exactly once. Because every `capture_` method has a unique name, all of
+them are found and called regardless of MRO order. The MRO only matters if
+two mixins define a method with the *same* name, in which case the
+leftmost class in the inheritance list wins.
+
+## Tailing output in real time
+
+`LiveStream` tails a JSONL output file in a background thread and fires
+`process_*` methods on each record as it arrives. It has two main use
+cases:
+
+**1. In-process monitoring** — react to results while a long job is still
+running in the same Python process:
+
+```python
+from microbench.livestream import LiveStream
+
+class MyStream(LiveStream):
+    def process_alert(self, data):
+        if sum(data['run_durations']) > 10.0:
+            print(f"Slow call on {data.get('hostname')}: {data['run_durations']}")
+
+stream = MyStream('/home/user/results.jsonl')
+# ... runs in background while your job continues ...
+stream.stop()
+stream.join()
+```
+
+**2. Separate terminal** — run a watcher script in a second terminal while
+your benchmark job writes to the file:
+
+```python
+# watch.py — run in a separate terminal: python watch.py
+from microbench.livestream import LiveStream
+import time
+
+class Watcher(LiveStream):
+    def filter(self, data):
+        # Only show records from GPU nodes
+        return 'gpu' in data.get('hostname', '')
+
+    def display(self, data):
+        print(f"{data['function_name']} | {data['hostname']} | {data['run_durations']}")
+
+stream = Watcher('/home/user/results.jsonl')
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    stream.stop()
+    stream.join()
+```
+
+The base class includes a `process_runtime` method that adds a `runtime`
+field (finish_time − start_time) to each record before `display()` is
+called. Override `display()` to change how records are shown, or `filter()`
+to skip records selectively.
+
+Requires [python-dateutil](https://pypi.org/project/python-dateutil/):
+`pip install python-dateutil`.
+
+## Comparing environments
+
+`envdiff` produces a side-by-side visual diff of two records in a Jupyter
+notebook, highlighting fields that differ. Useful for diagnosing why the
+same code performs differently on two nodes.
+
+Requires [IPython](https://ipython.org/): `pip install ipython`.
+
+```python
+from microbench.diff import envdiff
+import pandas
+
+results = pandas.read_json('/home/user/results.jsonl', lines=True)
+
+# Compare the environment of the slowest and fastest calls
+slowest = results.loc[results['run_durations'].apply(sum).idxmax()]
+fastest = results.loc[results['run_durations'].apply(sum).idxmin()]
+
+envdiff(slowest, fastest)
+```
+
+Differences are highlighted in red in the rendered output.

--- a/docs/user-guide/extending.md
+++ b/docs/user-guide/extending.md
@@ -23,56 +23,6 @@ class MyBench(MicroBench):
 Avoid key names that clash with built-in fields (e.g. `start_time`,
 `function_name`). The `mb_` prefix is reserved for microbench internals.
 
-## Custom JSON encoding
-
-Microbench serialises records as JSON. If a captured value is not
-JSON-serialisable (e.g. a custom object), microbench replaces it with a
-placeholder and emits a `JSONEncodeWarning`.
-
-To handle custom types, subclass `JSONEncoder`:
-
-```python
-import microbench as mb
-from igraph import Graph
-
-class MyEncoder(mb.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, Graph):
-            return str(o)
-        return super().default(o)
-
-class MyBench(mb.MicroBench, mb.MBReturnValue):
-    pass
-
-bench = MyBench(json_encoder=MyEncoder)
-
-@bench
-def make_graph():
-    return Graph(2, ((0, 1), (0, 2)))
-
-make_graph()  # no warning
-```
-
-`JSONEncoder` already handles `datetime`, `timedelta`, `timezone`, and
-numpy scalar/array types by default.
-
-## Writing a mixin
-
-A mixin is simply a class with one or more `capture_` or `capturepost_`
-methods. Define it as a standalone class, then include it in benchmark suite
-definitions via multiple inheritance:
-
-```python
-class MBMachineType:
-    """Capture the machine architecture (e.g. x86_64, arm64)."""
-
-    def capture_machine_type(self, bm_data):
-        import platform
-        bm_data['machine_type'] = platform.machine()
-
-
-class MyBench(MicroBench, MBMachineType, MBPythonVersion):
-    pass
-```
-
-Mixins have no required base class — they rely entirely on Python's MRO.
+For more advanced extension patterns — custom JSON encoding, writing
+reusable mixins, and tools for consuming benchmark output — see
+[Advanced usage](advanced.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,11 +64,11 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - User guide:
+    - Configuration: user-guide/configuration.md
     - Mixins: user-guide/mixins.md
     - Output: user-guide/output.md
     - Periodic monitoring: user-guide/monitoring.md
     - Extending microbench: user-guide/extending.md
-    - Configuration: user-guide/configuration.md
     - Advanced usage: user-guide/advanced.md
   - API reference: api-reference.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

- Move "Custom JSON encoding" and "Writing a mixin" from `extending.md` to `advanced.md`; add forward-reference link from `extending.md`
- Add `LiveStream` documentation to `advanced.md`: in-process monitoring and separate-terminal watcher patterns
- Add `envdiff` documentation to `advanced.md` with pandas usage example
- Reorder user-guide nav: Configuration → Mixins → Output → Periodic monitoring → Extending → Advanced (beginner-first ordering)
- Add `LiveStream` and `envdiff` to requirements table on home page
- Expand MRO explanation in "Writing a mixin" section

## Test plan

- [x] `mkdocs build` passes cleanly
- [x] Nav order matches beginner-first flow in rendered site
- [x] `LiveStream` and `envdiff` appear in requirements table on home page
- [x] Forward link in `extending.md` correctly points to `advanced.md`