### PR TITLE
feat: add python -m microbench CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **Command-line interface** (`python -m microbench`): wrap any external
+  command and record host metadata alongside timing without writing Python
+  code. Useful for SLURM jobs, shell scripts, and compiled executables.
+  Records `command` (full argument list) and `returncode` alongside the
+  standard timing fields. Use `--mixin` to select metadata to capture
+  (defaults to `MBHostInfo` and `MBSlurmInfo`); use `--field KEY=VALUE` to
+  attach extra labels. Capture failures are non-fatal by default
+  (`capture_optional = True`), making the CLI safe across heterogeneous
+  cluster nodes.
+
 - **`capture_optional` class attribute**: set `capture_optional = True` on
   a benchmark class to catch exceptions from `capture_` and `capturepost_`
   methods instead of aborting the benchmark call. Failures are recorded in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,16 @@ All notable changes to microbench are documented here.
 - **Command-line interface** (`python -m microbench`): wrap any external
   command and record host metadata alongside timing without writing Python
   code. Useful for SLURM jobs, shell scripts, and compiled executables.
-  Records `command` (full argument list) and `returncode` alongside the
-  standard timing fields. Use `--mixin` to select metadata to capture
-  (defaults to `MBHostInfo` and `MBSlurmInfo`); use `--field KEY=VALUE` to
-  attach extra labels; use `--iterations N` and `--warmup N` for repeat
-  timing. Capture failures are non-fatal by default (`capture_optional =
-  True`), making the CLI safe across heterogeneous cluster nodes. With
-  `--iterations`, `returncode` records the last non-zero exit code across
-  all iterations, or 0 if all succeeded.
+  Records `command`, `returncode` (list, one per timed iteration),
+  alongside the standard timing fields. Use `--mixin` to select metadata
+  to capture (defaults to `MBHostInfo` and `MBSlurmInfo`); use
+  `--field KEY=VALUE` to attach extra labels; use `--iterations N` and
+  `--warmup N` for repeat timing; use `--stdout[=suppress]` and
+  `--stderr[=suppress]` to capture subprocess output into the record
+  (output is re-printed to the terminal unless `=suppress` is given).
+  Capture failures are non-fatal by default (`capture_optional = True`),
+  making the CLI safe across heterogeneous cluster nodes. The process exits
+  with the highest returncode seen across all timed iterations.
 
 - **`capture_optional` class attribute**: set `capture_optional = True` on
   a benchmark class to catch exceptions from `capture_` and `capturepost_`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,11 @@ All notable changes to microbench are documented here.
   Records `command` (full argument list) and `returncode` alongside the
   standard timing fields. Use `--mixin` to select metadata to capture
   (defaults to `MBHostInfo` and `MBSlurmInfo`); use `--field KEY=VALUE` to
-  attach extra labels. Capture failures are non-fatal by default
-  (`capture_optional = True`), making the CLI safe across heterogeneous
-  cluster nodes.
+  attach extra labels; use `--iterations N` and `--warmup N` for repeat
+  timing. Capture failures are non-fatal by default (`capture_optional =
+  True`), making the CLI safe across heterogeneous cluster nodes. With
+  `--iterations`, `returncode` records the last non-zero exit code across
+  all iterations, or 0 if all succeeded.
 
 - **`capture_optional` class attribute**: set `capture_optional = True` on
   a benchmark class to catch exceptions from `capture_` and `capturepost_`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ result, the metadata shows exactly what was running.
 
 - **Zero-config timing** — decorate a function, get timestamps and run
   durations immediately, no setup required
+- **Command-line interface** — wrap any shell command, script, or compiled
+  executable with `python -m microbench -- COMMAND` and capture host
+  metadata alongside timing without writing Python code; ideal for SLURM
+  jobs
 - **Extensible via _mixins_** — capture Python version, hostname, CPU/RAM
   specs, conda/pip package versions, NVIDIA GPU info, line-level profiles,
   peak memory usage, and more by adding mixin classes
@@ -97,6 +101,22 @@ Constructor arguments:
 - `iterations=3` runs the function three times, recording all three durations.
 - `duration_counter` overrides the timer function, if you need precise timing.
 - `experiment='run-1'` adds a custom `experiment` field to every record.
