### PR TITLE
feat: add MBFileHash mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ All notable changes to microbench are documented here.
   when running outside a SLURM job. Supersedes the manual
   `env_vars = ('SLURM_JOB_ID', ...)` pattern.
 
+- **`MBFileHash` mixin**: records a cryptographic checksum of specified files
+  in the `file_hashes` field (a dict mapping path to hex digest). Defaults to
+  hashing `sys.argv[0]` — the running script. Set `hash_files` to an iterable
+  of paths to hash specific files instead. Set `hash_algorithm` to any
+  algorithm accepted by `hashlib.new` (default: `'sha256'`).
+
 - **`warmup` parameter**: pass `warmup=N` to run the function `N` times
   before timing begins, priming caches or JIT compilation without affecting
   results. Warmup calls are unrecorded and do not interact with the monitor

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -34,6 +34,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBCondaPackages` | `conda_versions` for every package in the active conda environment | `conda` on PATH |
 | `MBNvidiaSmi` | `nvidia_<attr>` per GPU (see below) | `nvidia-smi` on PATH |
 | `MBLineProfiler` | `line_profiler` (base64-encoded profile, see below) | line_profiler |
+| `MBFileHash` | `file_hashes` — SHA-256 checksum of each specified file | — |
 
 ## Function calls and return values
 
@@ -228,6 +229,65 @@ import numpy, pandas
 class Bench(MicroBench):
     capture_versions = (numpy, pandas)
 ```
+
+## Code provenance
+
+### `MBFileHash`
+
+Records a cryptographic checksum of one or more files alongside benchmark
+results. This ties a result to the exact version of the script that produced
+it — useful when benchmarks evolve over time and you need to know which code
+generated which numbers.
+
+```python
+from microbench import MicroBench, MBFileHash
+
+class Bench(MicroBench, MBFileHash):
+    pass
+
+bench = Bench()
+```
+
+By default, `MBFileHash` hashes `sys.argv[0]` — the script that was run. To
+hash specific files instead, set `hash_files`:
+
+```python
+class Bench(MicroBench, MBFileHash):
+    hash_files = ['run_experiment.py', 'config.yaml']
+```
+
+Each record will contain a `file_hashes` dict mapping each path to its
+hex digest:
+
+```json
+{
+  "file_hashes": {
+    "run_experiment.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "config.yaml": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+  }
+}
+```
+
+The default algorithm is SHA-256. Use `hash_algorithm` to select a different
+algorithm from Python's [`hashlib`](https://docs.python.org/3/library/hashlib.html):
+
+```python
+class Bench(MicroBench, MBFileHash):
+    hash_files = ['large_model_weights.bin']
+    hash_algorithm = 'md5'   # faster for large files
+```
+
+Any algorithm name accepted by `hashlib.new()` works: `'sha256'` (default),
+`'md5'`, `'sha1'`, `'blake2b'`, etc.
+
+!!! tip
+    Pair `MBFileHash` with `capture_optional = True` if the script path
+    may not always be available (e.g. interactive Python sessions):
+
+    ```python
+    class Bench(MicroBench, MBFileHash):
+        capture_optional = True
+    ```
 
 ## NVIDIA GPU — `MBNvidiaSmi`
 

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -256,6 +256,23 @@ class Bench(MicroBench, MBFileHash):
     hash_files = ['run_experiment.py', 'config.yaml']
 ```
 
+Relative paths in `hash_files` are resolved against the **working directory
+at the time the benchmarked function is called**, which may differ from the
+script's location (especially on clusters where a job scheduler launches
+scripts from a scratch directory). Use absolute paths to be safe:
+
+```python
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+class Bench(MicroBench, MBFileHash):
+    hash_files = [
+        os.path.join(SCRIPT_DIR, 'run_experiment.py'),
+        os.path.join(SCRIPT_DIR, 'config.yaml'),
+    ]
+```
+
 Each record will contain a `file_hashes` dict mapping each path to its
 hex digest:
 
@@ -286,6 +303,7 @@ Any algorithm name accepted by `hashlib.new()` works: `'sha256'` (default),
 
     ```python
     class Bench(MicroBench, MBFileHash):
