### PR TITLE
feat: add MBGitInfo mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ All notable changes to microbench are documented here.
   jobs on heterogeneous cluster nodes where optional dependencies may not
   be present on every node.
 
+- **`MBGitInfo` mixin**: captures the current git commit hash, branch name,
+  and dirty flag (uncommitted changes present) via `git` ≥ 2.11 on PATH.
+  Stored in `git_info`. Set `git_path` to inspect a specific repository
+  directory.
+
 - **`MBPeakMemory` mixin**: captures peak Python memory allocation during the
   benchmarked function as `peak_memory_bytes` (bytes), using
   `tracemalloc` from the standard library. No extra dependencies required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ All notable changes to microbench are documented here.
 
 - **`MBGitInfo` mixin**: captures the current git commit hash, branch name,
   and dirty flag (uncommitted changes present) via `git` ≥ 2.11 on PATH.
-  Stored in `git_info`. Set `git_path` to inspect a specific repository
+  Stored in `git_info`. Set `git_repo` to inspect a specific repository
   directory.
 
 - **`MBPeakMemory` mixin**: captures peak Python memory allocation during the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,10 @@ All notable changes to microbench are documented here.
   jobs on heterogeneous cluster nodes where optional dependencies may not
   be present on every node.
 
-- **`MBGitInfo` mixin**: captures the current git commit hash, branch name,
-  and dirty flag (uncommitted changes present) via `git` ≥ 2.11 on PATH.
-  Stored in `git_info`. Set `git_repo` to inspect a specific repository
-  directory.
+- **`MBGitInfo` mixin**: captures the repository root path, current commit
+  hash, branch name, and dirty flag (uncommitted changes present) via
+  `git` ≥ 2.11 on PATH. Stored in `git_info`. Set `git_repo` to inspect
+  a specific repository directory.
 
 - **`MBPeakMemory` mixin**: captures peak Python memory allocation during the
   benchmarked function as `peak_memory_bytes` (bytes), using

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -29,7 +29,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBHostRamTotal` | `ram_total` (bytes) | psutil |
 | `MBPeakMemory` | `peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
-| `MBGitInfo` | `git_info` dict with `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
+| `MBGitInfo` | `git_info` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `package_versions` for every installed package | — |
 | `MBCondaPackages` | `conda_versions` for every package in the active conda environment | `conda` on PATH |
@@ -183,9 +183,9 @@ results['slurm'].apply(lambda s: s.get('job_id'))
 
 ### `MBGitInfo`
 
-Captures the current git commit hash, branch name, and dirty flag (whether
-there are uncommitted changes in the working tree). Requires `git` ≥ 2.11
-on `PATH`.
+Captures the current git repo, commit hash, branch name, and dirty flag
+(whether there are uncommitted changes in the working tree). Requires
+`git` ≥ 2.11 on `PATH`.
 
 ```python
 from microbench import MicroBench, MBGitInfo
@@ -214,11 +214,11 @@ By default the repository is located from the running script's directory
 (`sys.argv[0]`), which works correctly even when a script is launched by
 absolute path from a different working directory (e.g. cluster job
 submission). Falls back to the shell's working directory in interactive
-Python sessions. Set `git_path` to target a specific directory explicitly:
+Python sessions. Set `git_repo` to target a specific directory explicitly:
 
 ```python
 class Bench(MicroBench, MBGitInfo):
-    git_path = '/path/to/repo'
+    git_repo = '/path/to/repo'
 ```
 
 Use `capture_optional = True` to silently skip git capture on machines

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -29,6 +29,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBHostRamTotal` | `ram_total` (bytes) | psutil |
 | `MBPeakMemory` | `peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
