### PR TITLE
feat: stream --stdout/--stderr to terminal in real time

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,8 +24,8 @@ python -m microbench [options] -- COMMAND [ARGS...]
 | `--no-mixin` | Disable all mixins including defaults. Records only timing and command fields. |
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
-| `--stdout[=suppress]` | Capture stdout into the record. Output is still shown on the terminal unless `=suppress` is given. |
-| `--stderr[=suppress]` | Capture stderr into the record. Output is still shown on the terminal unless `=suppress` is given. |
+| `--stdout[=suppress]` | Capture stdout into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
+| `--stderr[=suppress]` | Capture stderr into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 
 Use `--` to separate microbench options from the command being benchmarked.
@@ -123,6 +123,18 @@ With 10 iterations and 2 warmup runs, the record contains:
 
 Warmup runs are excluded from all three lists. The process exits with
 `max(returncode)` so any failing iteration propagates to the shell.
+
+!!! note "Subprocess-side buffering"
+    When stdout or stderr is captured via a pipe, many programs switch from
+    line-buffered to block-buffered mode because they detect they are not
+    writing to a TTY. Output will still stream to the terminal in real time
+    from microbench's perspective, but the subprocess itself may batch writes
+    into larger chunks. Use `stdbuf -oL` (Linux) or the program's own
+    unbuffering flag (e.g. `python -u`) if you need per-line flushing:
+
+    ```bash
+    python -m microbench --stdout -- stdbuf -oL ./run_simulation.sh
+    ```
 
 To detect failed iterations when analysing results with pandas:
 

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -13,6 +13,7 @@ import argparse
 import os
 import subprocess
 import sys
+import threading
 
 
 def _get_mixin_map():
@@ -217,29 +218,75 @@ def main(argv=None):
     bench._subprocess_stdout = []
     bench._subprocess_stderr = []
 
-    popen_kwargs = {}
-    if args.stdout in _CAPTURE_CHOICES:
-        popen_kwargs['stdout'] = subprocess.PIPE
-    if args.stderr in _CAPTURE_CHOICES:
-        popen_kwargs['stderr'] = subprocess.PIPE
-
     # Hold references to the real streams before any patching in tests.
     _real_stdout = sys.__stdout__
     _real_stderr = sys.__stderr__
 
     def run():
-        result = subprocess.run(cmd, **popen_kwargs)
-        bench._subprocess_returncodes.append(result.returncode)
-        if args.stdout in _CAPTURE_CHOICES:
-            out = result.stdout.decode(errors='replace') if result.stdout else ''
-            bench._subprocess_stdout.append(out)
-            if args.stdout == 'capture':
-                _real_stdout.write(out)
-        if args.stderr in _CAPTURE_CHOICES:
-            err = result.stderr.decode(errors='replace') if result.stderr else ''
-            bench._subprocess_stderr.append(err)
-            if args.stderr == 'capture':
-                _real_stderr.write(err)
+        capture_stdout = args.stdout in _CAPTURE_CHOICES
+        capture_stderr = args.stderr in _CAPTURE_CHOICES
+
+        if not capture_stdout and not capture_stderr:
+            result = subprocess.run(cmd)
+            bench._subprocess_returncodes.append(result.returncode)
+            return
+
+        # Use Popen with per-pipe reader threads so output is forwarded to
+        # the terminal in real time rather than buffered until the process exits.
+        stdout_chunks = []
+        stderr_chunks = []
+
+        def _reader(pipe, chunks, real_stream, passthrough):
+            for line in pipe:
+                chunk = line.decode(errors='replace')
+                chunks.append(chunk)
+                if passthrough:
+                    real_stream.write(chunk)
+                    real_stream.flush()
+
+        popen_kwargs = {}
+        if capture_stdout:
+            popen_kwargs['stdout'] = subprocess.PIPE
+        if capture_stderr:
+            popen_kwargs['stderr'] = subprocess.PIPE
+
+        with subprocess.Popen(cmd, **popen_kwargs) as proc:
+            threads = []
+            if capture_stdout:
+                t = threading.Thread(
+                    target=_reader,
+                    args=(
+                        proc.stdout,
+                        stdout_chunks,
+                        _real_stdout,
+                        args.stdout == 'capture',
+                    ),
+                    daemon=True,
+                )
+                t.start()
+                threads.append(t)
+            if capture_stderr:
+                t = threading.Thread(
+                    target=_reader,
+                    args=(
+                        proc.stderr,
+                        stderr_chunks,
+                        _real_stderr,
+                        args.stderr == 'capture',
+                    ),
+                    daemon=True,
+                )
+                t.start()
+                threads.append(t)
+            proc.wait()
+            for t in threads:
+                t.join()
+
+        bench._subprocess_returncodes.append(proc.returncode)
+        if capture_stdout:
+            bench._subprocess_stdout.append(''.join(stdout_chunks))
+        if capture_stderr:
+            bench._subprocess_stderr.append(''.join(stderr_chunks))
 
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -1,10 +1,22 @@
 import io
 import json
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from microbench.__main__ import main
+
+
+def _make_mock_popen(returncode=0, stdout_lines=None, stderr_lines=None):
+    """Create a mock Popen process for --stdout/--stderr capture tests."""
+    mock_proc = MagicMock()
+    mock_proc.__enter__.return_value = mock_proc
+    mock_proc.__exit__.return_value = False
+    mock_proc.returncode = returncode
+    mock_proc.stdout = iter(stdout_lines) if stdout_lines is not None else None
+    mock_proc.stderr = iter(stderr_lines) if stderr_lines is not None else None
+    return mock_proc
 
 
 def _run_main(argv, mock_returncode=0):
