### PR TITLE
feat: add --monitor-interval for CLI subprocess CPU/RAM monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,10 +112,21 @@ All notable changes to microbench are documented here.
   `--field KEY=VALUE` to attach extra labels; use `--iterations N` and
   `--warmup N` for repeat timing; use `--stdout[=suppress]` and
   `--stderr[=suppress]` to capture subprocess output into the record
-  (output is re-printed to the terminal unless `=suppress` is given).
-  Capture failures are non-fatal by default (`capture_optional = True`),
-  making the CLI safe across heterogeneous cluster nodes. The process exits
-  with the highest returncode seen across all timed iterations.
+  (output is re-printed to the terminal unless `=suppress` is given);
+  use `--monitor-interval SECONDS` to sample child process CPU and memory
+  over time (see below). Capture failures are non-fatal by default
+  (`capture_optional = True`), making the CLI safe across heterogeneous
+  cluster nodes. The process exits with the highest returncode seen across
+  all timed iterations.
+
+- **CLI subprocess monitoring** (`--monitor-interval SECONDS`): periodically
+  sample the child process's CPU usage and resident memory (RSS) while it
+  runs and record the time series in `subprocess_monitor`. Requires
+  `psutil`. Each element of `subprocess_monitor` is a list of
+  `{"timestamp", "cpu_percent", "rss_bytes"}` dicts for one timed
+  iteration; warmup iterations are excluded. Works on Linux, macOS, and
+  Windows. If the process exits before the first sample fires, the field is
+  omitted rather than written as empty.
 
 - **`capture_optional` class attribute**: set `capture_optional = True` on
   a benchmark class to catch exceptions from `capture_` and `capturepost_`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ result, the metadata shows exactly what was running.
 - **Command-line interface** — wrap any shell command, script, or compiled
   executable with `python -m microbench -- COMMAND` and capture host
   metadata alongside timing without writing Python code; ideal for SLURM
-  jobs
+  jobs; use `--monitor-interval` to record CPU and memory usage over time
 - **Extensible via _mixins_** — capture Python version, hostname, CPU/RAM
   specs, conda/pip package versions, NVIDIA GPU info, line-level profiles,
   peak memory usage, and more by adding mixin classes

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,7 @@ python -m microbench [options] -- COMMAND [ARGS...]
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
 | `--stdout[=suppress]` | Capture stdout into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--stderr[=suppress]` | Capture stderr into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
+| `--monitor-interval SECONDS` | Sample the child process CPU usage and RSS memory every SECONDS seconds. Requires `psutil`. See [Subprocess monitoring](#subprocess-monitoring) below. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 
 Use `--` to separate microbench options from the command being benchmarked.
@@ -40,6 +41,7 @@ Every record contains the standard fields (`start_time`, `finish_time`,
 | `command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
 | `returncode` | List of exit codes, one per timed iteration (warmup excluded). The process exits with the highest value. |
 | `function_name` | Basename of the executable, e.g. `"run_sim.sh"`. |
