### PR TITLE
feat: add bench.record_on_exit() for process-lifetime benchmarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`bench.record_on_exit(name, handle_sigterm=True)`**: registers a
+  process-exit handler that writes one benchmark record when the script
+  terminates. Captures wall-clock duration from the call site to exit plus
+  all mixin fields. Designed for SLURM jobs and batch scripts where
+  restructuring code around a decorator is impractical. Key behaviours:
+  - By default installs a SIGTERM handler (main thread only) that writes
+    the record, chains to any existing SIGTERM handler, then re-delivers
+    SIGTERM so the process exits with the conventional code 143 (128 + 15).
+  - Wraps `sys.excepthook` to capture unhandled exceptions into an
+    `exception` field before the process exits.
+  - Adds an `exit_signal` field when the exit was triggered by SIGTERM.
+  - Falls back to writing the record to `sys.stderr` if the primary output
+    sink raises (e.g. filesystem unmounted at exit time).
+  - Calling a second time on the same instance replaces the first
+    registration and resets the start time.
+
 - **`bench.record(name)` context manager**: times an arbitrary code block
   and writes one record, without requiring the code to be in a named
   function. All mixins, static fields, and output sinks behave identically

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,6 +182,42 @@ except SolverError:
 - `MBReturnValue` — silently a no-op; no `return_value` field is set.
 - `MBLineProfiler` — raises `NotImplementedError`; it requires a callable to profile and cannot be used with `bench.record()`. Use the `@bench` decorator instead.
 
+## Timing entire scripts with `record_on_exit`
+
+Call `bench.record_on_exit(name)` once near the top of a script to time
+the full process lifetime. The record is written automatically when the
+process exits — no restructuring of the script is required:
+
+```python
+from microbench import MicroBench, MBHostInfo, MBSlurmInfo
+
+class MyBench(MicroBench, MBHostInfo, MBSlurmInfo):
+    outfile = '/scratch/results.jsonl'
+    capture_optional = True  # recommended: don't let a failed capture abort exit
+
+bench = MyBench(experiment='baseline')
+bench.record_on_exit('simulation')
+
+run_simulation()  # whatever the script does
+```
+
+A single record is appended to `results.jsonl` when the process exits,
+containing the wall-clock duration from the `record_on_exit()` call to
+exit plus all mixin fields captured at exit time.
+
+**SIGTERM handling (SLURM walltime):** By default microbench installs a
+SIGTERM handler. When SLURM hits the job's walltime limit it sends SIGTERM
+(with a grace period before SIGKILL); the handler writes the record before
+re-delivering the signal so job accounting sees the correct exit code.
+Pass `handle_sigterm=False` to opt out.
+
+**Exception capture:** If the script exits due to an unhandled exception,
+the record includes an `exception` field with the error type and message.
+The exception is still printed and the process still exits non-zero.
+
+**Limitations:** SIGKILL and `os._exit()` cannot be caught; no record
+will be written in those cases.
+
 ## Benchmarking external commands
 
 Microbench can also wrap shell commands, scripts, and compiled executables

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -1,5 +1,66 @@
 # Advanced usage
 
