### PR TITLE
feat: add bench.record() context manager and transparent exception capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`bench.record(name)` context manager**: times an arbitrary code block
+  and writes one record, without requiring the code to be in a named
+  function. All mixins, static fields, and output sinks behave identically
+  to the decorator form.
+
+- **Exception capture**: when a benchmarked block raises — via
+  `bench.record()` or a `@bench`-decorated function — the record is
+  written before the exception propagates. An `exception` field is added
+  containing `{"type": ..., "message": ...}`. The exception is always
+  re-raised. With `--iterations N`, timing stops at the first exception.
+
 - **Command-line interface** (`python -m microbench`): wrap any external
   command and record host metadata alongside timing without writing Python
   code. Useful for SLURM jobs, shell scripts, and compiled executables.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,6 +139,49 @@ results.groupby('mb_run_id')['total_duration'].describe()
 
 See the [pandas documentation](https://pandas.pydata.org/docs/) for more.
 
+## Timing code blocks
+
+Use `bench.record(name)` when the code you want to time is not easily
+wrapped in a function — for example, a block in a notebook cell or a
+section of a script:
+
+```python
+from microbench import MicroBench, MBHostInfo
+
+class MyBench(MicroBench, MBHostInfo):
+    outfile = '/home/user/results.jsonl'
+
+bench = MyBench(experiment='run-1')
+
+with bench.record('data_loading'):
+    dataset = load_dataset('/data/train.h5')
+
+with bench.record('preprocessing'):
+    X, y = preprocess(dataset)
+```
+
+Each `with` block produces one record. The `name` argument sets the
+`function_name` field. All mixins, static fields, and output sinks
+behave identically to the decorator form.
+
+If the block raises an exception the record is still written, with an
+`exception` field containing the error type and message, and the
+exception is re-raised normally:
+
+```python
+try:
+    with bench.record('risky_step'):
+        result = unstable_solver(data)
+except SolverError:
+    pass  # record written with exception field; continue to next step
+```
+
+**Mixin compatibility notes:**
+
+- `MBFunctionCall` — records `args=[]` and `kwargs={}` (no callable to inspect); not an error, but not meaningful.
+- `MBReturnValue` — silently a no-op; no `return_value` field is set.
+- `MBLineProfiler` — raises `NotImplementedError`; it requires a callable to profile and cannot be used with `bench.record()`. Use the `@bench` decorator instead.
+
 ## Benchmarking external commands
 
 Microbench can also wrap shell commands, scripts, and compiled executables

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -1,5 +1,35 @@
 # Advanced usage
 
+## Exception capture
+
+When a benchmarked block raises an exception — whether via `bench.record()`
+or a `@bench`-decorated function — microbench writes the record before
+propagating the exception. The record includes an `exception` field with
+the error type and message:
+
+```json
+{
+  "function_name": "risky_step",
+  "run_durations": [0.042],
+  "exception": {"type": "SolverError", "message": "convergence failed"}
+}
+```
+
+The exception is always re-raised — microbench never silences errors.
+Failing calls still appear in your results file and can be identified in
+analysis:
+
+```python
+import pandas
+results = pandas.read_json('/home/user/results.jsonl', lines=True)
+
+# Records where the call raised
+failed = results[results['exception'].notna()]
+```
+
+With `--iterations N`, timing stops at the first exception; the record
+contains durations for all iterations up to and including the failing one.
+
 ## Tolerating capture failures
 
 By default, an exception in any `capture_` or `capturepost_` method

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -378,7 +378,8 @@ class MicroBench:
         )
 
     def capture_function_name(self, bm_data):
-        bm_data['function_name'] = bm_data['_func'].__name__
+        if '_func' in bm_data:
+            bm_data['function_name'] = bm_data['_func'].__name__
 
     def _capture_package_version(self, bm_data, pkg, skip_if_none=False):
         bm_data.setdefault('package_versions', {})
@@ -433,18 +434,29 @@ class MicroBench:
 
             self.pre_start_triggers(bm_data)
 
+            res = None
+            exc_info = None
             for _ in range(self.iterations):
                 self.pre_run_triggers(bm_data)
-
-                if isinstance(self, MBLineProfiler):
-                    res = self._line_profiler.runcall(func, *args, **kwargs)
-                else:
-                    res = func(*args, **kwargs)
+                try:
+                    if isinstance(self, MBLineProfiler):
+                        res = self._line_profiler.runcall(func, *args, **kwargs)
+                    else:
+                        res = func(*args, **kwargs)
+                except Exception as e:
+                    exc_info = e
+                    self.post_run_triggers(bm_data)
+                    break
                 self.post_run_triggers(bm_data)
 
             self.post_finish_triggers(bm_data)
 
