### PR TITLE
feat: add bench.time(name) sub-timing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`bench.time(name)` sub-timing API**: label phases inside a single benchmark
+  record with named timing sections. Sub-timings accumulate in `mb_timings` as
+  `[{"name": ..., "duration": ...}, ...]` in call order. Compatible with
+  `bench.record()`, `bench.arecord()`, `@bench` (sync and async), and
+  `bench.record_on_exit()`. Calling outside an active benchmark is a silent
+  no-op; `mb_timings` is absent when `bench.time()` is never called.
+
+  ```python
+  with bench.record('pipeline'):
+      with bench.time('parse'):
+          data = parse(raw)
+      with bench.time('transform'):
+          result = transform(data)
+  ```
+
 - **Async support**: the `@bench` decorator now detects `async def` functions
   and returns an `async def` wrapper that must be awaited. A new
   `bench.arecord(name)` method provides the async counterpart of

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ result, the metadata shows exactly what was running.
 - **Flexible output** — write to a local file, in-memory buffer, Redis, or
   custom destinations; file writes are safe for simultaneous writes from
   multiple processes
+- **Sub-timings** — label named phases inside a single record with
+  `bench.time(name)`; all phases share one metadata capture pass and results
+  accumulate in `mb_timings` in call order
 
 ## Installation
 

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -61,6 +61,79 @@ unmounted before the atexit handler fires), microbench falls back to
 writing the raw JSON record to `sys.stderr` so the record is not silently
 lost.
 
+## Sub-timings: `bench.time()`
+
+When a benchmarked block contains several distinct phases, `bench.time(name)`
+lets you label each one. All phases share the same benchmark record — and
+therefore the same metadata capture pass. There is no need to create a separate
+`MicroBench` instance per phase.
+
+```python
+with bench.record('pipeline'):
+    with bench.time('parse'):
+        data = parse(raw)
+    with bench.time('transform'):
+        result = transform(data)
+    with bench.time('write'):
+        write(result)
+```
+
+Sub-timings are appended to `mb_timings` in call order:
+
+```json
+{
+  "function_name": "pipeline",
+  "run_durations": [0.183],
+  "mb_timings": [
+    {"name": "parse",     "duration": 0.041},
+    {"name": "transform", "duration": 0.120},
+    {"name": "write",     "duration": 0.022}
+  ]
+}
+```
+
+`mb_timings` is absent from the record when `bench.time()` is never called.
+
+### Compatibility
+
+`bench.time()` works identically inside all four entry points:
+
+| Entry point | Usage |
+|---|---|
+| `bench.record()` | `with bench.record('name'): ... with bench.time('phase'): ...` |
+| `@bench` decorator (sync) | call `bench.time()` inside the decorated function body |
+| `@bench` decorator (async) | same — use `with bench.time()` (not `async with`) |
+| `bench.arecord()` | `async with bench.arecord('name'): ... with bench.time('phase'): ...` |
+| `bench.record_on_exit()` | call `bench.time()` anywhere after `record_on_exit()` returns |
+
+Calling `bench.time()` outside any active benchmark is a **silent no-op** — it
+records nothing and raises no error.
+
+### Behaviour with `iterations`
+
+With `iterations=N`, each call to the decorated function runs `N` times. Every
+`bench.time()` inside the body fires once per iteration, so `mb_timings` will
+contain `N` entries per named phase:
+
+```python
+bench = MicroBench(iterations=3)
+
+@bench
+def pipeline():
+    with bench.time('step'):
+        ...
+
+pipeline()
+# mb_timings → [{"name": "step", ...}, {"name": "step", ...}, {"name": "step", ...}]
+```
+
+### Exceptions
+
+An exception raised inside `with bench.time('phase')` closes the segment and
+records its duration before the exception propagates. The record will contain
+the partial `mb_timings` for all segments that completed or started before the
+exception.
+
 ## Exception capture
 
 When a benchmarked block raises an exception — whether via `bench.record()`

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -1,4 +1,5 @@
 import atexit
+import contextvars
 import functools
 import inspect
 import json