+## `bench.record_on_exit()` — reliability and signal handling
+
+`bench.record_on_exit()` is designed to work reliably in long-running batch
+jobs. This section covers the implementation details that matter for
+production use.
+
+### What is and isn't caught
+
+| Exit path | Record written? |
+|---|---|
+| Normal script completion | ✓ |
+| `sys.exit()` | ✓ |
+| Unhandled exception | ✓ (with `exception` field) |
+| `KeyboardInterrupt` (Ctrl-C) | ✓ (with `exception` field) |
+| SIGTERM (default `handle_sigterm=True`) | ✓ (with `exit_signal='SIGTERM'`) |
+| SIGKILL | ✗ — unkillable by design |
+| `os._exit()` | ✗ — bypasses atexit |
+
+### SIGTERM and signal chaining
+
+When `handle_sigterm=True`, microbench installs a SIGTERM handler that:
+
+1. Writes the record
+2. Chains to any previously installed SIGTERM handler (e.g. `MonitorThread`)
+3. Restores the default OS signal disposition (`SIG_DFL`) and re-delivers
+   SIGTERM to the process
+
+Step 3 is important for correct job accounting. When Python intercepts a
+signal, the process does not automatically exit with the signal's conventional
+exit code. By restoring the default disposition and then re-sending the signal,
+the process terminates as if Python had never handled it — with exit code 143.
+This number follows the Unix convention of 128 + signal number: SIGTERM is
+signal 15, so 128 + 15 = 143. SLURM and other schedulers use this exit code
+to distinguish a walltime kill from a normal non-zero exit.
+
+Signal handlers can only be registered from the main thread. If
+`record_on_exit()` is called from a non-main thread, microbench warns and
+proceeds without the SIGTERM handler; the record will still be written on
+normal exit.
+
+### Capture failures at exit time
+
+Mixin captures run inside the exit handler. Slow or unavailable captures
+(e.g. `MBCondaPackages` when conda is not installed) can delay exit, which
+matters when operating inside a SLURM grace period. Use
+`capture_optional = True` on the benchmark class so individual capture
+failures are recorded in `mb_capture_errors` rather than aborting the
+handler:
+
+```python
+class MyBench(MicroBench, MBHostInfo, MBCondaPackages):
+    capture_optional = True
+```
+
+### Output sink unavailability
+
+If the primary output sink raises (e.g. a shared filesystem that has been
+unmounted before the atexit handler fires), microbench falls back to
+writing the raw JSON record to `sys.stderr` so the record is not silently
+lost.
+
 ## Exception capture
 
 When a benchmarked block raises an exception — whether via `bench.record()`

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -1,3 +1,4 @@
+import atexit
 import base64
 import inspect
 import io