+
+## Command-line interface
+
+Microbench can also wrap any external command and record metadata alongside
+timing, without writing Python code:
+
+```bash
+python -m microbench --outfile results.jsonl -- ./run_simulation.sh --steps 1000
+```
+
+This is useful for SLURM jobs, shell scripts, and compiled executables. Host
+info and SLURM variables are captured by default. Use `--mixin`, `--field`,
+`--iterations`, and `--warmup` to customise the run.
+
+See the [CLI documentation](https://alubbock.github.io/microbench/cli/) for
+the full option reference.
 
 ## Documentation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,109 @@
+# Command-line interface
+
+Microbench can wrap any external command and record host metadata
+alongside timing, without writing any Python code:
+
+```bash
+python -m microbench --outfile results.jsonl -- ./run_simulation.sh
+```
+
+This is particularly useful for SLURM jobs, shell scripts, or compiled
+executables where adding a Python decorator is not practical.
+
+## Usage
+
+```
+python -m microbench [options] -- COMMAND [ARGS...]
+```
+
+| Option | Description |
+|---|---|
+| `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
+| `--mixin MIXIN` / `-m MIXIN` | Mixin to include. Replaces defaults when specified. Can be repeated. |
+| `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
+
+Use `--` to separate microbench options from the command being benchmarked.
+
+## Fields recorded
+
+Every record contains the standard fields (`start_time`, `finish_time`,
+`run_durations`, etc.) plus:
+
+| Field | Description |
+|---|---|
+| `command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
+| `returncode` | Exit code of the command. |
+| `function_name` | Basename of the executable, e.g. `"run_sim.sh"`. |
+
+## Default mixins
+
+When no `--mixin` is specified, `MBHostInfo` and `MBSlurmInfo` are
+included automatically, capturing hostname, operating system, and all
+`SLURM_*` environment variables. This covers the most common cluster
+metadata with no configuration.
+
+Specifying `--mixin` replaces the defaults entirely:
+
+```bash
+# Only Python version — no host info or SLURM
+python -m microbench --mixin MBPythonVersion -- ./job.sh
+```
+
+Available mixins (those marked `cli_compatible`):
+`MBCondaPackages`, `MBFileHash`, `MBGitInfo`, `MBHostCpuCores`,
+`MBHostInfo`, `MBHostRamTotal`, `MBInstalledPackages`, `MBNvidiaSmi`,
+`MBPythonVersion`, `MBSlurmInfo`.
+
+See [Mixins](user-guide/mixins.md) for details on each.
+
+## Capture failures
+
+Metadata capture failures (e.g. `nvidia-smi` not installed on this node,
+script not in a git repository) are caught automatically and recorded in
+`mb_capture_errors` rather than aborting the run. This makes the CLI safe
+to use across heterogeneous cluster nodes.
+
+## SLURM example
+
+A typical SLURM job script:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=my-sim
+#SBATCH --output=slurm-%j.out
+
+python -m microbench \
+    --outfile /scratch/$USER/results.jsonl \
+    --mixin MBHostInfo \
+    --mixin MBSlurmInfo \
+    --mixin MBHostCpuCores \
+    --field experiment=baseline \
+    -- ./run_simulation.sh --steps 10000
+```
+
+Each node that runs this job appends one JSONL record to `results.jsonl`,
+capturing hostname, CPU count, and all SLURM variables (job ID, array task
+ID, node list, etc.) alongside the wall-clock time of the simulation.
+
+Read the results with pandas:
+
+```python
+import pandas
+results = pandas.read_json('/scratch/user/results.jsonl', lines=True)
+results['total_duration'] = results['run_durations'].apply(sum)
+results.groupby('slurm.job_id')['total_duration'].describe()
+```
+
+## Extra metadata
+
+Use `--field` to attach experiment labels or other fixed values:
+
+```bash
+python -m microbench \
+    --outfile results.jsonl \
+    --field experiment=ablation-1 \
+    --field dataset=large \
+    -- python train.py
+```
+
+All `--field` values are stored as strings.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ Every record contains the standard fields (`start_time`, `finish_time`,
 | Field | Description |
 |---|---|
 | `command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
-| `returncode` | Exit code of the command. |
+| `returncode` | Exit code of the command. With `--iterations`, this is the last non-zero exit code seen across all iterations, or 0 if all succeeded. |
 | `function_name` | Basename of the executable, e.g. `"run_sim.sh"`. |
 
 ## Default mixins

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,9 @@ python -m microbench [options] -- COMMAND [ARGS...]
 |---|---|
 | `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
 | `--mixin MIXIN` / `-m MIXIN` | Mixin to include. Replaces defaults when specified. Can be repeated. |
+| `--all` / `-a` | Include all available mixins. |
+| `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
+| `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 
 Use `--` to separate microbench options from the command being benchmarked.
@@ -93,6 +96,19 @@ results = pandas.read_json('/scratch/user/results.jsonl', lines=True)
 results['total_duration'] = results['run_durations'].apply(sum)
 results.groupby('slurm.job_id')['total_duration'].describe()
 ```
+
+## Repeated runs
+
+Use `--iterations` to run the command multiple times within a single record.
+This is useful when the command is short-lived and you want to amortise
+per-record overhead or reduce timing noise:
+
+```bash
+python -m microbench --iterations 10 --warmup 2 -- ./run_simulation.sh
+```
+
+`run_durations` will contain 10 entries. The 2 warmup runs are not timed and
+do not appear in the record.
 
 ## Extra metadata
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,8 @@ python -m microbench [options] -- COMMAND [ARGS...]
 | `--all` / `-a` | Include all available mixins. |
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
+| `--stdout[=suppress]` | Capture stdout into the record. Output is still shown on the terminal unless `=suppress` is given. |
+| `--stderr[=suppress]` | Capture stderr into the record. Output is still shown on the terminal unless `=suppress` is given. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 
 Use `--` to separate microbench options from the command being benchmarked.
@@ -35,7 +37,7 @@ Every record contains the standard fields (`start_time`, `finish_time`,
 | Field | Description |
 |---|---|
 | `command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
-| `returncode` | Exit code of the command. With `--iterations`, this is the last non-zero exit code seen across all iterations, or 0 if all succeeded. |
+| `returncode` | List of exit codes, one per timed iteration (warmup excluded). The process exits with the highest value. |
 | `function_name` | Basename of the executable, e.g. `"run_sim.sh"`. |
 
 ## Default mixins

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,7 @@ python -m microbench [options] -- COMMAND [ARGS...]
 | `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
 | `--mixin MIXIN` / `-m MIXIN` | Mixin to include. Replaces defaults when specified. Can be repeated. |
 | `--all` / `-a` | Include all available mixins. |
+| `--no-mixin` | Disable all mixins including defaults. Records only timing and command fields. |
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
 | `--stdout[=suppress]` | Capture stdout into the record. Output is still shown on the terminal unless `=suppress` is given. |
@@ -47,11 +48,15 @@ included automatically, capturing hostname, operating system, and all
 `SLURM_*` environment variables. This covers the most common cluster
 metadata with no configuration.
 
-Specifying `--mixin` replaces the defaults entirely:
+Specifying `--mixin` replaces the defaults entirely. Use `--no-mixin` to
+disable all mixins and record only timing and command fields:
 
 ```bash
 # Only Python version — no host info or SLURM
 python -m microbench --mixin MBPythonVersion -- ./job.sh
+
+# No mixins at all — timing and command only
+python -m microbench --no-mixin -- ./job.sh
 ```
 
 Available mixins (those marked `cli_compatible`):
@@ -109,8 +114,20 @@ per-record overhead or reduce timing noise:
 python -m microbench --iterations 10 --warmup 2 -- ./run_simulation.sh
 ```
 
-`run_durations` will contain 10 entries. The 2 warmup runs are not timed and
-do not appear in the record.
+With 10 iterations and 2 warmup runs, the record contains:
+
+- `run_durations` — list of 10 wall-clock durations in seconds
+- `returncode` — list of 10 exit codes (one per timed iteration)
+- `stdout` / `stderr` — list of 10 captured strings, if `--stdout`/`--stderr` is used
+
+Warmup runs are excluded from all three lists. The process exits with
+`max(returncode)` so any failing iteration propagates to the shell.
+
+To detect failed iterations when analysing results with pandas:
+
+```python
+results['any_failed'] = results['returncode'].apply(lambda rc: max(rc) != 0)
+```
 
 ## Extra metadata
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,3 +138,27 @@ results.groupby('mb_run_id')['total_duration'].describe()
 ```
 
 See the [pandas documentation](https://pandas.pydata.org/docs/) for more.
+
+## Benchmarking external commands
+
+Microbench can also wrap shell commands, scripts, and compiled executables
+without writing any Python code. This is useful for SLURM jobs or any
+workload where adding a Python decorator is not practical:
+
+```bash
+python -m microbench --outfile results.jsonl -- ./run_simulation.sh --steps 1000
+```
+
+Host information and SLURM environment variables are captured by default.
+Use `--field KEY=VALUE` to attach labels and `--iterations N` to run the
+command multiple times:
+
+```bash
+python -m microbench \
+    --outfile results.jsonl \
+    --field experiment=baseline \
+    --iterations 5 \
+    -- ./run_simulation.sh
+```
+
+See the [CLI reference](cli.md) for all options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ mixins.
 ## Key features
 
 - **Zero-config timing** — decorate a function and get start/finish timestamps and run durations immediately, with no setup
+- **Command-line interface** — wrap any shell command or compiled executable with `python -m microbench -- COMMAND` and capture host metadata alongside timing without writing Python code; ideal for SLURM jobs
 - **Extensible via mixins** — mix in exactly what you need: Python version, hostname, CPU/RAM specs, conda/pip packages, NVIDIA GPU info, line-level profiling, and more
 - **Cluster and HPC ready** — capture SLURM environment variables, psutil resource metrics, and run IDs for correlating results across nodes
 - **JSONL output** — one JSON object per call; load directly into pandas with `read_json(..., lines=True)`; no schema lock-in

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -1,5 +1,4 @@
 import base64
-import importlib
 import inspect
 import io
 import json
@@ -14,6 +13,7 @@ import sys
 import threading
 import time
 import types
+import uuid
 import warnings
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
@@ -46,6 +46,10 @@ except ImportError:
         __version__ = _version('microbench')
     except Exception:
         __version__ = 'unknown'
+
+# Generated once at import time; shared by all MicroBench instances in this
+# process, allowing records from independent bench suites to be correlated.
+_run_id = str(uuid.uuid4())
 
 __all__ = [
     # Core
@@ -282,6 +286,9 @@ class MicroBench:
         bm_data['timestamp_tz'] = str(self.tz)
         # Store duration counter function name
         bm_data['duration_counter'] = self._duration_counter.__name__
+        # Run ID and package version (added to every record automatically)
+        bm_data['mb_run_id'] = _run_id
+        bm_data['mb_version'] = __version__
 
         # Capture environment variables
         if hasattr(self, 'env_vars'):
@@ -501,6 +508,8 @@ class MBReturnValue:
 class MBPythonVersion:
     """Capture the Python version and location of the Python executable"""
 
+    cli_compatible = True
+
     def capture_python_version(self, bm_data):
         bm_data['python_version'] = platform.python_version()
 
@@ -510,6 +519,8 @@ class MBPythonVersion:
 
 class MBHostInfo:
     """Capture the hostname and operating system"""
+
+    cli_compatible = True
 
     def capture_hostname(self, bm_data):
         bm_data['hostname'] = socket.gethostname()
@@ -549,6 +560,8 @@ class MBSlurmInfo:
         }
     """
 
+    cli_compatible = True
+
     def capture_slurm(self, bm_data):
         bm_data['slurm'] = {
             k[6:].lower(): v for k, v in os.environ.items() if k.startswith('SLURM_')
@@ -586,6 +599,8 @@ class MBGitInfo:
             }
         }
     """
+
+    cli_compatible = True
 
     def capture_git_info(self, bm_data):
         if hasattr(self, 'git_repo'):
@@ -658,6 +673,8 @@ class MBFileHash:
         }
     """
 
+    cli_compatible = True
+
     def capture_file_hashes(self, bm_data):
         import hashlib
 
@@ -724,6 +741,7 @@ class MBCondaPackages:
             Defaults to ``False``.
     """
 
+    cli_compatible = True
     include_builds = True
     include_channels = False
 
@@ -758,9 +776,12 @@ class MBInstalledPackages:
             package under ``package_paths``. Defaults to ``False``.
     """
 
+    cli_compatible = True
     capture_paths = False
 
     def capture_packages(self, bm_data):
+        import importlib.metadata
+
         bm_data['package_versions'] = {}
         if self.capture_paths:
             bm_data['package_paths'] = {}
@@ -815,6 +836,8 @@ class _NeedsPsUtil:
 class MBHostCpuCores(_NeedsPsUtil):
     """Capture the number of logical CPU cores"""
 
+    cli_compatible = True
+
     def capture_cpu_cores(self, bm_data):
         self._check_psutil()
         bm_data['cpu_cores_logical'] = psutil.cpu_count(logical=True)
@@ -823,6 +846,8 @@ class MBHostCpuCores(_NeedsPsUtil):
 
 class MBHostRamTotal(_NeedsPsUtil):
     """Capture the total host RAM in bytes"""
+
+    cli_compatible = True
 
     def capture_total_ram(self, bm_data):
         self._check_psutil()
@@ -879,6 +904,7 @@ class MBNvidiaSmi:
             after a reboot). Omit to poll all installed GPUs.
     """
 
+    cli_compatible = True
     _nvidia_default_attributes = ('gpu_name', 'memory.total')
     _nvidia_gpu_regex = re.compile(r'^[0-9A-Za-z\-:]+$')
 

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -29,6 +29,8 @@ def _get_mixin_map():
 
 _DEFAULT_MIXINS = ('MBHostInfo', 'MBSlurmInfo')
 
+_CAPTURE_CHOICES = ('capture', 'suppress')
+
 
 def _build_parser(mixin_names):
     parser = argparse.ArgumentParser(
@@ -84,6 +86,30 @@ def _build_parser(mixin_names):
         help='Run N unrecorded warm-up calls before timing begins. Defaults to 0.',
     )
     parser.add_argument(
+        '--stdout',
+        nargs='?',
+        const='capture',
+        default=None,
+        metavar='suppress',
+        help=(
+            'Capture stdout into the record (one entry per iteration). '
+            'Output is still shown on the terminal by default; '
+            'use --stdout=suppress to hide it.'
+        ),
+    )
+    parser.add_argument(
+        '--stderr',
+        nargs='?',
+        const='capture',
+        default=None,
+        metavar='suppress',
+        help=(
+            'Capture stderr into the record (one entry per iteration). '
+            'Output is still shown on the terminal by default; '
+            'use --stderr=suppress to hide it.'
+        ),
+    )
+    parser.add_argument(
         '--field',
         '-f',
         action='append',
@@ -110,6 +136,13 @@ def main(argv=None):
     if not cmd:
         parser.error('No command specified.')
 
+    for flag, val in (('--stdout', args.stdout), ('--stderr', args.stderr)):
+        if val not in (None,) + _CAPTURE_CHOICES:
+            parser.error(
+                f'{flag}: invalid value {val!r}. '
+                f'Use {flag} to capture or {flag}=suppress to capture and suppress.'
+            )
+
     if args.all_mixins:
         mixin_names = sorted(mixin_map)
     elif args.mixins is not None:
@@ -128,9 +161,20 @@ def main(argv=None):
     from microbench import FileOutput, MicroBench
 
     class _MBSubprocessResult:
+        def capture_subprocess_reset(self, bm_data):
+            # Runs in pre_start_triggers: after warmup, before timed iterations.
+            # Discard any warmup results so only timed iterations are recorded.
+            self._subprocess_returncodes = []
+            self._subprocess_stdout = []
+            self._subprocess_stderr = []
+
         def capturepost_subprocess_result(self, bm_data):
             bm_data['command'] = self._subprocess_command
-            bm_data['returncode'] = self._subprocess_returncode
+            bm_data['returncode'] = self._subprocess_returncodes
+            if self._subprocess_stdout:
+                bm_data['stdout'] = self._subprocess_stdout
+            if self._subprocess_stderr:
+                bm_data['stderr'] = self._subprocess_stderr
 
     BenchClass = type(
         'CLIBench',
@@ -146,17 +190,38 @@ def main(argv=None):
         **extra_fields,
     )
     bench._subprocess_command = cmd
-    bench._subprocess_returncode = 0
+    bench._subprocess_returncodes = []
+    bench._subprocess_stdout = []
+    bench._subprocess_stderr = []
+
+    popen_kwargs = {}
+    if args.stdout in _CAPTURE_CHOICES:
+        popen_kwargs['stdout'] = subprocess.PIPE
+    if args.stderr in _CAPTURE_CHOICES:
+        popen_kwargs['stderr'] = subprocess.PIPE
+
+    # Hold references to the real streams before any patching in tests.
+    _real_stdout = sys.__stdout__
+    _real_stderr = sys.__stderr__
 
     def run():
-        result = subprocess.run(cmd)
-        if result.returncode != 0:
-            bench._subprocess_returncode = result.returncode
+        result = subprocess.run(cmd, **popen_kwargs)
+        bench._subprocess_returncodes.append(result.returncode)
+        if args.stdout in _CAPTURE_CHOICES:
+            out = result.stdout.decode(errors='replace') if result.stdout else ''
+            bench._subprocess_stdout.append(out)
+            if args.stdout == 'capture':
+                _real_stdout.write(out)
+        if args.stderr in _CAPTURE_CHOICES:
+            err = result.stderr.decode(errors='replace') if result.stderr else ''
+            bench._subprocess_stderr.append(err)
+            if args.stderr == 'capture':
+                _real_stderr.write(err)
 
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()
 
-    sys.exit(bench._subprocess_returncode or 0)
+    sys.exit(max(bench._subprocess_returncodes, default=0))
 
 
 if __name__ == '__main__':

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -32,6 +32,21 @@ _DEFAULT_MIXINS = ('MBHostInfo', 'MBSlurmInfo')
 _CAPTURE_CHOICES = ('capture', 'suppress')
 
 
+def _int_at_least(minimum):
+    """Return an argparse type function that accepts integers >= minimum."""
+
+    def _parse(value):
+        try:
+            ivalue = int(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f'{value!r} is not an integer')
+        if ivalue < minimum:
+            raise argparse.ArgumentTypeError(f'must be >= {minimum}, got {ivalue}')
+        return ivalue
+
+    return _parse
+
+
 def _build_parser(mixin_names):
     parser = argparse.ArgumentParser(
         prog='python -m microbench',
@@ -70,9 +85,15 @@ def _build_parser(mixin_names):
         help='Include all available mixins. Overrides --mixin.',
     )
     parser.add_argument(
+        '--no-mixin',
+        action='store_true',
+        dest='no_mixins',
+        help='Disable all mixins including defaults. Overrides --mixin.',
+    )
+    parser.add_argument(
         '--iterations',
         '-n',
-        type=int,
+        type=_int_at_least(1),
         default=1,
         metavar='N',
         help='Run the command N times, recording each duration. Defaults to 1.',
@@ -80,7 +101,7 @@ def _build_parser(mixin_names):
     parser.add_argument(
         '--warmup',
         '-w',
-        type=int,
+        type=_int_at_least(0),
         default=0,
         metavar='N',
         help='Run N unrecorded warm-up calls before timing begins. Defaults to 0.',
@@ -145,6 +166,8 @@ def main(argv=None):
 
     if args.all_mixins:
         mixin_names = sorted(mixin_map)
+    elif args.no_mixins:
+        mixin_names = []
     elif args.mixins is not None:
         mixin_names = args.mixins
     else:

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -1,0 +1,140 @@
+"""Command-line interface for microbench.
+
+Run an external command and record benchmark metadata:
+
+    python -m microbench [options] -- COMMAND [ARGS...]
+
+Results are written in JSONL format to stdout (default) or a file with
+--outfile. By default MBHostInfo and MBSlurmInfo are included; use
+--mixin to override.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def _get_mixin_map():
+    """Return {name: class} for all CLI-compatible mixins."""
+    import microbench as _mb
+
+    return {
+        name: getattr(_mb, name)
+        for name in _mb.__all__
+        if isinstance(getattr(_mb, name, None), type)
+        and getattr(getattr(_mb, name), 'cli_compatible', False)
+    }
+
+
+_DEFAULT_MIXINS = ('MBHostInfo', 'MBSlurmInfo')
+
+
+def _build_parser(mixin_names):
+    parser = argparse.ArgumentParser(
+        prog='python -m microbench',
+        description=(
+            'Run an external command and record benchmark metadata to JSONL.\n\n'
+            'By default captures MBHostInfo and MBSlurmInfo. '
+            'Specifying --mixin replaces the defaults. '
+            'Metadata capture failures are recorded in mb_capture_errors '
+            'rather than aborting the run.'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        '--outfile',
+        '-o',
+        metavar='FILE',
+        help='Append results to FILE (JSONL format). Defaults to stdout.',
+    )
+    parser.add_argument(
+        '--mixin',
+        '-m',
+        action='append',
+        dest='mixins',
+        metavar='MIXIN',
+        choices=sorted(mixin_names),
+        help=(
+            'Mixin to include. Replaces defaults when specified. '
+            'Can be repeated. Available: %(choices)s.'
+        ),
+    )
+    parser.add_argument(
+        '--all',
+        '-a',
+        action='store_true',
+        dest='all_mixins',
+        help='Include all available mixins. Overrides --mixin.',
+    )
+    parser.add_argument(
+        '--field',
+        '-f',
+        action='append',
+        dest='fields',
+        metavar='KEY=VALUE',
+        help='Extra metadata field added to every record. Can be repeated.',
+    )
+    parser.add_argument(
+        'command',
+        nargs=argparse.REMAINDER,
+        help='Command to benchmark (use -- to separate from microbench options).',
+    )
+    return parser
+
+
+def main(argv=None):
+    mixin_map = _get_mixin_map()
+    parser = _build_parser(mixin_map)
+    args = parser.parse_args(argv)
+
+    cmd = args.command
+    if cmd and cmd[0] == '--':
+        cmd = cmd[1:]
+    if not cmd:
+        parser.error('No command specified.')
+
+    if args.all_mixins:
+        mixin_names = sorted(mixin_map)
+    elif args.mixins is not None:
+        mixin_names = args.mixins
+    else:
+        mixin_names = list(_DEFAULT_MIXINS)
+    mixins = [mixin_map[name] for name in mixin_names]
+
+    extra_fields = {}
+    for field in args.fields or []:
+        if '=' not in field:
+            parser.error(f'Invalid --field: {field!r}. Use KEY=VALUE.')
+        k, v = field.split('=', 1)
+        extra_fields[k] = v
+
+    from microbench import FileOutput, MicroBench
+
+    class _MBSubprocessResult:
+        def capturepost_subprocess_result(self, bm_data):
+            bm_data['command'] = self._subprocess_command
+            bm_data['returncode'] = self._subprocess_returncode
+
+    BenchClass = type(
+        'CLIBench',
+        (MicroBench, _MBSubprocessResult, *mixins),
+        {'capture_optional': True},
+    )
+
+    output = FileOutput(args.outfile) if args.outfile else FileOutput(sys.stdout)
+    bench = BenchClass(outputs=[output], **extra_fields)
+    bench._subprocess_command = cmd
+
+    def run():
+        result = subprocess.run(cmd)
+        bench._subprocess_returncode = result.returncode
+
+    run.__name__ = os.path.basename(cmd[0])
+    bench(run)()
+
+    sys.exit(bench._subprocess_returncode or 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -146,10 +146,12 @@ def main(argv=None):
         **extra_fields,
     )
     bench._subprocess_command = cmd
+    bench._subprocess_returncode = 0
 
     def run():
         result = subprocess.run(cmd)
-        bench._subprocess_returncode = result.returncode
+        if result.returncode != 0:
+            bench._subprocess_returncode = result.returncode
 
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -68,6 +68,22 @@ def _build_parser(mixin_names):
         help='Include all available mixins. Overrides --mixin.',
     )
     parser.add_argument(
+        '--iterations',
+        '-n',
+        type=int,
+        default=1,
+        metavar='N',
+        help='Run the command N times, recording each duration. Defaults to 1.',
+    )
+    parser.add_argument(
+        '--warmup',
+        '-w',
+        type=int,
+        default=0,
+        metavar='N',
+        help='Run N unrecorded warm-up calls before timing begins. Defaults to 0.',
+    )
+    parser.add_argument(
         '--field',
         '-f',
         action='append',
@@ -123,7 +139,12 @@ def main(argv=None):
     )
 
     output = FileOutput(args.outfile) if args.outfile else FileOutput(sys.stdout)
-    bench = BenchClass(outputs=[output], **extra_fields)
+    bench = BenchClass(
+        outputs=[output],
+        iterations=args.iterations,
+        warmup=args.warmup,
+        **extra_fields,
+    )
     bench._subprocess_command = cmd
 
     def run():

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -353,6 +353,35 @@ def test_capture_packages_importlib():
     assert pandas.__version__ == results['package_versions'][0]['pandas']
 
 
+def test_capture_packages_self_imports_metadata():
+    """capture_packages imports importlib.metadata itself, not via prior imports."""
+    import sys
+
+    # Evict importlib.metadata so the method's own import statement is exercised.
+    # Without 'import importlib.metadata' inside capture_packages, this would raise
+    # AttributeError: module 'importlib' has no attribute 'metadata'.
+    saved = sys.modules.pop('importlib.metadata', None)
+    try:
+
+        class PkgBench(MicroBench, MBInstalledPackages):
+            pass
+
+        bench = PkgBench()
+
+        @bench
+        def noop():
+            pass
+
+        noop()
+
+        results = bench.get_results()
+        assert isinstance(results['package_versions'][0], dict)
+        assert len(results['package_versions'][0]) > 0
+    finally:
+        if saved is not None:
+            sys.modules['importlib.metadata'] = saved
+
+
 def test_monitor():
     class MonitorBench(MicroBench):
         @staticmethod

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -35,6 +35,55 @@ from microbench import __version__ as microbench_version
 from .globals_capture import globals_bench
 
 
+def test_mb_run_id_and_version():
+    """Every record contains mb_run_id (UUID) and mb_version."""
+    import re
+
+    import microbench
+
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+    noop()
+
+    results = bench.get_results()
+
+    # mb_run_id is a valid UUID and consistent across calls
+    uuid_re = re.compile(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    )
+    assert results['mb_run_id'].nunique() == 1
+    assert uuid_re.match(results['mb_run_id'][0])
+
+    # mb_version matches the installed package version
+    assert (results['mb_version'] == microbench.__version__).all()
+
+
+def test_mb_run_id_shared_across_instances():
+    """All MicroBench instances in the same process share the same mb_run_id."""
+    bench_a = MicroBench()
+    bench_b = MicroBench()
+
+    @bench_a
+    def func_a():
+        pass
+
+    @bench_b
+    def func_b():
+        pass
+
+    func_a()
+    func_b()
+
+    run_id_a = bench_a.get_results()['mb_run_id'][0]
+    run_id_b = bench_b.get_results()['mb_run_id'][0]
+    assert run_id_a == run_id_b
+
+
 def test_function():
     class MyBench(MicroBench, MBFunctionCall, MBPythonVersion, MBHostInfo):
         capture_versions = (pandas, io)

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -11,6 +11,8 @@ def _run_main(argv, mock_returncode=0):
     """Run main() with a mocked subprocess and captured stdout."""
     mock_result = MagicMock()
     mock_result.returncode = mock_returncode
+    mock_result.stdout = None
+    mock_result.stderr = None
 
     buf = io.StringIO()
     with patch('subprocess.run', return_value=mock_result) as mock_run:
@@ -26,7 +28,7 @@ def test_cli_records_command_and_timing():
 
     assert code == 0
     assert record['command'] == ['sleep', '1']
-    assert record['returncode'] == 0
+    assert record['returncode'] == [0]
     assert 'start_time' in record
     assert 'finish_time' in record
     assert 'run_durations' in record
@@ -38,7 +40,7 @@ def test_cli_nonzero_returncode():
     code, record, _ = _run_main(['--', 'false'], mock_returncode=1)
 
     assert code == 1
-    assert record['returncode'] == 1
+    assert record['returncode'] == [1]
 
 
 def test_cli_custom_field():
@@ -88,6 +90,8 @@ def test_cli_outfile(tmp_path):
     outfile = tmp_path / 'results.jsonl'
     mock_result = MagicMock()
     mock_result.returncode = 0
+    mock_result.stdout = None
+    mock_result.stderr = None
 
     with patch('subprocess.run', return_value=mock_result):
         with pytest.raises(SystemExit):
@@ -95,7 +99,7 @@ def test_cli_outfile(tmp_path):
 
     record = json.loads(outfile.read_text())
     assert record['command'] == ['true']
-    assert record['returncode'] == 0
+    assert record['returncode'] == [0]
 
 
 def test_cli_no_command_exits_with_error():
@@ -170,6 +174,7 @@ def test_cli_iterations():
 
     assert mock_run.call_count == 3
     assert len(record['run_durations']) == 3
+    assert len(record['returncode']) == 3
 
 
 def test_cli_warmup():
@@ -179,6 +184,7 @@ def test_cli_warmup():
     # 2 warmup calls + 1 timed call
     assert mock_run.call_count == 3
     assert len(record['run_durations']) == 1
+    assert len(record['returncode']) == 1
 
 
 def test_cli_iterations_and_warmup():
@@ -189,20 +195,24 @@ def test_cli_iterations_and_warmup():
 
     assert mock_run.call_count == 6
     assert len(record['run_durations']) == 4
+    assert len(record['returncode']) == 4
 
 
-def test_cli_iterations_returncode_latches_failure():
-    """With --iterations, a failing run is not masked by later successful runs."""
-    mock_results = [MagicMock(returncode=1), MagicMock(returncode=0)]
+def test_cli_returncode_is_max_across_iterations():
+    """Process exits with the highest returncode seen across all iterations."""
+    mock_results = [
+        MagicMock(returncode=0, stdout=None, stderr=None),
+        MagicMock(returncode=2, stdout=None, stderr=None),
+        MagicMock(returncode=1, stdout=None, stderr=None),
+    ]
     buf = io.StringIO()
-    with patch('subprocess.run', side_effect=mock_results) as mock_run:
+    with patch('subprocess.run', side_effect=mock_results):
         with patch('sys.stdout', buf):
             with pytest.raises(SystemExit) as exc:
-                main(['--iterations', '2', '--', 'true'])
+                main(['--iterations', '3', '--', 'true'])
 
-    assert exc.value.code == 1
-    assert json.loads(buf.getvalue())['returncode'] == 1
-    assert mock_run.call_count == 2
+    assert exc.value.code == 2
+    assert json.loads(buf.getvalue())['returncode'] == [0, 2, 1]
 
 
 def test_cli_multiple_mixins():
@@ -254,3 +264,146 @@ def test_cli_field_values_are_strings():
     assert isinstance(record['count'], str)
     assert record['ratio'] == '3.14'
     assert isinstance(record['ratio'], str)
+
+
+def test_cli_no_stdout_capture_by_default():
+    """stdout and stderr fields are absent unless --stdout/--stderr are given."""
+    _, record, _ = _run_main(['--', 'echo', 'hello'])
+
+    assert 'stdout' not in record
+    assert 'stderr' not in record
+
+
+def test_cli_capture_stdout_records_output():
+    """--stdout records subprocess stdout as a list and re-prints to terminal."""
+    import subprocess as _subprocess
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = b'hello\n'
+    mock_result.stderr = None
+
+    buf = io.StringIO()
+    terminal = io.StringIO()
+    with patch('subprocess.run', return_value=mock_result) as mock_run:
+        with patch('sys.stdout', buf):
+            with patch('sys.__stdout__', terminal):
+                with pytest.raises(SystemExit):
+                    main(['--stdout', '--', 'echo', 'hello'])
+
+    record = json.loads(buf.getvalue())
+    assert record['stdout'] == ['hello\n']
+    assert 'stderr' not in record
+    assert terminal.getvalue() == 'hello\n'
+    assert mock_run.call_args[1].get('stdout') == _subprocess.PIPE
+
+
+def test_cli_capture_stdout_suppress():
+    """--stdout=suppress records output without re-printing to terminal."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = b'hello\n'
+    mock_result.stderr = None
+
+    buf = io.StringIO()
+    terminal = io.StringIO()
+    with patch('subprocess.run', return_value=mock_result):
+        with patch('sys.stdout', buf):
+            with patch('sys.__stdout__', terminal):
+                with pytest.raises(SystemExit):
+                    main(['--stdout=suppress', '--', 'echo', 'hello'])
+
+    record = json.loads(buf.getvalue())
+    assert record['stdout'] == ['hello\n']
+    assert terminal.getvalue() == ''  # nothing re-printed
+
+
+def test_cli_capture_stderr_records_output():
+    """--stderr records subprocess stderr as a list and re-prints to terminal."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = None
+    mock_result.stderr = b'warning\n'
+
+    buf = io.StringIO()
+    terminal_err = io.StringIO()
+    with patch('subprocess.run', return_value=mock_result):
+        with patch('sys.stdout', buf):
+            with patch('sys.__stderr__', terminal_err):
+                with pytest.raises(SystemExit):
+                    main(['--stderr', '--', 'cmd'])
+
+    record = json.loads(buf.getvalue())
+    assert record['stderr'] == ['warning\n']
+    assert 'stdout' not in record
+    assert terminal_err.getvalue() == 'warning\n'
+
+
+def test_cli_capture_stderr_suppress():
+    """--stderr=suppress records stderr without re-printing."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = None
+    mock_result.stderr = b'warning\n'
+
+    buf = io.StringIO()
+    terminal_err = io.StringIO()
+    with patch('subprocess.run', return_value=mock_result):
+        with patch('sys.stdout', buf):
+            with patch('sys.__stderr__', terminal_err):
+                with pytest.raises(SystemExit):
+                    main(['--stderr=suppress', '--', 'cmd'])
+
+    record = json.loads(buf.getvalue())
+    assert record['stderr'] == ['warning\n']
+    assert terminal_err.getvalue() == ''
+
+
+def test_cli_capture_stdout_multiple_iterations():
+    """With --iterations, stdout has one entry per timed iteration (warmup excluded)."""
+    mock_results = [
+        MagicMock(returncode=0, stdout=b'warmup\n', stderr=None),  # warmup
+        MagicMock(returncode=0, stdout=b'run1\n', stderr=None),
+        MagicMock(returncode=0, stdout=b'run2\n', stderr=None),
+        MagicMock(returncode=0, stdout=b'run3\n', stderr=None),
+    ]
+
+    buf = io.StringIO()
+    with patch('subprocess.run', side_effect=mock_results):
+        with patch('sys.stdout', buf):
+            with patch('sys.__stdout__', io.StringIO()):
+                with pytest.raises(SystemExit):
+                    main(
+                        ['--stdout', '--warmup', '1', '--iterations', '3', '--', 'cmd']
+                    )
+
+    record = json.loads(buf.getvalue())
+    assert record['stdout'] == ['run1\n', 'run2\n', 'run3\n']
+    assert len(record['stdout']) == len(record['run_durations'])
+
+
+def test_cli_capture_stdout_and_stderr():
+    """--stdout and --stderr can be used together."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = b'out\n'
+    mock_result.stderr = b'err\n'
+
+    buf = io.StringIO()
+    with patch('subprocess.run', return_value=mock_result):
+        with patch('sys.stdout', buf):
+            with patch('sys.__stdout__', io.StringIO()):
+                with patch('sys.__stderr__', io.StringIO()):
+                    with pytest.raises(SystemExit):
+                        main(['--stdout', '--stderr', '--', 'cmd'])
+
+    record = json.loads(buf.getvalue())
+    assert record['stdout'] == ['out\n']
+    assert record['stderr'] == ['err\n']
+
+
+def test_cli_capture_invalid_value():
+    """--stdout=invalid exits non-zero."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--stdout=invalid', '--', 'cmd'])
+    assert exc.value.code != 0

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -162,3 +162,30 @@ def test_cli_double_dash_separator():
     mock_run.assert_called_once()
     called_cmd = mock_run.call_args[0][0]
     assert called_cmd == ['echo', 'hello']
+
+
+def test_cli_iterations():
+    """--iterations N runs the command N times and produces N run_durations entries."""
+    _, record, mock_run = _run_main(['--iterations', '3', '--', 'true'])
+
+    assert mock_run.call_count == 3
+    assert len(record['run_durations']) == 3
+
+
+def test_cli_warmup():
+    """--warmup N runs the command N extra times before timing begins."""
+    _, record, mock_run = _run_main(['--warmup', '2', '--', 'true'])
+
+    # 2 warmup calls + 1 timed call
+    assert mock_run.call_count == 3
+    assert len(record['run_durations']) == 1
+
+
+def test_cli_iterations_and_warmup():
+    """--iterations and --warmup together produce the right call count."""
+    _, record, mock_run = _run_main(
+        ['--iterations', '4', '--warmup', '2', '--', 'true']
+    )
+
+    assert mock_run.call_count == 6
+    assert len(record['run_durations']) == 4

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -1,0 +1,164 @@
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from microbench.__main__ import main
+
+
+def _run_main(argv, mock_returncode=0):
+    """Run main() with a mocked subprocess and captured stdout."""
+    mock_result = MagicMock()
+    mock_result.returncode = mock_returncode
+
+    buf = io.StringIO()
+    with patch('subprocess.run', return_value=mock_result) as mock_run:
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit) as exc:
+                main(argv)
+    return exc.value.code, json.loads(buf.getvalue()), mock_run
+
+
+def test_cli_records_command_and_timing():
+    """CLI records command list, returncode, and standard timing fields."""
+    code, record, _ = _run_main(['--', 'sleep', '1'])
+
+    assert code == 0
+    assert record['command'] == ['sleep', '1']
+    assert record['returncode'] == 0
+    assert 'start_time' in record
+    assert 'finish_time' in record
+    assert 'run_durations' in record
+    assert record['function_name'] == 'sleep'
+
+
+def test_cli_nonzero_returncode():
+    """CLI exits with the subprocess returncode."""
+    code, record, _ = _run_main(['--', 'false'], mock_returncode=1)
+
+    assert code == 1
+    assert record['returncode'] == 1
+
+
+def test_cli_custom_field():
+    """--field KEY=VALUE adds metadata to every record."""
+    _, record, _ = _run_main(['--field', 'experiment=run-1', '--', 'true'])
+
+    assert record['experiment'] == 'run-1'
+
+
+def test_cli_multiple_fields():
+    """Multiple --field flags all appear in the record."""
+    _, record, _ = _run_main(
+        ['--field', 'experiment=run-1', '--field', 'trial=3', '--', 'true']
+    )
+
+    assert record['experiment'] == 'run-1'
+    assert record['trial'] == '3'
+
+
+def test_cli_default_mixins_include_host_info():
+    """Default configuration includes MBHostInfo fields."""
+    _, record, _ = _run_main(['--', 'true'])
+
+    assert 'hostname' in record
+    assert 'operating_system' in record
+
+
+def test_cli_default_mixins_include_slurm():
+    """Default configuration includes MBSlurmInfo (slurm field)."""
+    _, record, _ = _run_main(['--', 'true'])
+
+    assert 'slurm' in record
+
+
+def test_cli_explicit_mixin_replaces_defaults():
+    """Specifying --mixin replaces the default mixin set."""
+    _, record, _ = _run_main(['--mixin', 'MBPythonVersion', '--', 'true'])
+
+    assert 'python_version' in record
+    # Default mixins should not be present
+    assert 'hostname' not in record
+    assert 'slurm' not in record
+
+
+def test_cli_outfile(tmp_path):
+    """--outfile writes JSONL to the specified file."""
+    outfile = tmp_path / 'results.jsonl'
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('subprocess.run', return_value=mock_result):
+        with pytest.raises(SystemExit):
+            main(['--outfile', str(outfile), '--', 'true'])
+
+    record = json.loads(outfile.read_text())
+    assert record['command'] == ['true']
+    assert record['returncode'] == 0
+
+
+def test_cli_no_command_exits_with_error():
+    """Omitting the command prints an error and exits non-zero."""
+    with pytest.raises(SystemExit) as exc:
+        main([])
+    assert exc.value.code != 0
+
+
+def test_cli_capture_optional_on_by_default():
+    """Capture failures are recorded in mb_capture_errors, not raised."""
+
+    def bad_capture(self, bm_data):
+        raise RuntimeError('simulated capture failure')
+
+    from microbench import MBHostInfo
+
+    with patch.object(MBHostInfo, 'capture_hostname', bad_capture):
+        _, record, _ = _run_main(['--mixin', 'MBHostInfo', '--', 'true'])
+
+    assert 'mb_capture_errors' in record
+    assert any('capture_hostname' in e['method'] for e in record['mb_capture_errors'])
+
+
+def test_cli_all_flag_includes_all_mixins():
+    """--all includes every cli_compatible mixin."""
+    from microbench.__main__ import _get_mixin_map
+
+    all_names = set(_get_mixin_map())
+
+    # Patch every mixin's capture methods to no-ops to avoid external calls
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        buf = io.StringIO()
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit):
+                with patch('subprocess.check_output', side_effect=Exception('skip')):
+                    main(['--all', '--', 'true'])
+
+    # At minimum the record should be written (even with capture_optional errors)
+    record = json.loads(buf.getvalue())
+    assert 'command' in record
+    assert len(all_names) > 2  # sanity: more than just defaults
+
+
+def test_cli_includes_mb_run_id_and_version():
+    """CLI records mb_run_id and mb_version in every record."""
+    import re
+
+    import microbench
+
+    _, record, _ = _run_main(['--', 'true'])
+
+    uuid_re = re.compile(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    )
+    assert uuid_re.match(record['mb_run_id'])
+    assert record['mb_version'] == microbench.__version__
+
+
+def test_cli_double_dash_separator():
+    """-- separator is stripped before passing the command to subprocess."""
+    _, _, mock_run = _run_main(['--', 'echo', 'hello'])
+
+    mock_run.assert_called_once()
+    called_cmd = mock_run.call_args[0][0]
+    assert called_cmd == ['echo', 'hello']

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -189,3 +189,68 @@ def test_cli_iterations_and_warmup():
 
     assert mock_run.call_count == 6
     assert len(record['run_durations']) == 4
+
+
+def test_cli_iterations_returncode_latches_failure():
+    """With --iterations, a failing run is not masked by later successful runs."""
+    mock_results = [MagicMock(returncode=1), MagicMock(returncode=0)]
+    buf = io.StringIO()
+    with patch('subprocess.run', side_effect=mock_results) as mock_run:
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit) as exc:
+                main(['--iterations', '2', '--', 'true'])
+
+    assert exc.value.code == 1
+    assert json.loads(buf.getvalue())['returncode'] == 1
+    assert mock_run.call_count == 2
+
+
+def test_cli_multiple_mixins():
+    """Multiple --mixin flags all take effect."""
+    _, record, _ = _run_main(
+        ['--mixin', 'MBHostInfo', '--mixin', 'MBPythonVersion', '--', 'true']
+    )
+
+    assert 'hostname' in record
+    assert 'python_version' in record
+
+
+def test_cli_all_overrides_mixin():
+    """--all takes precedence over --mixin."""
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        buf = io.StringIO()
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit):
+                with patch('subprocess.check_output', side_effect=Exception('skip')):
+                    main(['--mixin', 'MBHostInfo', '--all', '--', 'true'])
+
+    record = json.loads(buf.getvalue())
+    # --all should activate every mixin, so slurm (from MBSlurmInfo) must be present
+    # even though --mixin only listed MBHostInfo
+    assert 'slurm' in record
+
+
+def test_cli_field_invalid_format():
+    """--field without = exits non-zero."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--field', 'no-equals', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_field_value_with_equals():
+    """--field preserves = characters in the value."""
+    _, record, _ = _run_main(['--field', 'url=a=b=c', '--', 'true'])
+
+    assert record['url'] == 'a=b=c'
+
+
+def test_cli_field_values_are_strings():
+    """--field values are always stored as strings, not coerced to other types."""
+    _, record, _ = _run_main(
+        ['--field', 'count=42', '--field', 'ratio=3.14', '--', 'true']
+    )
+
+    assert record['count'] == '42'
+    assert isinstance(record['count'], str)
+    assert record['ratio'] == '3.14'
+    assert isinstance(record['ratio'], str)

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -407,3 +407,44 @@ def test_cli_capture_invalid_value():
     with pytest.raises(SystemExit) as exc:
         main(['--stdout=invalid', '--', 'cmd'])
     assert exc.value.code != 0
+
+
+def test_cli_iterations_zero_exits_error():
+    """--iterations 0 is rejected."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--iterations', '0', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_iterations_negative_exits_error():
+    """--iterations -1 is rejected."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--iterations', '-1', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_warmup_negative_exits_error():
+    """--warmup -1 is rejected."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--warmup', '-1', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_no_mixin_omits_all_metadata():
+    """--no-mixin produces a record with no mixin fields."""
+    _, record, _ = _run_main(['--no-mixin', '--', 'true'])
+
+    assert 'hostname' not in record
+    assert 'slurm' not in record
+    assert 'python_version' not in record
+    # Core fields still present
+    assert 'command' in record
+    assert 'returncode' in record
+    assert 'run_durations' in record
+
+
+def test_cli_no_mixin_overrides_mixin():
+    """--no-mixin takes precedence over --mixin."""
+    _, record, _ = _run_main(['--no-mixin', '--mixin', 'MBHostInfo', '--', 'true'])
+
+    assert 'hostname' not in record

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ extra:
 nav:
   - Home: index.md
   - Getting started: getting-started.md
+  - Command-line interface: cli.md
   - User guide:
     - Configuration: user-guide/configuration.md
     - Mixins: user-guide/mixins.md


### PR DESCRIPTION
## Summary

- Adds `python -m microbench [options] -- COMMAND [ARGS...]` for wrapping external commands (shell scripts, compiled executables, SLURM jobs) without writing Python
- Captures timing, host metadata, and returncode as JSONL to stdout or `--outfile`
- Mixin selection via `--mixin NAME` (replaces defaults) or `--all`; mixins opt in via `cli_compatible = True`
- Extra labels via `--field KEY=VALUE`
- `capture_optional = True` baked in so missing tools (nvidia-smi, git, etc.) don't abort the run
- Fixes `AttributeError` in `MBInstalledPackages` (`importlib.metadata` submodule not auto-imported)
- Restores `mb_run_id` and `mb_version` fields lost in the v1.x merge
- 13 new CLI tests + `mb_run_id`/`mb_version` tests
- New `docs/cli.md` page with SLURM example, field reference, and capture-failure behaviour