@@ -53,6 +54,14 @@ from .mixins import (
 # Generated once at import time; shared by all MicroBench instances in this
 # process, allowing records from independent bench suites to be correlated.
 _run_id = str(uuid.uuid4())
+
+# ContextVar set to the active bm_data dict while inside bench.record(),
+# bench.arecord(), or a @bench-decorated call.  bench.time() reads this to
+# attach sub-timings to the current benchmark.  Each asyncio.Task gets its own
+# copy, so concurrent arecord() calls stay isolated.
+_active_bm_data: contextvars.ContextVar = contextvars.ContextVar(
+    '_active_bm_data', default=None
+)
 
 __all__ = [
     # Core
@@ -302,13 +311,87 @@ class MicroBench:
                     await func(*args, **kwargs)
 
                 self.pre_start_triggers(bm_data)
+                _ctx_token = _active_bm_data.set(bm_data)
 
                 res = None
                 exc_info = None
+                try:
+                    for _ in range(self.iterations):
+                        self.pre_run_triggers(bm_data)
+                        try:
+                            res = await func(*args, **kwargs)
+                        except Exception as e:
+                            exc_info = e
+                            self.post_run_triggers(bm_data)
+                            break
+                        self.post_run_triggers(bm_data)
+
+                    self.post_finish_triggers(bm_data)
+
+                    if exc_info is not None:
+                        bm_data['exception'] = {
+                            'type': type(exc_info).__name__,
+                            'message': str(exc_info),
+                        }
+                    elif isinstance(self, MBReturnValue):
+                        try:
+                            self.to_json(res)
+                            bm_data['return_value'] = res
+                        except TypeError:
+                            warnings.warn(
+                                f'Return value is not JSON encodable '
+                                f'(type: {type(res)}). '
+                                'Extend JSONEncoder class to fix (see README).',
+                                JSONEncodeWarning,
+                            )
+                            bm_data['return_value'] = _UNENCODABLE_PLACEHOLDER_VALUE
+
+                    # Delete any underscore-prefixed keys
+                    bm_data = {
+                        k: v for k, v in bm_data.items() if not k.startswith('_')
+                    }
+
+                    self.output_result(bm_data)
+                finally:
+                    _active_bm_data.reset(_ctx_token)
+
+                if exc_info is not None:
+                    raise exc_info
+
+                return res
+
+            return inner
+
+        def inner(*args, **kwargs):
+            bm_data = dict()
+            bm_data.update(self._bm_static)
+            bm_data['_func'] = func
+            bm_data['_args'] = args
+            bm_data['_kwargs'] = kwargs
+
+            if isinstance(self, MBLineProfiler):
+                if not line_profiler:
+                    raise ImportError(
+                        'This functionality requires the "line_profiler" package'
+                    )
+                self._line_profiler = line_profiler.LineProfiler(func)
+
+            for _ in range(self.warmup):
+                func(*args, **kwargs)
+
+            self.pre_start_triggers(bm_data)
+            _ctx_token = _active_bm_data.set(bm_data)
+
+            res = None
+            exc_info = None
+            try:
                 for _ in range(self.iterations):
                     self.pre_run_triggers(bm_data)
                     try:
-                        res = await func(*args, **kwargs)
+                        if isinstance(self, MBLineProfiler):
+                            res = self._line_profiler.runcall(func, *args, **kwargs)
+                        else:
+                            res = func(*args, **kwargs)
                     except Exception as e:
                         exc_info = e
                         self.post_run_triggers(bm_data)
@@ -338,71 +421,8 @@ class MicroBench:
                 bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
 
                 self.output_result(bm_data)
-
-                if exc_info is not None:
-                    raise exc_info
-
-                return res
-
-            return inner
-
-        def inner(*args, **kwargs):
-            bm_data = dict()
-            bm_data.update(self._bm_static)
-            bm_data['_func'] = func
-            bm_data['_args'] = args
-            bm_data['_kwargs'] = kwargs
-
-            if isinstance(self, MBLineProfiler):
-                if not line_profiler:
-                    raise ImportError(
-                        'This functionality requires the "line_profiler" package'
-                    )
-                self._line_profiler = line_profiler.LineProfiler(func)
-
-            for _ in range(self.warmup):
-                func(*args, **kwargs)
-
-            self.pre_start_triggers(bm_data)
-
-            res = None
-            exc_info = None
-            for _ in range(self.iterations):
-                self.pre_run_triggers(bm_data)
-                try:
-                    if isinstance(self, MBLineProfiler):
-                        res = self._line_profiler.runcall(func, *args, **kwargs)
-                    else:
-                        res = func(*args, **kwargs)
-                except Exception as e:
-                    exc_info = e
-                    self.post_run_triggers(bm_data)
-                    break
-                self.post_run_triggers(bm_data)
-
-            self.post_finish_triggers(bm_data)
-
-            if exc_info is not None:
-                bm_data['exception'] = {
-                    'type': type(exc_info).__name__,
-                    'message': str(exc_info),
-                }
-            elif isinstance(self, MBReturnValue):
-                try:
-                    self.to_json(res)
-                    bm_data['return_value'] = res
-                except TypeError:
-                    warnings.warn(
-                        f'Return value is not JSON encodable (type: {type(res)}). '
-                        'Extend JSONEncoder class to fix (see README).',
-                        JSONEncodeWarning,
-                    )
-                    bm_data['return_value'] = _UNENCODABLE_PLACEHOLDER_VALUE
-
-            # Delete any underscore-prefixed keys
-            bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
-
-            self.output_result(bm_data)
+            finally:
+                _active_bm_data.reset(_ctx_token)
 
             if exc_info is not None:
                 raise exc_info
@@ -445,6 +465,20 @@ class MicroBench:
                 await load_data()
         """
         return _AsyncContextManagerRun(self, name)
+
+    def time(self, name: str) -> '_TimingSection':
+        """Return a context manager recording a named sub-timing within a benchmark.
+
+        Sub-timings are stored in ``mb_timings`` as a list of
+        ``{"name": ..., "duration": ...}`` dicts in call order.
+        Compatible with ``bench.record()``, ``bench.arecord()``,
+        ``@bench`` (sync and async), and ``bench.record_on_exit()``.
+        Calling outside an active benchmark is a silent no-op.
+
+        Args:
+            name (str): Label for this timing section.
+        """
+        return _TimingSection(self, name)
 
     def record_on_exit(self, name=None, handle_sigterm=True):
         """Register a process-exit handler that writes one benchmark record.
@@ -510,6 +544,9 @@ class MicroBench:
             # Store handle so a subsequent record_on_exit() can terminate it.
             self._record_on_exit_monitor_thread = _early_monitor
 
+        # Reset timings list; bench.time() appends here when ContextVar is None.
+        self._record_on_exit_timings = []
+
         _start_counter = self._duration_counter()
         _start_time = datetime.now(self.tz)
 
@@ -567,6 +604,9 @@ class MicroBench:
             if exit_signal is not None:
                 bm_data['exit_signal'] = exit_signal
 
+            if self._record_on_exit_timings:
+                bm_data['mb_timings'] = list(self._record_on_exit_timings)
+
             bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
 
             try:
@@ -615,7 +655,7 @@ class MicroBench:
 class _ContextManagerRun:
     """Context manager returned by :meth:`MicroBench.record`."""
 
-    __slots__ = ('_bench', '_name', '_bm_data')
+    __slots__ = ('_bench', '_name', '_bm_data', '_ctx_token')
 
     def __init__(self, bench, name):
         self._bench = bench
@@ -636,6 +676,7 @@ class _ContextManagerRun:
         bm_data['_args'] = ()
         bm_data['_kwargs'] = {}
         self._bm_data = bm_data
+        self._ctx_token = _active_bm_data.set(bm_data)
         self._bench.pre_start_triggers(bm_data)
         self._bench.pre_run_triggers(bm_data)
         return self
@@ -650,13 +691,14 @@ class _ContextManagerRun:
             }
         bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
         self._bench.output_result(bm_data)
+        _active_bm_data.reset(self._ctx_token)
         return False  # never suppress exceptions
 
 
 class _AsyncContextManagerRun:
     """Async context manager returned by :meth:`MicroBench.arecord`."""
 
-    __slots__ = ('_bench', '_name', '_bm_data')
+    __slots__ = ('_bench', '_name', '_bm_data', '_ctx_token')
 
     def __init__(self, bench, name):
         self._bench = bench
@@ -674,6 +716,7 @@ class _AsyncContextManagerRun:
         bm_data['_args'] = ()
         bm_data['_kwargs'] = {}
         self._bm_data = bm_data
+        self._ctx_token = _active_bm_data.set(bm_data)
         self._bench.pre_start_triggers(bm_data)
         self._bench.pre_run_triggers(bm_data)
         return self
@@ -688,4 +731,40 @@ class _AsyncContextManagerRun:
             }
         bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
         self._bench.output_result(bm_data)