-            if isinstance(self, MBReturnValue):
+            if exc_info is not None:
+                bm_data['exception'] = {
+                    'type': type(exc_info).__name__,
+                    'message': str(exc_info),
+                }
+            elif isinstance(self, MBReturnValue):
                 try:
                     self.to_json(res)
                     bm_data['return_value'] = res
@@ -461,9 +473,67 @@ class MicroBench:
 
             self.output_result(bm_data)
 
+            if exc_info is not None:
+                raise exc_info
+
             return res
 
         return inner
+
+    def record(self, name=None):
+        """Return a context manager that times a block and writes one record.
+
+        Args:
+            name (str, optional): Value for the ``function_name`` field.
+                Defaults to ``'<record>'``.
+
+        Example::
+
+            with bench.record('training'):
+                model.fit(X, y)
+        """
+        return _ContextManagerRun(self, name)
+
+
+class _ContextManagerRun:
+    """Context manager returned by :meth:`MicroBench.record`."""
+
+    __slots__ = ('_bench', '_name', '_bm_data')
+
+    def __init__(self, bench, name):
+        self._bench = bench
+        self._name = name
+
+    def __enter__(self):
+        if isinstance(self._bench, MBLineProfiler):
+            raise NotImplementedError(
+                'MBLineProfiler requires a callable to profile and cannot be '
+                'used with bench.record(). Use the @bench decorator instead.'
+            )
+        bm_data = dict()
+        bm_data.update(self._bench._bm_static)
+        bm_data['function_name'] = self._name or '<record>'
+        # Sentinels so MBFunctionCall produces args=[], kwargs={} rather than
+        # a KeyError; _func is intentionally absent so capture_function_name
+        # leaves function_name as set above.
+        bm_data['_args'] = ()
+        bm_data['_kwargs'] = {}
+        self._bm_data = bm_data
+        self._bench.pre_start_triggers(bm_data)
+        self._bench.pre_run_triggers(bm_data)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._bench.post_run_triggers(self._bm_data)
+        self._bench.post_finish_triggers(self._bm_data)
+        if exc_type is not None:
+            self._bm_data['exception'] = {
+                'type': exc_type.__name__,
+                'message': str(exc_val),
+            }
+        bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
+        self._bench.output_result(bm_data)
+        return False  # never suppress exceptions
 
 
 class MBFunctionCall:

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -1241,3 +1241,250 @@ def test_mb_file_hash_missing_file_raises(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         noop()
+
+
+# ---------------------------------------------------------------------------
+# bench.record() context manager
+# ---------------------------------------------------------------------------
+
+
+def test_record_standard_fields():
+    """bench.record() produces a record with all standard timing fields."""
+    bench = MicroBench()
+
+    with bench.record('my_block'):
+        pass
+
+    results = bench.get_results()
+    assert len(results) == 1
+    row = results.iloc[0]
+    assert row['function_name'] == 'my_block'
+    assert 'start_time' in results.columns
+    assert 'finish_time' in results.columns
+    assert len(row['run_durations']) == 1
+    assert 'mb_run_id' in results.columns
+    assert 'mb_version' in results.columns
+
+
+def test_record_no_name_defaults():
+    """bench.record() with no name sets function_name to '<record>'."""
+    bench = MicroBench()
+
+    with bench.record():
+        pass
+
+    results = bench.get_results()
+    assert results.iloc[0]['function_name'] == '<record>'
+
+
+def test_record_static_fields():
+    """Static fields passed to MicroBench() appear in bench.record() output."""
+    bench = MicroBench(experiment='run-1', trial=3)
+
+    with bench.record('block'):
+        pass
+
+    results = bench.get_results()
+    assert results.iloc[0]['experiment'] == 'run-1'
+    assert results.iloc[0]['trial'] == 3
+
+
+def test_record_mixin_fields():
+    """Mixin capture methods run during bench.record()."""
+
+    class Bench(MicroBench, MBHostInfo):
+        pass
+
+    bench = Bench()
+
+    with bench.record('block'):
+        pass
+
+    results = bench.get_results()
+    assert 'hostname' in results.columns
+    assert 'operating_system' in results.columns
+
+
+def test_record_multiple_records():
+    """Each bench.record() call appends a separate record."""
+    bench = MicroBench()
+
+    with bench.record('first'):
+        pass
+    with bench.record('second'):
+        pass
+
+    results = bench.get_results()
+    assert len(results) == 2
+    assert list(results['function_name']) == ['first', 'second']
+
+
+def test_record_exception_captured_and_reraised():
+    """Exceptions inside bench.record() are recorded then re-raised."""
+    bench = MicroBench()
+
+    with pytest.raises(ValueError, match='oops'):
+        with bench.record('block'):
+            raise ValueError('oops')
+
+    results = bench.get_results()
+    assert len(results) == 1
+    exc = results.iloc[0]['exception']
+    assert exc['type'] == 'ValueError'
+    assert exc['message'] == 'oops'
+
+
+def test_record_no_exception_field_on_success():
+    """No 'exception' field is present when the block completes normally."""
+    bench = MicroBench()
+
+    with bench.record('block'):
+        pass
+
+    results = bench.get_results()
+    assert 'exception' not in results.columns
+
+
+def test_record_coexists_with_decorator():
+    """bench.record() and @bench decorator write to the same output sink."""
+    bench = MicroBench()
+
+    with bench.record('ctx'):
+        pass
+
+    @bench
+    def decorated():
+        pass
+
+    decorated()
+
+    results = bench.get_results()
+    assert len(results) == 2
+    assert set(results['function_name']) == {'ctx', 'decorated'}
+
+
+# ---------------------------------------------------------------------------
+# Exception capture — decorator
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_exception_captured_and_reraised():
+    """Exceptions from @bench functions are recorded then re-raised."""
+    bench = MicroBench()
+
+    @bench
+    def failing():
+        raise RuntimeError('boom')
+
+    with pytest.raises(RuntimeError, match='boom'):
+        failing()
+
+    results = bench.get_results()
+    assert len(results) == 1
+    exc = results.iloc[0]['exception']
+    assert exc['type'] == 'RuntimeError'
+    assert exc['message'] == 'boom'
+
+
+def test_decorator_no_exception_field_on_success():
+    """No 'exception' field when the decorated function returns normally."""
+    bench = MicroBench()
+
+    @bench
+    def ok():
+        pass
+
+    ok()
+
+    results = bench.get_results()
+    assert 'exception' not in results.columns
+
+
+def test_decorator_exception_stops_iterations():
+    """An exception on iteration 2 stops the loop; only 2 durations recorded."""
+    call_count = 0
+
+    bench = MicroBench(iterations=5)
+
+    @bench
+    def sometimes_fails():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise ValueError('fail on second')
+
+    with pytest.raises(ValueError):
+        sometimes_fails()
+
+    results = bench.get_results()
+    assert call_count == 2
+    assert len(results.iloc[0]['run_durations']) == 2
+
+
+def test_decorator_return_value_mixin_skipped_on_exception():
+    """MBReturnValue does not set return_value when the function raised."""
+
+    class Bench(MicroBench, MBReturnValue):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def failing():
+        raise TypeError('no return')
+
+    with pytest.raises(TypeError):
+        failing()
+
+    results = bench.get_results()
+    assert 'return_value' not in results.columns
+
+
+# ---------------------------------------------------------------------------
+# Mixin behaviour with bench.record()
+# ---------------------------------------------------------------------------
+
+
+def test_record_mbfunctioncall_produces_empty_args():
+    """MBFunctionCall with bench.record() records args=[] kwargs={} (no callable)."""
+
+    class Bench(MicroBench, MBFunctionCall):
+        pass
+
+    bench = Bench()
+
+    with bench.record('block'):
+        pass
+
+    results = bench.get_results()
+    assert results.iloc[0]['args'] == []
+    assert results.iloc[0]['kwargs'] == {}
+
+
+def test_record_mbreturnvalue_ignored():
+    """MBReturnValue is silently a no-op with bench.record() (no return value)."""
+
+    class Bench(MicroBench, MBReturnValue):
+        pass
+
+    bench = Bench()
+
+    with bench.record('block'):
+        pass
+
+    results = bench.get_results()
+    assert 'return_value' not in results.columns
+
+
+def test_record_mblineprofiler_raises():
+    """MBLineProfiler raises NotImplementedError with bench.record()."""
+    from microbench import MBLineProfiler
+
+    class Bench(MicroBench, MBLineProfiler):
+        pass
+
+    bench = Bench()
+
+    with pytest.raises(NotImplementedError, match='MBLineProfiler'):
+        with bench.record('block'):
+            pass


### PR DESCRIPTION
## Summary

- Adds `bench.record(name)` — a context manager that times an arbitrary code block and writes one record, reusing the full mixin/trigger/output-sink infrastructure. Useful for notebook cells, script sections, and any code that can't be wrapped in a named function.
- Adds transparent exception capture for both `bench.record()` and `@bench`-decorated functions: the record is written with an `exception: {type, message}` field before the exception propagates. The exception is always re-raised.
- With `iterations=N`, the decorator stops at the first exception; durations up to and including the failing iteration are preserved.

**Mixin compatibility for `bench.record()`:**
- `MBFunctionCall` — produces `args=[], kwargs={}` (no callable to inspect); documented
- `MBReturnValue` — silently a no-op; documented
- `MBLineProfiler` — raises `NotImplementedError` with a clear message; documented