@@ -283,16 +295,11 @@ def test_cli_no_stdout_capture_by_default():
 
 def test_cli_capture_stdout_records_output():
     """--stdout records subprocess stdout as a list and re-prints to terminal."""
-    import subprocess as _subprocess
-
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = b'hello\n'
-    mock_result.stderr = None
+    mock_proc = _make_mock_popen(returncode=0, stdout_lines=[b'hello\n'])
 
     buf = io.StringIO()
     terminal = io.StringIO()
-    with patch('subprocess.run', return_value=mock_result) as mock_run:
+    with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
         with patch('sys.stdout', buf):
             with patch('sys.__stdout__', terminal):
                 with pytest.raises(SystemExit):
@@ -302,19 +309,16 @@ def test_cli_capture_stdout_records_output():
     assert record['stdout'] == ['hello\n']
     assert 'stderr' not in record
     assert terminal.getvalue() == 'hello\n'
-    assert mock_run.call_args[1].get('stdout') == _subprocess.PIPE
+    assert mock_popen.call_args[1].get('stdout') == subprocess.PIPE
 
 
 def test_cli_capture_stdout_suppress():
     """--stdout=suppress records output without re-printing to terminal."""
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = b'hello\n'
-    mock_result.stderr = None
+    mock_proc = _make_mock_popen(returncode=0, stdout_lines=[b'hello\n'])
 
     buf = io.StringIO()
     terminal = io.StringIO()
-    with patch('subprocess.run', return_value=mock_result):
+    with patch('subprocess.Popen', return_value=mock_proc):
         with patch('sys.stdout', buf):
             with patch('sys.__stdout__', terminal):
                 with pytest.raises(SystemExit):
@@ -327,14 +331,11 @@ def test_cli_capture_stdout_suppress():
 
 def test_cli_capture_stderr_records_output():
     """--stderr records subprocess stderr as a list and re-prints to terminal."""
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = None
-    mock_result.stderr = b'warning\n'
+    mock_proc = _make_mock_popen(returncode=0, stderr_lines=[b'warning\n'])
 
     buf = io.StringIO()
     terminal_err = io.StringIO()
-    with patch('subprocess.run', return_value=mock_result):
+    with patch('subprocess.Popen', return_value=mock_proc):
         with patch('sys.stdout', buf):
             with patch('sys.__stderr__', terminal_err):
                 with pytest.raises(SystemExit):
@@ -348,14 +349,11 @@ def test_cli_capture_stderr_records_output():
 
 def test_cli_capture_stderr_suppress():
     """--stderr=suppress records stderr without re-printing."""
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = None
-    mock_result.stderr = b'warning\n'
+    mock_proc = _make_mock_popen(returncode=0, stderr_lines=[b'warning\n'])
 
     buf = io.StringIO()
     terminal_err = io.StringIO()
-    with patch('subprocess.run', return_value=mock_result):
+    with patch('subprocess.Popen', return_value=mock_proc):
         with patch('sys.stdout', buf):
             with patch('sys.__stderr__', terminal_err):
                 with pytest.raises(SystemExit):
@@ -368,15 +366,15 @@ def test_cli_capture_stderr_suppress():
 
 def test_cli_capture_stdout_multiple_iterations():
     """With --iterations, stdout has one entry per timed iteration (warmup excluded)."""
-    mock_results = [
-        MagicMock(returncode=0, stdout=b'warmup\n', stderr=None),  # warmup
-        MagicMock(returncode=0, stdout=b'run1\n', stderr=None),
-        MagicMock(returncode=0, stdout=b'run2\n', stderr=None),
-        MagicMock(returncode=0, stdout=b'run3\n', stderr=None),
+    mock_procs = [
+        _make_mock_popen(returncode=0, stdout_lines=[b'warmup\n']),  # warmup
+        _make_mock_popen(returncode=0, stdout_lines=[b'run1\n']),
+        _make_mock_popen(returncode=0, stdout_lines=[b'run2\n']),
+        _make_mock_popen(returncode=0, stdout_lines=[b'run3\n']),
     ]
 
     buf = io.StringIO()
-    with patch('subprocess.run', side_effect=mock_results):
+    with patch('subprocess.Popen', side_effect=mock_procs):
         with patch('sys.stdout', buf):
             with patch('sys.__stdout__', io.StringIO()):
                 with pytest.raises(SystemExit):
@@ -391,13 +389,12 @@ def test_cli_capture_stdout_multiple_iterations():
 
 def test_cli_capture_stdout_and_stderr():
     """--stdout and --stderr can be used together."""
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = b'out\n'
-    mock_result.stderr = b'err\n'
+    mock_proc = _make_mock_popen(
+        returncode=0, stdout_lines=[b'out\n'], stderr_lines=[b'err\n']
+    )
 
     buf = io.StringIO()
-    with patch('subprocess.run', return_value=mock_result):
+    with patch('subprocess.Popen', return_value=mock_proc):
         with patch('sys.stdout', buf):
             with patch('sys.__stdout__', io.StringIO()):
                 with patch('sys.__stderr__', io.StringIO()):


### PR DESCRIPTION
## Summary

- `--stdout` and `--stderr` now forward captured output to the terminal line-by-line as the subprocess writes it, rather than buffering until the process exits
- Uses `subprocess.Popen` with a daemon reader thread per pipe; the non-capture path (`subprocess.run` with inherited streams) is unchanged
- Adds a docs note about subprocess-side block-buffering when writing to a pipe, with `stdbuf -oL` / `python -u` as workarounds