@@ -493,6 +494,139 @@ class MicroBench:
                 model.fit(X, y)
         """
         return _ContextManagerRun(self, name)
+
+    def record_on_exit(self, name=None, handle_sigterm=True):
+        """Register a process-exit handler that writes one benchmark record.
+
+        Call once near the start of a script. When the process exits normally
+        (or via SIGTERM when *handle_sigterm* is ``True``), a record is written
+        containing the wall-clock duration from this call to exit, plus all
+        mixin fields captured at exit time.
+
+        Calling this method a second time on the same instance replaces the
+        previous registration and resets the start time.
+
+        Args:
+            name (str, optional): Value for the ``function_name`` field.
+                Defaults to ``'<process>'``.
+            handle_sigterm (bool): Install a SIGTERM handler that writes the
+                record before re-delivering the signal. Only effective when
+                called from the main thread. Defaults to ``True``.
+
+        Fields added beyond the standard timing fields:
+
+        - ``exit_signal``: ``'SIGTERM'`` when the handler was triggered by
+          SIGTERM; absent otherwise.
+        - ``exception``: ``{"type": ..., "message": ...}`` when the process
+          is exiting due to an unhandled exception; absent otherwise.
+
+        .. note::
+            SIGKILL and ``os._exit()`` cannot be caught; no record will be
+            written in those cases. Use ``capture_optional = True`` on the
+            benchmark class so that slow or unavailable capture methods do
+            not delay the exit handler.
+
+        Example::
+
+            bench = MyBench(outfile='/scratch/results.jsonl')
+            bench.record_on_exit('simulation')
+
+            run_simulation()
+        """
+        # Deregister any previous registration from this instance.
+        if hasattr(self, '_record_on_exit_handler'):
+            atexit.unregister(self._record_on_exit_handler)
+
+        _start_counter = self._duration_counter()
+        _start_time = datetime.now(self.tz)
+
+        # Wrap sys.excepthook to capture unhandled exceptions.  atexit
+        # handlers cannot reliably read sys.exc_info() at exit time.
+        _exception_info = [None]
+        _orig_excepthook = sys.excepthook
+
+        def _excepthook(exc_type, exc_val, exc_tb):
+            _exception_info[0] = (exc_type, exc_val)
+            _orig_excepthook(exc_type, exc_val, exc_tb)
+
+        sys.excepthook = _excepthook
+
+        # Shared state to prevent double-writing if both atexit and the
+        # SIGTERM handler fire in the same exit sequence.
+        _ctx = {'fired': False}
+
+        def _exit_handler(exit_signal=None):
+            if _ctx['fired']:
+                return
+            _ctx['fired'] = True
+
+            bm_data = dict()
+            bm_data.update(self._bm_static)
+            bm_data['function_name'] = name or '<process>'
+            bm_data['_args'] = ()
+            bm_data['_kwargs'] = {}
+
+            self.pre_start_triggers(bm_data)
+            # pre_start_triggers sets start_time and run_durations=[]; override
+            # both with the values recorded at the call site.
+            bm_data['start_time'] = _start_time
+            bm_data['run_durations'] = [self._duration_counter() - _start_counter]
+
+            self.post_finish_triggers(bm_data)
+
+            if _exception_info[0] is not None:
+                exc_type, exc_val = _exception_info[0]
+                bm_data['exception'] = {
+                    'type': exc_type.__name__,
+                    'message': str(exc_val),
+                }
+
+            if exit_signal is not None:
+                bm_data['exit_signal'] = exit_signal
+
+            bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
+
+            try:
+                self.output_result(bm_data)
+            except Exception:
+                # Fallback: write JSON directly to stderr so the record is not
+                # silently lost if the primary output sink is unavailable.
+                try:
+                    sys.stderr.write(self.to_json(bm_data) + '\n')
+                except Exception:
+                    pass
+
+        # Unique wrapper so atexit.unregister can target exactly this
+        # registration on a subsequent record_on_exit() call.
+        def _atexit_handler():
+            _exit_handler()
+
+        self._record_on_exit_handler = _atexit_handler
+        atexit.register(_atexit_handler)
+
+        if handle_sigterm:
+            if threading.current_thread() is threading.main_thread():
+                _prev_sigterm = signal.getsignal(signal.SIGTERM)
+
+                def _sigterm_handler(signum, frame):
+                    _exit_handler(exit_signal='SIGTERM')
+                    # Chain to any previously installed handler (e.g.
+                    # MonitorThread.terminate) so it also runs cleanly.
+                    if callable(_prev_sigterm):
+                        _prev_sigterm(signum, frame)
+                    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+                    os.kill(os.getpid(), signal.SIGTERM)
+
+                signal.signal(signal.SIGTERM, _sigterm_handler)
+            else:
+                warnings.warn(
+                    'bench.record_on_exit(): SIGTERM handler not registered '
+                    'because called from a non-main thread. The record will '
+                    'still be written on normal exit but may be lost if the '
+                    'process receives SIGTERM.',
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
 
 class _ContextManagerRun:

--- a/microbench/tests/test_base.py
+++ b/microbench/tests/test_base.py
@@ -1,6 +1,8 @@
+import atexit as _atexit
 import datetime
 import io
 import os
+import signal as _signal
 import sys
 import tempfile
 import threading
@@ -1488,3 +1490,241 @@ def test_record_mblineprofiler_raises():
     with pytest.raises(NotImplementedError, match='MBLineProfiler'):
         with bench.record('block'):
             pass
+
+
+# ---------------------------------------------------------------------------
+# bench.record_on_exit()
+# ---------------------------------------------------------------------------
+
+
+def _invoke_record_on_exit(bench):
+    """Directly call the registered exit handler and return its results."""
+    bench._record_on_exit_handler()
+    return bench.get_results()
+
+
+def test_record_on_exit_standard_fields():
+    """record_on_exit() produces a record with all standard timing fields."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('simulation')
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert len(results) == 1
+    row = results.iloc[0]
+    assert row['function_name'] == 'simulation'
+    assert len(row['run_durations']) == 1
+    assert row['run_durations'][0] >= 0
+    assert 'start_time' in results.columns
+    assert 'finish_time' in results.columns
+    assert 'mb_run_id' in results.columns
+    assert 'mb_version' in results.columns
+
+
+def test_record_on_exit_default_name():
+    """record_on_exit() with no name sets function_name to '<process>'."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit()
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert results.iloc[0]['function_name'] == '<process>'
+
+
+def test_record_on_exit_static_fields():
+    """Static fields from MicroBench() constructor appear in the record."""
+    bench = MicroBench(experiment='run-1', trial=7)
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert results.iloc[0]['experiment'] == 'run-1'
+    assert results.iloc[0]['trial'] == 7
+
+
+def test_record_on_exit_mixin_fields():
+    """Mixin capture methods run in the exit handler."""
+
+    class Bench(MicroBench, MBHostInfo):
+        pass
+
+    bench = Bench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert 'hostname' in results.columns
+    assert 'operating_system' in results.columns
+
+
+def test_record_on_exit_exception_capture():
+    """Unhandled exceptions are captured via sys.excepthook."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        # Simulate Python calling sys.excepthook for an unhandled exception.
+        exc = RuntimeError('something broke')
+        sys.excepthook(type(exc), exc, None)
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert len(results) == 1
+    exc_field = results.iloc[0]['exception']
+    assert exc_field['type'] == 'RuntimeError'
+    assert exc_field['message'] == 'something broke'
+
+
+def test_record_on_exit_no_exception_field_on_clean_exit():
+    """No 'exception' field when the process exits cleanly."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert 'exception' not in results.columns
+
+
+def test_record_on_exit_sigterm_writes_record():
+    """The SIGTERM handler writes the record with exit_signal='SIGTERM'."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    orig_sigterm = _signal.getsignal(_signal.SIGTERM)
+    try:
+        bench.record_on_exit('sim', handle_sigterm=True)
+        handler = _signal.getsignal(_signal.SIGTERM)
+        assert callable(handler)
+        # Invoke the handler but prevent it from re-killing the process.
+        with patch('os.kill'), patch('signal.signal'):
+            handler(_signal.SIGTERM, None)
+        results = bench.get_results()
+    finally:
+        sys.excepthook = orig_excepthook
+        _signal.signal(_signal.SIGTERM, orig_sigterm)
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert len(results) == 1
+    assert results.iloc[0]['exit_signal'] == 'SIGTERM'
+
+
+def test_record_on_exit_handle_sigterm_false():
+    """handle_sigterm=False leaves the SIGTERM handler unchanged."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    orig_sigterm = _signal.getsignal(_signal.SIGTERM)
+    try:
+        bench.record_on_exit('sim', handle_sigterm=False)
+        assert _signal.getsignal(_signal.SIGTERM) is orig_sigterm
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+
+def test_record_on_exit_double_fire_prevention():
+    """Calling the exit handler twice writes only one record."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        bench._record_on_exit_handler()
+        bench._record_on_exit_handler()
+        results = bench.get_results()
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert len(results) == 1
+
+
+def test_record_on_exit_re_registration_replaces_first():
+    """A second record_on_exit() call replaces the first registration."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('first')
+        first_handler = bench._record_on_exit_handler
+        bench.record_on_exit('second')
+        second_handler = bench._record_on_exit_handler
+
+        # Old handler should be deregistered; calling it is now a no-op
+        # because it is no longer in the atexit list — but it would still
+        # run if called directly. The key check is that they are distinct.
+        assert first_handler is not second_handler
+
+        second_handler()
+        results = bench.get_results()
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert len(results) == 1
+    assert results.iloc[0]['function_name'] == 'second'
+
+
+def test_record_on_exit_non_main_thread_warns():
+    """record_on_exit() warns when called from a non-main thread."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    orig_sigterm = _signal.getsignal(_signal.SIGTERM)
+    warning_holder = []
+
+    def run():
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            bench.record_on_exit('sim', handle_sigterm=True)
+            warning_holder.extend(w)
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+    try:
+        assert any(issubclass(w.category, RuntimeWarning) for w in warning_holder)
+        assert _signal.getsignal(_signal.SIGTERM) is orig_sigterm
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+
+def test_record_on_exit_output_fallback_to_stderr(capsys):
+    """When output_result raises, the record is written to stderr."""
+
+    class BrokenOutput(Output):
+        def write(self, bm_json_str):
+            raise OSError('disk full')
+
+    bench = MicroBench(outputs=[BrokenOutput()])
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        bench._record_on_exit_handler()
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    captured = capsys.readouterr()
+    import json as _json
+
+    record = _json.loads(captured.err.strip())
+    assert record['function_name'] == 'sim'


### PR DESCRIPTION
## Summary

- Adds `bench.record_on_exit(name, handle_sigterm=True)` — registers a process-exit handler (via `atexit`) that writes one benchmark record when the script terminates
- Designed for SLURM jobs and batch scripts where restructuring code around a decorator or context manager is impractical
- SIGTERM handler writes the record, chains to existing handlers, then re-delivers SIGTERM so the process exits with code 143 (128 + 15), which SLURM job accounting recognises as a walltime kill
- `sys.excepthook` wrapping captures unhandled exceptions into an `exception` field before exit
- Falls back to `sys.stderr` if the primary output sink raises at exit time
- Re-calling replaces the previous registration and resets the start time
- Warns (does not raise) if called from a non-main thread where signal registration is not possible