+        _active_bm_data.reset(self._ctx_token)
         return False  # never suppress exceptions
+
+
+class _TimingSection:
+    """Context manager returned by :meth:`MicroBench.time`."""
+
+    __slots__ = ('_bench', '_name', '_bm_data', '_start')
+
+    def __init__(self, bench, name):
+        self._bench = bench
+        self._name = name
+        # Capture the active bm_data now (at construction time) so that nested
+        # bench.time() calls inside async tasks always attach to the right record.
+        self._bm_data = _active_bm_data.get()
+        self._start = None
+
+    def __enter__(self):
+        self._start = self._bench._duration_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._start is None:
+            return False
+        duration = self._bench._duration_counter() - self._start
+        entry = {'name': self._name, 'duration': duration}
+        if self._bm_data is not None:
+            self._bm_data.setdefault('mb_timings', []).append(entry)
+        elif hasattr(self._bench, '_record_on_exit_timings'):
+            self._bench._record_on_exit_timings.append(entry)
+        return False  # never suppress exceptions
+
+    async def __aenter__(self):
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return self.__exit__(exc_type, exc_val, exc_tb)

--- a/microbench/tests/test_core.py
+++ b/microbench/tests/test_core.py
@@ -1131,3 +1131,227 @@ def test_monitor_record_on_exit_re_registration_terminates_old_thread():
         _atexit.unregister(bench._record_on_exit_handler)
 
     assert results.iloc[0]['function_name'] == 'second'
