### PR TITLE
feat: add MBPeakMemory mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ All notable changes to microbench are documented here.
   jobs on heterogeneous cluster nodes where optional dependencies may not
   be present on every node.
 
+- **`MBPeakMemory` mixin**: captures peak Python memory allocation during the
+  benchmarked function as `peak_memory_bytes` (bytes), using
+  `tracemalloc` from the standard library. No extra dependencies required.
+
 - **`MBSlurmInfo` mixin**: captures all `SLURM_*` environment variables into
   a `slurm` dict (keys lowercased, `SLURM_` prefix stripped). Empty dict
   when running outside a SLURM job. Supersedes the manual

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -27,6 +27,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBHostInfo` | `hostname`, `operating_system` | — |
 | `MBHostCpuCores` | `cpu_cores_logical`, `cpu_cores_physical` | psutil |
 | `MBHostRamTotal` | `ram_total` (bytes) | psutil |
+| `MBPeakMemory` | `peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `package_versions` for every installed package | — |
@@ -81,6 +82,58 @@ The return value must be JSON-serialisable. If it is not, a
 `JSONEncodeWarning` is issued and a placeholder is stored. See
 [Custom JSON encoding](extending.md#custom-json-encoding) to handle
 custom types.
+
+## Host resources
+
+### `MBHostCpuCores` and `MBHostRamTotal`
+
+Capture static host hardware information. Requires
+[psutil](https://pypi.org/project/psutil/).
+
+```python
+from microbench import MicroBench, MBHostCpuCores, MBHostRamTotal
+
+class Bench(MicroBench, MBHostCpuCores, MBHostRamTotal):
+    pass
+```
+
+Fields: `cpu_cores_logical`, `cpu_cores_physical`, `ram_total` (bytes).
+
+## Job resource utilisation
+
+### `MBPeakMemory`
+
+Captures the peak Python memory allocation during the benchmarked function
+(across all iterations when `iterations > 1`) as `peak_memory_bytes` (bytes).
+Uses [`tracemalloc`](https://docs.python.org/3/library/tracemalloc.html) from
+the standard library — no extra dependencies required.
+
+```python
+from microbench import MicroBench, MBPeakMemory
+
+class Bench(MicroBench, MBPeakMemory):
+    pass
+
+bench = Bench()
+
+@bench
+def process(data):
+    return sorted(data)
+
+process(list(range(1_000_000, 0, -1)))
+# record contains: {"peak_memory_bytes": 8056968, ...}
+```
+
+!!! note
+    `tracemalloc` tracks memory that goes through Python's allocator, which
+    covers Python objects and most C-extension allocations. Memory allocated
+    directly via `malloc` in C extensions (e.g. some large NumPy operations)
+    is not tracked.
+
+!!! tip "Continuous resource monitoring"
+    `MBPeakMemory` gives a single high-water mark per call. For time-series
+    sampling of memory, CPU, and other metrics *while the function runs*,
+    see [Periodic monitoring](monitoring.md).
 
 ## HPC / SLURM
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     'MBHostInfo',
     'MBHostCpuCores',
     'MBHostRamTotal',
+    'MBPeakMemory',
     'MBSlurmInfo',
     'MBGlobalPackages',
     'MBInstalledPackages',
@@ -697,6 +698,38 @@ class MBHostRamTotal(_NeedsPsUtil):
     def capture_total_ram(self, bm_data):
         self._check_psutil()
         bm_data['ram_total'] = psutil.virtual_memory().total
+
+
+class MBPeakMemory:
+    """Capture peak Python memory allocation during the benchmarked function.
+
+    Uses :mod:`tracemalloc` from the Python standard library (no extra
+    dependencies). Records the peak memory allocated in bytes across all
+    iterations as ``peak_memory_bytes``.
+
+    Note:
+        ``tracemalloc`` tracks memory that goes through Python's allocator,
+        which covers Python objects and most C-extension allocations. Memory
+        allocated directly via ``malloc`` in C extensions (e.g. some large
+        NumPy arrays) is not tracked.
+    """
+
+    def capture_peak_memory(self, bm_data):
+        import tracemalloc
+
+        self._tracemalloc_was_tracing = tracemalloc.is_tracing()
+        if self._tracemalloc_was_tracing:
+            tracemalloc.reset_peak()
+        else:
+            tracemalloc.start()
+
+    def capturepost_peak_memory(self, bm_data):
+        import tracemalloc
+
+        _, peak = tracemalloc.get_traced_memory()
+        bm_data['peak_memory_bytes'] = peak
+        if not self._tracemalloc_was_tracing:
+            tracemalloc.stop()
 
 
 class MBNvidiaSmi:

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -19,6 +19,7 @@ from microbench import (
     MBFunctionCall,
     MBHostInfo,
     MBInstalledPackages,
+    MBPeakMemory,
     MBPythonVersion,
     MBReturnValue,
     MBSlurmInfo,
@@ -672,6 +673,67 @@ def test_redis_output_get_results_without_pandas():
         with patch.object(microbench, 'pandas', None):
             with pytest.raises(ImportError, match='pandas'):
                 bench.get_results()
+
+
+def test_mb_peak_memory():
+    class Bench(MicroBench, MBPeakMemory):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def allocate():
+        return [0] * 100_000
+
+    allocate()
+
+    results = bench.get_results()
+    assert results['peak_memory_bytes'][0] > 0
+
+
+def test_mb_peak_memory_stops_tracemalloc():
+    """MBPeakMemory stops tracemalloc after the call if it was not already running."""
+    import tracemalloc
+
+    assert not tracemalloc.is_tracing()
+
+    class Bench(MicroBench, MBPeakMemory):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    assert not tracemalloc.is_tracing()
+
+
+def test_mb_peak_memory_preserves_existing_trace():
+    """MBPeakMemory leaves tracemalloc running if it was already active."""
+    import tracemalloc
+
+    tracemalloc.start()
+    try:
+
+        class Bench(MicroBench, MBPeakMemory):
+            pass
+
+        bench = Bench()
+
+        @bench
+        def noop():
+            pass
+
+        noop()
+
+        assert tracemalloc.is_tracing()
+        results = bench.get_results()
+        assert 'peak_memory_bytes' in results.columns
+    finally:
+        tracemalloc.stop()
 
 
 def test_redis_output_multiple_results():


### PR DESCRIPTION
Adds `MBPeakMemory`, a new mixin that captures peak Python memory
allocation during the benchmarked function as `peak_memory_bytes`
(bytes).

## Design

- Uses `tracemalloc` from the standard library — no extra dependencies
- Measures peak across all iterations when `iterations > 1`
- Restores tracemalloc state: if tracing was already active when the
  benchmark runs, resets the peak counter and leaves it running;
  otherwise starts and stops tracing around the call
- Three tests: basic measurement, stops tracing when it started it,
  preserves existing tracing session

## Docs

- New "Host resources" section in the mixins page documenting
  `MBHostCpuCores` and `MBHostRamTotal`
- New "Job resource utilisation" section documenting `MBPeakMemory`,
  with a tip linking to the periodic monitoring page for time-series use
  cases