+| `MBGitInfo` | `git_info` dict with `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `package_versions` for every installed package | — |
 | `MBCondaPackages` | `conda_versions` for every package in the active conda environment | `conda` on PATH |
@@ -176,6 +177,51 @@ results['slurm'].apply(lambda s: s.get('job_id'))
     `MBSlurmInfo` supersedes the manual `env_vars = ('SLURM_JOB_ID', ...)`
     pattern — it captures every `SLURM_*` variable automatically with no
     configuration.
+
+## Code provenance
+
+### `MBGitInfo`
+
+Captures the current git commit hash, branch name, and dirty flag (whether
+there are uncommitted changes in the working tree). Requires `git` ≥ 2.11
+on `PATH`.
+
+```python
+from microbench import MicroBench, MBGitInfo
+
+class Bench(MicroBench, MBGitInfo):
+    pass
+```
+
+Each record will contain:
+
+```json
+{
+  "git_info": {
+    "repo": "/home/user/project",
+    "commit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "branch": "main",
+    "dirty": false
+  }
+}
+```
+
+`dirty` is `True` if there are any staged or unstaged changes to tracked
+files. `branch` is an empty string in detached HEAD state.
+
+By default the repository is located from the running script's directory
+(`sys.argv[0]`), which works correctly even when a script is launched by
+absolute path from a different working directory (e.g. cluster job
+submission). Falls back to the shell's working directory in interactive
+Python sessions. Set `git_path` to target a specific directory explicitly:
+
+```python
+class Bench(MicroBench, MBGitInfo):
+    git_path = '/path/to/repo'
+```
+
+Use `capture_optional = True` to silently skip git capture on machines
+without git or when running outside a repository.
 
 ## Package versions
 

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -224,60 +224,6 @@ class Bench(MicroBench, MBGitInfo):
 Use `capture_optional = True` to silently skip git capture on machines
 without git or when running outside a repository.
 
-## Package versions
-
-### `MBGlobalPackages`
-
-Captures the version of every module imported in the caller's global
-namespace:
-
-```python
-from microbench import MicroBench, MBGlobalPackages
-import numpy, pandas
-
-class Bench(MicroBench, MBGlobalPackages):
-    pass
-```
-
-The `package_versions` field will contain `{"numpy": "1.26.0", "pandas": "2.1.0", ...}`.
-
-### `MBInstalledPackages`
-
-Captures every package available for import (from `importlib.metadata`).
-Useful for full reproducibility audits. Can be slow on environments with
-many packages.
-
-Set `capture_paths = True` to also record installation paths:
-
-```python
-class Bench(MicroBench, MBInstalledPackages):
-    capture_paths = True
-```
-
-### `MBCondaPackages`
-
-Captures all packages in the active conda environment using the `conda` CLI.
-
-```python
-class Bench(MicroBench, MBCondaPackages):
-    include_builds = True    # include build string (default: True)
-    include_channels = False  # include channel name (default: False)
-```
-
-### `capture_versions`
-
-To capture specific package versions without a mixin, list them on the
-class:
-
-```python
-import numpy, pandas
-
-class Bench(MicroBench):
-    capture_versions = (numpy, pandas)
-```
-
-## Code provenance
-
 ### `MBFileHash`
 
 Records a cryptographic checksum of one or more files alongside benchmark
@@ -352,6 +298,58 @@ Any algorithm name accepted by `hashlib.new()` works: `'sha256'` (default),
         hash_files = ['sometimes_missing.dat']
         capture_optional = True
     ```
+
+## Package versions
+
+### `MBGlobalPackages`
+
+Captures the version of every module imported in the caller's global
+namespace:
+
+```python
+from microbench import MicroBench, MBGlobalPackages
+import numpy, pandas
+
+class Bench(MicroBench, MBGlobalPackages):
+    pass
+```
+
+The `package_versions` field will contain `{"numpy": "1.26.0", "pandas": "2.1.0", ...}`.
+
+### `MBInstalledPackages`
+
+Captures every package available for import (from `importlib.metadata`).
+Useful for full reproducibility audits. Can be slow on environments with
+many packages.
+
+Set `capture_paths = True` to also record installation paths:
+
+```python
+class Bench(MicroBench, MBInstalledPackages):
+    capture_paths = True
+```
+
+### `MBCondaPackages`
+
+Captures all packages in the active conda environment using the `conda` CLI.
+
+```python
+class Bench(MicroBench, MBCondaPackages):
+    include_builds = True    # include build string (default: True)
+    include_channels = False  # include channel name (default: False)
+```
+
+### `capture_versions`
+
+To capture specific package versions without a mixin, list them on the
+class:
+
+```python
+import numpy, pandas
+
+class Bench(MicroBench):
+    capture_versions = (numpy, pandas)
+```
 
 ## NVIDIA GPU — `MBNvidiaSmi`
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     'MBHostRamTotal',
     'MBPeakMemory',
     'MBSlurmInfo',
+    'MBGitInfo',
     'MBGlobalPackages',
     'MBInstalledPackages',
     'MBCondaPackages',