+
+
+# ---------------------------------------------------------------------------
+# bench.time() sub-timing API
+# ---------------------------------------------------------------------------
+
+
+def test_time_with_record():
+    """bench.time() inside bench.record() appends entries to mb_timings."""
+    bench = MicroBench()
+
+    with bench.record('pipeline'):
+        with bench.time('parse'):
+            pass
+        with bench.time('transform'):
+            pass
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 2
+    assert timings[0]['name'] == 'parse'
+    assert timings[1]['name'] == 'transform'
+    assert timings[0]['duration'] >= 0
+    assert timings[1]['duration'] >= 0
+
+
+def test_time_with_decorator():
+    """bench.time() inside a sync @bench-decorated function records sub-timings."""
+    bench = MicroBench()
+
+    @bench
+    def pipeline():
+        with bench.time('step_a'):
+            pass
+        with bench.time('step_b'):
+            pass
+
+    pipeline()
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 2
+    assert timings[0]['name'] == 'step_a'
+    assert timings[1]['name'] == 'step_b'
+
+
+@pytest.mark.asyncio
+async def test_time_with_async_decorator():
+    """bench.time() inside an async @bench-decorated function records sub-timings."""
+    bench = MicroBench()
+
+    @bench
+    async def async_pipeline():
+        with bench.time('fetch'):
+            await asyncio.sleep(0)
+        with bench.time('process'):
+            pass
+
+    await async_pipeline()
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 2
+    assert timings[0]['name'] == 'fetch'
+    assert timings[1]['name'] == 'process'
+
+
+@pytest.mark.asyncio
+async def test_time_with_arecord():
+    """bench.time() inside bench.arecord() records sub-timings."""
+    bench = MicroBench()
+
+    async with bench.arecord('pipeline'):
+        with bench.time('load'):
+            await asyncio.sleep(0)
+        with bench.time('save'):
+            pass
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 2
+    assert timings[0]['name'] == 'load'
+    assert timings[1]['name'] == 'save'
+
+
+def test_time_with_record_on_exit():
+    """bench.time() after bench.record_on_exit() accumulates in mb_timings."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        with bench.time('setup'):
+            pass
+        with bench.time('run'):
+            pass
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 2
+    assert timings[0]['name'] == 'setup'
+    assert timings[1]['name'] == 'run'
+    assert timings[0]['duration'] >= 0
+    assert timings[1]['duration'] >= 0
+
+
+def test_time_noop_outside_benchmark():
+    """bench.time() outside any active benchmark is a silent no-op."""
+    bench = MicroBench()
+
+    # No active context — should not raise
+    with bench.time('orphan'):
+        pass
+
+    # Nothing written
+    results = bench.get_results()
+    assert len(results) == 0
+
+
+def test_time_absent_when_not_used():
+    """mb_timings is absent from the record when bench.time() is never called."""
+    bench = MicroBench()
+
+    with bench.record('block'):
+        pass
+
+    results = bench.get_results()
+    assert 'mb_timings' not in results.columns
+
+
+def test_time_multiple_iterations():
+    """With iterations=3, each bench.time() call appends one entry per iteration."""
+    bench = MicroBench(iterations=3)
+
+    @bench
+    def pipeline():
+        with bench.time('step'):
+            pass
+
+    pipeline()
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 3
+    assert all(t['name'] == 'step' for t in timings)
+
+
+def test_time_exception_closes_segment():
+    """An exception inside bench.time() still records the segment duration."""
+    bench = MicroBench()
+
+    with pytest.raises(ValueError):
+        with bench.record('block'):
+            with bench.time('risky'):
+                raise ValueError('fail')
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 1
+    assert timings[0]['name'] == 'risky'
+    assert timings[0]['duration'] >= 0
+
+
+def test_time_ordering_preserved():
+    """mb_timings entries appear in call order."""
+    bench = MicroBench()
+
+    names = ['alpha', 'beta', 'gamma', 'delta']
+    with bench.record('block'):
+        for n in names:
+            with bench.time(n):
+                pass
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert [t['name'] for t in timings] == names
+
+
+def test_time_same_name_multiple_times():
+    """Calling bench.time() with the same name produces multiple list entries."""
+    bench = MicroBench()
+
+    with bench.record('block'):
+        for _ in range(3):
+            with bench.time('repeat'):
+                pass
+
+    results = bench.get_results()
+    timings = results.iloc[0]['mb_timings']
+    assert len(timings) == 3
+    assert all(t['name'] == 'repeat' for t in timings)
+
+
+@pytest.mark.asyncio
+async def test_time_concurrent_arecord():
+    """Two concurrent arecord() calls get independent mb_timings."""
+    bench = MicroBench()
+
+    async def task_a():
+        async with bench.arecord('a'):
+            with bench.time('a_step'):
+                await asyncio.sleep(0)
+
+    async def task_b():
+        async with bench.arecord('b'):
+            with bench.time('b_step'):
+                await asyncio.sleep(0)
+
+    await asyncio.gather(task_a(), task_b())
+
+    results = bench.get_results()
+    assert len(results) == 2
+    by_name = {row['function_name']: row for _, row in results.iterrows()}
+
+    assert by_name['a']['mb_timings'] == [
+        {'name': 'a_step', 'duration': by_name['a']['mb_timings'][0]['duration']}
+    ]
+    assert by_name['b']['mb_timings'] == [
+        {'name': 'b_step', 'duration': by_name['b']['mb_timings'][0]['duration']}
+    ]
+    assert by_name['a']['mb_timings'][0]['name'] == 'a_step'
+    assert by_name['b']['mb_timings'][0]['name'] == 'b_step'


### PR DESCRIPTION
## Summary

- Adds `bench.time(name)` context manager to label named phases inside a single benchmark record, so all phases share one metadata capture pass (conda packages, git info, SLURM vars, nvidia-smi, etc.)
- Sub-timings accumulate in `mb_timings` as `[{"name": ..., "duration": ...}]` in call order; the field is absent when `bench.time()` is never used
- Works identically with `bench.record()`, `bench.arecord()`, `@bench` (sync and async), and `bench.record_on_exit()`; calling outside any active benchmark is a silent no-op

## Implementation

- Module-level `_active_bm_data` ContextVar (default `None`) threaded through all four entry points; each `asyncio.Task` gets its own copy so concurrent `arecord()` calls stay isolated
- `_TimingSection` class captures `bm_data` at construction time and appends `{"name", "duration"}` on `__exit__`; supports both `with` and `async with`
- `record_on_exit` path: `bench.time()` appends to `self._record_on_exit_timings` (instance list reset on each `record_on_exit()` call); `_exit_handler` copies it into the record