+| `subprocess_monitor` | *(present only with `--monitor-interval`)* List of per-iteration sample lists. See [Subprocess monitoring](#subprocess-monitoring). |
 
 ## Default mixins
 
@@ -155,3 +157,63 @@ python -m microbench \
 ```
 
 All `--field` values are stored as strings.
+
+## Subprocess monitoring
+
+Use `--monitor-interval SECONDS` to periodically sample the child process
+while it runs. This requires the [`psutil`](https://psutil.readthedocs.io/)
+package (`pip install psutil`).
+
+```bash
+python -m microbench \
+    --outfile results.jsonl \
+    --monitor-interval 5 \
+    -- ./run_simulation.sh --steps 10000
+```
+
+The record gains a `subprocess_monitor` field: a list of per-iteration
+sample lists (one inner list per `--iterations` call, warmup excluded).
+Each sample is a dict with three keys:
+
+| Key | Description |
+|---|---|
+| `timestamp` | ISO 8601 UTC timestamp of the sample. |
+| `cpu_percent` | CPU usage of the child process as a percentage (0–100 per core, so values above 100 are possible on multi-core machines). The first sample is always `0.0` — this is a psutil limitation where two successive calls are needed to compute a ratio. |
+| `rss_bytes` | Resident set size (physical RAM) of the child process in bytes. |
+
+Example record (single iteration, two samples):
+
+```json
+{
+  "subprocess_monitor": [
+    [
+      {"timestamp": "2025-01-01T12:00:05Z", "cpu_percent": 0.0,  "rss_bytes": 52428800},
+      {"timestamp": "2025-01-01T12:00:10Z", "cpu_percent": 87.3, "rss_bytes": 61865984}
+    ]
+  ]
+}
+```
+
+Only the direct child process is tracked. If the child spawns its own
+subprocesses, their CPU and memory usage are not included.
+
+If the process exits before the first sample interval fires (e.g. a very
+short-lived command with a long `--monitor-interval`), the inner list will
+be empty and `subprocess_monitor` is omitted from the record.
+
+Analyse with pandas:
+
+```python
+import pandas, json
+
+results = pandas.read_json('results.jsonl', lines=True)
+
+# Flatten all samples for the first iteration across all records
+samples = pandas.DataFrame([
+    s
+    for row in results['subprocess_monitor']
+    for s in row[0]          # row[0] = first iteration
+])
+samples['rss_mb'] = samples['rss_bytes'] / 1024 / 1024
+print(samples[['timestamp', 'cpu_percent', 'rss_mb']])
+```

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 import threading
+from datetime import datetime, timezone
 
 
 def _get_mixin_map():
@@ -31,6 +32,43 @@ def _get_mixin_map():
 _DEFAULT_MIXINS = ('MBHostInfo', 'MBSlurmInfo', 'MBLoadedModules')
 
 _CAPTURE_CHOICES = ('capture', 'suppress')
+
+
+class _SubprocessMonitorThread(threading.Thread):
+    """Background thread that samples CPU and RSS of a child process."""
+
+    def __init__(self, pid, interval):
+        super().__init__(daemon=True)
+        self._pid = pid
+        self._interval = interval
+        self._stop = threading.Event()
+        self.samples = []
+
+    def stop(self):
+        self._stop.set()
+
+    def run(self):
+        try:
+            import psutil
+        except ImportError:
+            return
+        try:
+            proc = psutil.Process(self._pid)
+            # First call primes the CPU percentage counter; result is always 0.0.
+            proc.cpu_percent(interval=None)
+            while not self._stop.wait(self._interval):
+                try:
+                    self.samples.append(
+                        {
+                            'timestamp': datetime.now(timezone.utc),
+                            'cpu_percent': proc.cpu_percent(interval=None),
+                            'rss_bytes': proc.memory_info().rss,
+                        }
+                    )
+                except psutil.NoSuchProcess:
+                    break
+        except psutil.NoSuchProcess:
+            pass
 
 
 def _int_at_least(minimum):
@@ -132,6 +170,17 @@ def _build_parser(mixin_names):
         ),
     )
     parser.add_argument(
+        '--monitor-interval',
+        type=_int_at_least(1),
+        default=None,
+        metavar='SECONDS',
+        help=(
+            'Sample child process CPU usage and RSS every SECONDS seconds, '
+            'recording results in subprocess_monitor. Requires psutil. '
+            'Monitoring is disabled when this flag is omitted.'
+        ),
+    )
+    parser.add_argument(
         '--field',
         '-f',
         action='append',
@@ -182,6 +231,12 @@ def main(argv=None):
         k, v = field.split('=', 1)
         extra_fields[k] = v
 
+    if args.monitor_interval is not None:
+        try:
+            import psutil  # noqa: F401
+        except ImportError:
+            parser.error('--monitor-interval requires the "psutil" package.')
+
     from microbench import FileOutput, MicroBench
 
     class _MBSubprocessResult:
@@ -191,6 +246,8 @@ def main(argv=None):
             self._subprocess_returncodes = []
             self._subprocess_stdout = []
             self._subprocess_stderr = []
+            self._subprocess_monitor = []
+            self._subprocess_timed_phase = True
 
         def capturepost_subprocess_result(self, bm_data):
             bm_data['command'] = self._subprocess_command
@@ -199,6 +256,8 @@ def main(argv=None):
                 bm_data['stdout'] = self._subprocess_stdout
             if self._subprocess_stderr:
                 bm_data['stderr'] = self._subprocess_stderr
+            if any(self._subprocess_monitor):
+                bm_data['subprocess_monitor'] = self._subprocess_monitor
 
     BenchClass = type(
         'CLIBench',
@@ -217,6 +276,8 @@ def main(argv=None):
     bench._subprocess_returncodes = []
     bench._subprocess_stdout = []
     bench._subprocess_stderr = []
+    bench._subprocess_monitor = []
+    bench._subprocess_timed_phase = False  # becomes True after warmup
 
     # Hold references to the real streams before any patching in tests.
     _real_stdout = sys.__stdout__
@@ -225,14 +286,15 @@ def main(argv=None):
     def run():
         capture_stdout = args.stdout in _CAPTURE_CHOICES
         capture_stderr = args.stderr in _CAPTURE_CHOICES
+        monitor_interval = args.monitor_interval
 
-        if not capture_stdout and not capture_stderr:
+        if not capture_stdout and not capture_stderr and monitor_interval is None:
             result = subprocess.run(cmd)
             bench._subprocess_returncodes.append(result.returncode)
             return
 
-        # Use Popen with per-pipe reader threads so output is forwarded to
-        # the terminal in real time rather than buffered until the process exits.
+        # Use Popen so we have the PID (needed for monitoring) and can read
+        # stdout/stderr pipes in real time when capture is requested.
         stdout_chunks = []
         stderr_chunks = []
 
@@ -278,7 +340,19 @@ def main(argv=None):
                 )
                 t.start()
                 threads.append(t)
+
+            monitor_thread = None
+            if monitor_interval is not None and bench._subprocess_timed_phase:
+                monitor_thread = _SubprocessMonitorThread(proc.pid, monitor_interval)
+                monitor_thread.start()
+
             proc.wait()
+
+            if monitor_thread is not None:
+                monitor_thread.stop()
+                monitor_thread.join()
+                bench._subprocess_monitor.append(monitor_thread.samples)
+
             for t in threads:
                 t.join()
 

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -54,9 +54,10 @@ class _SubprocessMonitorThread(threading.Thread):
             return
         try:
             proc = psutil.Process(self._pid)
-            # First call primes the CPU percentage counter; result is always 0.0.
-            proc.cpu_percent(interval=None)
-            while not self._stop.wait(self._interval):
+            # Prime the CPU counter with a short blocking interval so the
+            # immediate first sample has a meaningful cpu_percent value.
+            proc.cpu_percent(interval=0.1)
+            while True:
                 try:
                     self.samples.append(
                         {
@@ -66,6 +67,8 @@ class _SubprocessMonitorThread(threading.Thread):
                         }
                     )
                 except psutil.NoSuchProcess:
+                    break
+                if self._stop.wait(self._interval):
                     break
         except psutil.NoSuchProcess:
             pass

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -452,3 +452,232 @@ def test_cli_no_mixin_overrides_mixin():
     _, record, _ = _run_main(['--no-mixin', '--mixin', 'MBHostInfo', '--', 'true'])
 
     assert 'hostname' not in record
+
+
+# ---------------------------------------------------------------------------
+# --monitor-interval tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_popen_for_monitor(returncode=0, pid=12345):
+    """Popen mock that exposes a .pid and no pipes (no stdout/stderr capture)."""
+    mock_proc = MagicMock()
+    mock_proc.__enter__.return_value = mock_proc
+    mock_proc.__exit__.return_value = False
+    mock_proc.returncode = returncode
+    mock_proc.pid = pid
+    mock_proc.stdout = None
+    mock_proc.stderr = None
+    return mock_proc
+
+
+def _run_main_with_monitor(argv, mock_pid=12345, mock_returncode=0, fake_samples=None):
+    """
+    Run main() with --monitor-interval, mocking both Popen and the monitor thread.
+
+    fake_samples: list of sample dicts the thread will report (default: one sample).
+    """
+    if fake_samples is None:
+        fake_samples = [{'timestamp': 'T0', 'cpu_percent': 12.5, 'rss_bytes': 1048576}]
+
+    mock_proc = _make_mock_popen_for_monitor(returncode=mock_returncode, pid=mock_pid)
+
+    # Patch _SubprocessMonitorThread so no real psutil calls happen.
+    with patch('microbench.__main__._SubprocessMonitorThread') as MockThread:
+        mock_thread = MagicMock()
+        mock_thread.samples = fake_samples
+        MockThread.return_value = mock_thread
+
+        buf = io.StringIO()
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(argv)
+
+    return json.loads(buf.getvalue()), MockThread, mock_thread
+
+
+def test_cli_monitor_interval_absent_by_default():
+    """subprocess_monitor is absent when --monitor-interval is not given."""
+    _, record, _ = _run_main(['--no-mixin', '--', 'true'])
+
+    assert 'subprocess_monitor' not in record
+
+
+def test_cli_monitor_interval_creates_field():
+    """--monitor-interval produces a subprocess_monitor field with samples."""
+    record, MockThread, mock_thread = _run_main_with_monitor(
+        ['--no-mixin', '--monitor-interval', '5', '--', 'sleep', '10']
+    )
+
+    assert 'subprocess_monitor' in record
+    assert len(record['subprocess_monitor']) == 1  # one iteration
+    assert record['subprocess_monitor'][0][0]['cpu_percent'] == 12.5
+    assert record['subprocess_monitor'][0][0]['rss_bytes'] == 1048576
+
+
+def test_cli_monitor_interval_thread_constructed_correctly():
+    """Monitor thread is created with the subprocess PID and requested interval."""
+    _, MockThread, _ = _run_main_with_monitor(
+        ['--no-mixin', '--monitor-interval', '30', '--', 'cmd'],
+        mock_pid=99999,
+    )
+
+    MockThread.assert_called_once_with(99999, 30)
+
+
+def test_cli_monitor_interval_thread_lifecycle():
+    """Monitor thread is started, stopped, and joined for each iteration."""
+    _, _, mock_thread = _run_main_with_monitor(
+        ['--no-mixin', '--monitor-interval', '5', '--', 'cmd']
+    )
+
+    mock_thread.start.assert_called_once()
+    mock_thread.stop.assert_called_once()
+    mock_thread.join.assert_called_once()
+
+
+def test_cli_monitor_interval_empty_samples():
+    """subprocess_monitor field is absent when no samples were collected."""
+    # A very fast process may exit before the first sample interval fires.
+    record, _, _ = _run_main_with_monitor(
+        ['--no-mixin', '--monitor-interval', '60', '--', 'true'],
+        fake_samples=[],
+    )
+
+    # Empty per-iteration lists → outer list is [[]], which is falsy per-element
+    # but the field should still be absent (no data to report).
+    assert 'subprocess_monitor' not in record
+
+
+def test_cli_monitor_interval_multiple_iterations():
+    """With --iterations N, subprocess_monitor has N inner lists."""
+    mock_proc = _make_mock_popen_for_monitor(pid=42)
+
+    samples_per_iter = [
+        [{'timestamp': 'T0', 'cpu_percent': 10.0, 'rss_bytes': 100}],
+        [{'timestamp': 'T1', 'cpu_percent': 20.0, 'rss_bytes': 200}],
+        [{'timestamp': 'T2', 'cpu_percent': 30.0, 'rss_bytes': 300}],
+    ]
+    call_count = {'n': 0}
+
+    def make_thread(pid, interval):
+        idx = call_count['n']
+        call_count['n'] += 1
+        t = MagicMock()
+        t.samples = samples_per_iter[idx]
+        return t
+
+    buf = io.StringIO()
+    with patch('microbench.__main__._SubprocessMonitorThread', side_effect=make_thread):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(
+                        [
+                            '--no-mixin',
+                            '--monitor-interval',
+                            '5',
+                            '--iterations',
+                            '3',
+                            '--',
+                            'cmd',
+                        ]
+                    )
+
+    record = json.loads(buf.getvalue())
+    assert len(record['subprocess_monitor']) == 3
+    assert record['subprocess_monitor'][0][0]['cpu_percent'] == 10.0
+    assert record['subprocess_monitor'][1][0]['cpu_percent'] == 20.0
+    assert record['subprocess_monitor'][2][0]['cpu_percent'] == 30.0
+
+
+def test_cli_monitor_interval_warmup_excluded():
+    """Warmup iterations not monitored; subprocess_monitor length == --iterations."""
+    mock_proc = _make_mock_popen_for_monitor(pid=7)
+    call_count = {'n': 0}
+    # 2 warmup + 2 timed = 4 Popen calls; but only 2 monitor threads should start.
+    sample = [{'timestamp': 'T', 'cpu_percent': 5.0, 'rss_bytes': 50}]
+
+    def make_thread(pid, interval):
+        call_count['n'] += 1
+        t = MagicMock()
+        t.samples = sample
+        return t
+
+    buf = io.StringIO()
+    with patch('microbench.__main__._SubprocessMonitorThread', side_effect=make_thread):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(
+                        [
+                            '--no-mixin',
+                            '--monitor-interval',
+                            '5',
+                            '--warmup',
+                            '2',
+                            '--iterations',
+                            '2',
+                            '--',
+                            'cmd',
+                        ]
+                    )
+
+    record = json.loads(buf.getvalue())
+    assert len(record['subprocess_monitor']) == 2
+    assert call_count['n'] == 2  # only timed iterations got a monitor thread
+
+
+def test_cli_monitor_interval_minimum_one():
+    """--monitor-interval 0 is rejected."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--monitor-interval', '0', '--', 'cmd'])
+    assert exc.value.code != 0
+
+
+def test_cli_monitor_interval_negative_rejected():
+    """--monitor-interval -1 is rejected."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--monitor-interval', '-1', '--', 'cmd'])
+    assert exc.value.code != 0
+
+
+def test_cli_monitor_interval_requires_psutil():
+    """--monitor-interval exits with an error when psutil is not installed."""
+    with patch.dict('sys.modules', {'psutil': None}):
+        with pytest.raises(SystemExit) as exc:
+            main(['--monitor-interval', '5', '--', 'cmd'])
+    assert exc.value.code != 0
+
+
+def test_cli_monitor_interval_with_stdout_capture():
+    """--monitor-interval and --stdout can be combined."""
+    mock_proc = _make_mock_popen_for_monitor(pid=55)
+    mock_proc.stdout = iter([b'hello\n'])
+    mock_proc.stderr = None
+    fake_samples = [{'timestamp': 'T', 'cpu_percent': 8.0, 'rss_bytes': 2048}]
+
+    buf = io.StringIO()
+    with patch('microbench.__main__._SubprocessMonitorThread') as MockThread:
+        mock_thread = MagicMock()
+        mock_thread.samples = fake_samples
+        MockThread.return_value = mock_thread
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stdout__', io.StringIO()):
+                    with pytest.raises(SystemExit):
+                        main(
+                            [
+                                '--no-mixin',
+                                '--monitor-interval',
+                                '5',
+                                '--stdout',
+                                '--',
+                                'cmd',
+                            ]
+                        )
+
+    record = json.loads(buf.getvalue())
+    assert record['stdout'] == ['hello\n']
+    assert record['subprocess_monitor'][0][0]['cpu_percent'] == 8.0


### PR DESCRIPTION
## Summary

- Adds `--monitor-interval SECONDS` to `python -m microbench`, periodically sampling the child process's CPU usage and RSS while it runs
- Results recorded in `subprocess_monitor`: a list of per-iteration sample lists, each sample containing `timestamp`, `cpu_percent`, and `rss_bytes`
- Monitoring is opt-in (flag must be specified), warmup iterations are excluded, field is omitted if no samples collected
- Requires `psutil`; fails at startup with a clear error if unavailable
- Works on Linux, macOS, and Windows via psutil's cross-platform API