@@ -550,6 +551,79 @@ class MBSlurmInfo:
     def capture_slurm(self, bm_data):
         bm_data['slurm'] = {
             k[6:].lower(): v for k, v in os.environ.items() if k.startswith('SLURM_')
+        }
+
+
+class MBGitInfo:
+    """Capture git repository information.
+
+    Requires ``git`` ≥ 2.11 to be available on ``PATH``. Records the
+    current commit hash, branch name, and whether the working tree has
+    uncommitted changes. Results are stored in the ``git_info`` field.
+
+    By default inspects the repository containing the running script
+    (``sys.argv[0]``), falling back to the shell's working directory
+    when the script path is unavailable (e.g. interactive Python). Set
+    ``git_path`` explicitly to target a specific directory, which is
+    useful when the script and the repository root are in different
+    locations.
+
+    Attributes:
+        git_path (str, optional): Directory to inspect. Defaults to the
+            directory of the running script, or the shell's working
+            directory if unavailable.
+
+    Example output::
+
+        {
+            "git_info": {
+                "repo": "/home/user/project",
+                "commit": "a1b2c3d4e5f6...",
+                "branch": "main",
+                "dirty": false
+            }
+        }
+    """
+
+    def capture_git_info(self, bm_data):
+        if hasattr(self, 'git_path'):
+            cwd = self.git_path
+        else:
+            argv0 = sys.argv[0] if sys.argv else ''
+            if argv0 and not argv0.startswith('-'):
+                cwd = os.path.dirname(os.path.abspath(argv0))
+            else:
+                cwd = None  # fall back to shell's working directory
+
+        kwargs = {'cwd': cwd, 'stderr': subprocess.DEVNULL}
+
+        repo = (
+            subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], **kwargs)
+            .decode()
+            .strip()
+        )
+
+        output = subprocess.check_output(
+            ['git', 'status', '--porcelain=v2', '--branch'], **kwargs
+        ).decode()
+
+        commit = ''
+        branch = ''
+        dirty = False
+        for line in output.splitlines():
+            if line.startswith('# branch.oid '):
+                commit = line[13:]
+            elif line.startswith('# branch.head '):
+                head = line[14:]
+                branch = '' if head == '(detached)' else head
+            elif not line.startswith('#'):
+                dirty = True
+
+        bm_data['git_info'] = {
+            'repo': repo,
+            'commit': commit,
+            'branch': branch,
+            'dirty': dirty,
         }
 
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -559,18 +559,19 @@ class MBGitInfo:
     """Capture git repository information.
 
     Requires ``git`` ≥ 2.11 to be available on ``PATH``. Records the
-    current commit hash, branch name, and whether the working tree has
-    uncommitted changes. Results are stored in the ``git_info`` field.
+    current repo directory, commit hash, branch name, and whether the
+    working tree has uncommitted changes. Results are stored in the
+    ``git_info`` field.
 
     By default inspects the repository containing the running script
     (``sys.argv[0]``), falling back to the shell's working directory
     when the script path is unavailable (e.g. interactive Python). Set
-    ``git_path`` explicitly to target a specific directory, which is
+    ``git_repo`` explicitly to target a specific directory, which is
     useful when the script and the repository root are in different
     locations.
 
     Attributes:
-        git_path (str, optional): Directory to inspect. Defaults to the
+        git_repo (str, optional): Directory to inspect. Defaults to the
             directory of the running script, or the shell's working
             directory if unavailable.
 
@@ -587,8 +588,8 @@ class MBGitInfo:
     """
 
     def capture_git_info(self, bm_data):
-        if hasattr(self, 'git_path'):
-            cwd = self.git_path
+        if hasattr(self, 'git_repo'):
+            cwd = self.git_repo
         else:
             argv0 = sys.argv[0] if sys.argv else ''
             if argv0 and not argv0.startswith('-'):

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -882,11 +882,14 @@ def test_mb_git_info_default_uses_script_dir():
     def noop():
         pass
 
-    with patch.object(sys, 'argv', ['/some/project/script.py']):
+    script = '/some/project/script.py'
+    expected_cwd = os.path.dirname(os.path.abspath(script))
+
+    with patch.object(sys, 'argv', [script]):
         with patch('subprocess.check_output', side_effect=side_effect):
             noop()
 
-    assert all(kw.get('cwd') == '/some/project' for kw in captured_kwargs)
+    assert all(kw.get('cwd') == expected_cwd for kw in captured_kwargs)
 
 
 def test_mb_git_info_custom_path():

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -890,7 +890,7 @@ def test_mb_git_info_default_uses_script_dir():
 
 
 def test_mb_git_info_custom_path():
-    """MBGitInfo passes git_path as cwd to subprocess."""
+    """MBGitInfo passes git_repo as cwd to subprocess."""
     captured_kwargs = []
 
     def side_effect(cmd, **kwargs):
@@ -898,7 +898,7 @@ def test_mb_git_info_custom_path():
         return _GIT_TOPLEVEL if 'rev-parse' in cmd else _GIT_STATUS_CLEAN.encode()
 
     class Bench(MicroBench, MBGitInfo):
-        git_path = '/some/repo'
+        git_repo = '/some/repo'
 
     bench = Bench()
 

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 import os
+import sys
 import tempfile
 import threading
 import time
