### PR TITLE
docs: add citation section to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ Each call produces one record. `results` is a pandas DataFrame:
 Full documentation, including a getting-started guide, mixin reference, and
 API docs, is at **https://alubbock.github.io/microbench/**.
 
+## Citing microbench
+
+If you use microbench in your research, please cite:
+
+> Lubbock, A.L.R. and Lopez, C.F. (2022). Microbench: automated metadata
+> management for systems biology benchmarking and reproducibility in Python.
+> *Bioinformatics*, 38(20), 4823–4825.
+> https://doi.org/10.1093/bioinformatics/btac580
+
+Although the paper was written in the context of systems biology, microbench
+is a general-purpose benchmarking tool applicable to any Python workload.
+
 ## Feedback
 
 Bug reports and feature requests are welcome in

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -1,0 +1,27 @@
+# Citing microbench
+
+If you use microbench in your research, please cite:
+
+> Lubbock, A.L.R. and Lopez, C.F. (2022). Microbench: automated metadata
+> management for systems biology benchmarking and reproducibility in Python.
+> *Bioinformatics*, 38(20), 4823–4825.
+> <https://doi.org/10.1093/bioinformatics/btac580>
+
+Although the paper was written in the context of systems biology, microbench
+is a general-purpose benchmarking tool applicable to any Python workload.
+
+## BibTeX
+
+```bibtex
+@article{Lubbock2022,
+  title={Microbench: automated metadata management for systems biology
+         benchmarking and reproducibility in {P}ython},
+  author={Lubbock, Alexander LR and Lopez, Carlos F},
+  journal={Bioinformatics},
+  volume={38},
+  number={20},
+  pages={4823--4825},
+  year={2022},
+  doi={10.1093/bioinformatics/btac580}
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,4 +71,5 @@ nav:
     - Extending microbench: user-guide/extending.md
     - Advanced usage: user-guide/advanced.md
   - API reference: api-reference.md
+  - Citing microbench: citing.md
   - Changelog: changelog.md


### PR DESCRIPTION
Add `docs/citing.md` with plain-text citation and BibTeX entry for
Lubbock & Lopez (2022), doi:10.1093/bioinformatics/btac580. Add
"Citing microbench" to the nav (between API reference and Changelog)
and a matching section to the README. Both include a note that although
the paper was written in a systems biology context, microbench is a
general-purpose tool.