### PR TITLE
fix: start monitor thread at record_on_exit() call time, not exit time

### DIFF
--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -488,6 +488,28 @@ class MicroBench:
         if hasattr(self, '_record_on_exit_handler'):
             atexit.unregister(self._record_on_exit_handler)
 
+        # Terminate any monitor thread from a previous record_on_exit() call;
+        # its samples will be discarded because the start time is also reset.
+        if hasattr(self, '_record_on_exit_monitor_thread'):
+            self._record_on_exit_monitor_thread.terminate()
+            # No join here: we don't need the data and don't want to block.
+
+        # Start the monitor thread *now* so it spans the full process lifetime
+        # from this call to exit.  _exit_handler terminates it and injects the
+        # samples into the record, replacing the exit-time-only slot that
+        # pre_start_triggers would otherwise create.
+        _monitor_slot = None
+        _early_monitor = None
+        if hasattr(self, 'monitor'):
+            interval = getattr(self, 'monitor_interval', 60)
+            _monitor_slot = []
+            _early_monitor = _MonitorThread(
+                self.monitor, interval, _monitor_slot, self.tz
+            )
+            _early_monitor.start()
+            # Store handle so a subsequent record_on_exit() can terminate it.
+            self._record_on_exit_monitor_thread = _early_monitor
+
         _start_counter = self._duration_counter()
         _start_time = datetime.now(self.tz)
 
@@ -511,6 +533,13 @@ class MicroBench:
                 return
             _ctx['fired'] = True
 
+            # Stop the process-lifetime monitor thread before pre_start_triggers
+            # starts a new (exit-time-only) one.
+            if _early_monitor is not None:
+                _early_monitor.terminate()
+                timeout = getattr(self, 'monitor_timeout', 30)
+                _early_monitor.join(timeout)
+
             bm_data = dict()
             bm_data.update(self._bm_static)
             bm_data['function_name'] = name or '<process>'
@@ -522,6 +551,9 @@ class MicroBench:
             # both with the values recorded at the call site.
             bm_data['start_time'] = _start_time
             bm_data['run_durations'] = [self._duration_counter() - _start_counter]
+            # Replace exit-time-only monitor samples with our full-run ones.
+            if _monitor_slot is not None:
+                bm_data['monitor'] = _monitor_slot
 
             self.post_finish_triggers(bm_data)
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -504,7 +504,7 @@ class MicroBench:
             interval = getattr(self, 'monitor_interval', 60)
             _monitor_slot = []
             _early_monitor = _MonitorThread(
-                self.monitor, interval, _monitor_slot, self.tz
+                self.monitor, interval, _monitor_slot, self.tz, daemon=True
             )
             _early_monitor.start()
             # Store handle so a subsequent record_on_exit() can terminate it.

--- a/microbench/tests/test_core.py
+++ b/microbench/tests/test_core.py
@@ -1043,3 +1043,91 @@ async def test_async_monitor_thread():
     assert not monitor_bench._monitor_thread.is_alive()
     results = monitor_bench.get_results()
     assert len(results['monitor'][0]) > 0
+
+
+@pytest.mark.asyncio
+async def test_monitor_with_arecord():
+    """Monitor thread starts and stops correctly with bench.arecord()."""
+
+    class MonitorBench(MicroBench):
+        @staticmethod
+        def monitor(process):
+            return {'rss': process.memory_info().rss}
+
+    bench = MonitorBench()
+
+    async with bench.arecord('block'):
+        await asyncio.sleep(0)
+
+    assert not bench._monitor_thread.is_alive()
+    results = bench.get_results()
+    assert len(results) == 1
+    assert len(results.iloc[0]['monitor']) > 0
+
+
+# ---------------------------------------------------------------------------
+# monitor + record_on_exit() — monitor spans process lifetime
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_record_on_exit_samples_span_lifetime():
+    """Monitor samples are collected from record_on_exit() call time, not exit.
+
+    Before the fix, the monitor thread started inside _exit_handler, so it
+    collected at most one sample (from the exit instant).  After the fix it
+    starts at record_on_exit() call time and accumulates samples throughout
+    the process lifetime.
+    """
+
+    class MonitorBench(MicroBench):
+        monitor_interval = 0.05
+
+        @staticmethod
+        def monitor(process):
+            return {'rss': process.memory_info().rss}
+
+    bench = MonitorBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        time.sleep(0.25)  # long enough for several monitor samples
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert len(results) == 1
+    monitor_data = results.iloc[0]['monitor']
+    assert len(monitor_data) >= 2, (
+        f'Expected >=2 monitor samples across process lifetime, got {len(monitor_data)}'
+    )
+
+
+def test_monitor_record_on_exit_re_registration_terminates_old_thread():
+    """Re-calling record_on_exit() terminates the previous monitor thread."""
+
+    class MonitorBench(MicroBench):
+        monitor_interval = 60  # long interval — thread should not sample again
+
+        @staticmethod
+        def monitor(process):
+            return {'rss': process.memory_info().rss}
+
+    bench = MonitorBench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('first')
+        first_thread = bench._record_on_exit_monitor_thread
+        assert first_thread.is_alive()
+
+        bench.record_on_exit('second')
+        # Give the first thread time to notice the terminate signal
+        first_thread.join(timeout=2.0)
+        assert not first_thread.is_alive(), 'Old monitor thread should be stopped'
+
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert results.iloc[0]['function_name'] == 'second'


### PR DESCRIPTION
## Summary

- The `monitor` thread was started inside `_exit_handler` (via `pre_start_triggers`), so it only ran during the brief exit-handler window — collecting one or two samples from the exit instant, not from across the process lifetime. `start_time` and `run_durations` were correctly backdated; `monitor` samples were not.
- Start the monitor thread immediately in `record_on_exit()` so it spans the full process lifetime.
- Re-registration (second `record_on_exit()` call) terminates the previous monitor thread before starting a new one.

## Implementation

`_exit_handler` terminates and joins the early-started thread before `pre_start_triggers` runs (which starts a short-lived second thread for other captures). After `pre_start_triggers`, the full-run sample list is injected into `bm_data['monitor']`, replacing the exit-time-only slot the second thread wrote to. `post_finish_triggers` cleans up the second thread in the usual way.

## New tests

- `test_monitor_with_arecord` — `bench.arecord()` + monitor was previously untested
- `test_monitor_record_on_exit_samples_span_lifetime` — regression guard: sleeps 250 ms with `monitor_interval=0.05`, asserts ≥ 2 samples
- `test_monitor_record_on_exit_re_registration_terminates_old_thread` — verifies the old thread is stopped before the new one starts