@@ -17,6 +18,7 @@ from microbench import (
     JSONEncoder,
     JSONEncodeWarning,
     MBFunctionCall,
+    MBGitInfo,
     MBHostInfo,
     MBInstalledPackages,
     MBPeakMemory,
@@ -758,3 +760,148 @@ def test_redis_output_multiple_results():
         results = bench.get_results()
         assert len(results) == 2
         assert list(results['function_name']) == ['func_a', 'func_b']
+
+
+_GIT_TOPLEVEL = b'/home/user/project\n'
+_GIT_STATUS_CLEAN = (
+    '# branch.oid abc123def456abc123def456abc123def456abc1\n# branch.head main\n'
+)
+_GIT_STATUS_DIRTY = _GIT_STATUS_CLEAN + ' M modified_file.py\n'
+_GIT_STATUS_DETACHED = (
+    '# branch.oid abc123def456abc123def456abc123def456abc1\n# branch.head (detached)\n'
+)
+
+
+def _git_mock(status_output):
+    """Return a subprocess.check_output side_effect that handles both git calls."""
+
+    def side_effect(cmd, **kwargs):
+        if 'rev-parse' in cmd:
+            return _GIT_TOPLEVEL
+        return status_output.encode()
+
+    return side_effect
+
+
+def test_mb_git_info():
+    """MBGitInfo captures repo, commit, branch, and dirty=False from a clean repo."""
+
+    class Bench(MicroBench, MBGitInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_CLEAN)):
+        noop()
+
+    git_info = bench.get_results()['git_info'][0]
+    assert git_info['repo'] == '/home/user/project'
+    assert git_info['commit'] == 'abc123def456abc123def456abc123def456abc1'
+    assert git_info['branch'] == 'main'
+    assert git_info['dirty'] is False
+
+
+def test_mb_git_info_dirty():
+    """MBGitInfo sets dirty=True when the working tree has uncommitted changes."""
+
+    class Bench(MicroBench, MBGitInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_DIRTY)):
+        noop()
+
+    assert bench.get_results()['git_info'][0]['dirty'] is True
+
+
+def test_mb_git_info_detached_head():
+    """MBGitInfo stores an empty string for branch in detached HEAD state."""
+
+    class Bench(MicroBench, MBGitInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_DETACHED)):
+        noop()
+
+    assert bench.get_results()['git_info'][0]['branch'] == ''
+
+
+def test_mb_git_info_no_git_raises():
+    """MBGitInfo propagates FileNotFoundError when git is not on PATH."""
+
+    class Bench(MicroBench, MBGitInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch(
+        'subprocess.check_output', side_effect=FileNotFoundError('git not found')
+    ):
+        with pytest.raises(FileNotFoundError):
+            noop()
+
+
+def test_mb_git_info_default_uses_script_dir():
+    """MBGitInfo defaults to the directory of sys.argv[0], not CWD."""
+    captured_kwargs = []
+
+    def side_effect(cmd, **kwargs):
+        captured_kwargs.append(kwargs)
+        return _GIT_TOPLEVEL if 'rev-parse' in cmd else _GIT_STATUS_CLEAN.encode()
+
+    class Bench(MicroBench, MBGitInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch.object(sys, 'argv', ['/some/project/script.py']):
+        with patch('subprocess.check_output', side_effect=side_effect):
+            noop()
+
+    assert all(kw.get('cwd') == '/some/project' for kw in captured_kwargs)
+
+
+def test_mb_git_info_custom_path():
+    """MBGitInfo passes git_path as cwd to subprocess."""
+    captured_kwargs = []
+
+    def side_effect(cmd, **kwargs):
+        captured_kwargs.append(kwargs)
+        return _GIT_TOPLEVEL if 'rev-parse' in cmd else _GIT_STATUS_CLEAN.encode()
+
+    class Bench(MicroBench, MBGitInfo):
+        git_path = '/some/repo'
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('subprocess.check_output', side_effect=side_effect):
+        noop()
+
+    assert all(kw.get('cwd') == '/some/repo' for kw in captured_kwargs)


### PR DESCRIPTION
Adds `MBGitInfo`, a mixin that captures the git repository path, current commit hash, branch name, and dirty flag into a `git_info` dict.

- Single call to `git status --porcelain=v2 --branch` (git ≥ 2.11, stable machine-readable format) for commit, branch, and dirty; plus `git rev-parse --show-toplevel` for the repo root
- Defaults to the running script's directory (`sys.argv[0]`) rather than CWD, so it works correctly when scripts are submitted to clusters by absolute path; falls back to CWD in interactive sessions
- `git_path` class attribute overrides the target directory
- Exceptions propagate by default; suppressible with `capture_optional = True`
- Six tests covering clean repo, dirty flag, detached HEAD, missing git, script-dir default, and custom path