+        hash_files = ['sometimes_missing.dat']
         capture_optional = True
     ```
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     'MBHostRamTotal',
     'MBPeakMemory',
     'MBSlurmInfo',
+    'MBFileHash',
     'MBGlobalPackages',
     'MBInstalledPackages',
     'MBCondaPackages',
@@ -551,6 +552,59 @@ class MBSlurmInfo:
         bm_data['slurm'] = {
             k[6:].lower(): v for k, v in os.environ.items() if k.startswith('SLURM_')
         }
+
+
+class MBFileHash:
+    """Capture cryptographic hashes of specified files.
+
+    Useful for recording the exact state of scripts or configuration
+    files alongside benchmark results, so results can be tied to a
+    specific version of the code even without version control.
+
+    By default hashes the running script (``sys.argv[0]``). Set
+    ``hash_files`` to an iterable of paths to hash specific files
+    instead. Files are read in 64 KB chunks, so large files are handled
+    without loading them fully into memory.
+
+    Attributes:
+        hash_files (iterable of str, optional): File paths to hash.
+            Defaults to ``[sys.argv[0]]``.
+        hash_algorithm (str, optional): Hash algorithm name accepted by
+            :func:`hashlib.new`. Defaults to ``'sha256'``. Use ``'md5'``
+            for faster hashing of large files where cryptographic strength
+            is not required.
+
+    Example output::
+
+        {
+            "file_hashes": {
+                "run_experiment.py": "e3b0c44298fc1c14..."
+            }
+        }
+    """
+
+    def capture_file_hashes(self, bm_data):
+        import hashlib
+
+        if hasattr(self, 'hash_files'):
+            paths = list(self.hash_files)
+        else:
+            argv0 = sys.argv[0] if sys.argv else ''
+            paths = [argv0] if argv0 and not argv0.startswith('-') else []
+
+        algorithm = getattr(self, 'hash_algorithm', 'sha256')
+        hashes = {}
+        for path in paths:
+            with open(path, 'rb') as f:
+                if hasattr(hashlib, 'file_digest'):
+                    # Python 3.11+: C-level loop, faster for large files
+                    hashes[path] = hashlib.file_digest(f, algorithm).hexdigest()
+                else:
+                    h = hashlib.new(algorithm)
+                    for chunk in iter(lambda: f.read(65536), b''):
+                        h.update(chunk)
+                    hashes[path] = h.hexdigest()
+        bm_data['file_hashes'] = hashes
 
 
 class MBGlobalPackages:

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 import os
+import sys
 import tempfile
 import threading
 import time
@@ -16,6 +17,7 @@ from microbench import (
     FileOutput,
     JSONEncoder,
     JSONEncodeWarning,
+    MBFileHash,
     MBFunctionCall,
     MBHostInfo,
     MBInstalledPackages,
@@ -758,3 +760,164 @@ def test_redis_output_multiple_results():
         results = bench.get_results()
         assert len(results) == 2
         assert list(results['function_name']) == ['func_a', 'func_b']
+
+
+# ---------------------------------------------------------------------------
+# MBFileHash
+# ---------------------------------------------------------------------------
+
+
+def test_mb_file_hash_specific_file(tmp_path):
+    """MBFileHash records the SHA-256 digest of a specified file."""
+    import hashlib
+
+    content = b'hello microbench'
+    target = tmp_path / 'data.txt'
+    target.write_bytes(content)
+
+    expected = hashlib.sha256(content).hexdigest()
+
+    class Bench(MicroBench, MBFileHash):
+        hash_files = [str(target)]
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results()
+    assert results['file_hashes'][0] == {str(target): expected}
+
+
+def test_mb_file_hash_multiple_files(tmp_path):
+    """MBFileHash records digests for all specified files."""
+    import hashlib
+
+    files = {}
+    for name in ('a.txt', 'b.txt'):
+        p = tmp_path / name
+        p.write_bytes(name.encode())
+        files[str(p)] = hashlib.sha256(name.encode()).hexdigest()
+
+    class Bench(MicroBench, MBFileHash):
+        hash_files = list(files.keys())
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results()
+    assert results['file_hashes'][0] == files
+
+
+def test_mb_file_hash_custom_algorithm(tmp_path):
+    """MBFileHash respects the hash_algorithm class attribute."""
+    import hashlib
+
+    content = b'test data'
+    target = tmp_path / 'script.py'
+    target.write_bytes(content)
+
+    expected = hashlib.md5(content).hexdigest()
+
+    class Bench(MicroBench, MBFileHash):
+        hash_files = [str(target)]
+        hash_algorithm = 'md5'
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results()
+    assert results['file_hashes'][0] == {str(target): expected}
+
+
+def test_mb_file_hash_default_uses_argv(tmp_path):
+    """MBFileHash defaults to sys.argv[0] when hash_files is not set."""
+    import hashlib
+
+    content = b'print("hello")'
+    script = tmp_path / 'run.py'
+    script.write_bytes(content)
+
+    expected = hashlib.sha256(content).hexdigest()
+
+    class Bench(MicroBench, MBFileHash):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch.object(sys, 'argv', [str(script)]):
+        noop()
+
+    results = bench.get_results()
+    assert results['file_hashes'][0] == {str(script): expected}
+
+
+def test_mb_file_hash_no_argv_empty(tmp_path):
+    """MBFileHash records an empty dict when sys.argv is empty."""
+
+    class Bench(MicroBench, MBFileHash):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch.object(sys, 'argv', []):
+        noop()
+
+    results = bench.get_results()
+    assert results['file_hashes'][0] == {}
+
+
+def test_mb_file_hash_interactive_argv_empty_string(tmp_path):
+    """MBFileHash records an empty dict in interactive Python (argv[0] == '')."""
+
+    class Bench(MicroBench, MBFileHash):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch.object(sys, 'argv', ['']):
+        noop()
+
+    results = bench.get_results()
+    assert results['file_hashes'][0] == {}
+
+
+def test_mb_file_hash_missing_file_raises(tmp_path):
+    """MBFileHash raises FileNotFoundError for a path that does not exist."""
+
+    class Bench(MicroBench, MBFileHash):
+        hash_files = [str(tmp_path / 'nonexistent.py')]
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with pytest.raises(FileNotFoundError):
+        noop()


### PR DESCRIPTION
## Summary

- Adds `MBFileHash` mixin that records cryptographic checksums of specified files in a `file_hashes` field
- Defaults to hashing `sys.argv[0]` (the running script); set `hash_files` to specify other paths
- `hash_algorithm` class attribute selects any `hashlib` algorithm (default: `'sha256'`)
- Uses `hashlib.file_digest` on Python ≥ 3.11 (C-level loop) with a 64 KB chunked fallback for 3.10
- No-ops gracefully in interactive Python (`sys.argv[0] == ''` or `sys.argv` empty)