### PR TITLE
feat: add MBCgroupLimits mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,28 @@ All notable changes to microbench are documented here.
 
 ### New features
 
+- **`MBCgroupLimits`**: captures the CPU quota and memory limit enforced by
+  the Linux cgroup filesystem. Works for SLURM jobs and Kubernetes pods (cgroup
+  v1 and v2). Fields in `cgroup_limits`: `cpu_cores` (float — quota ÷ period,
+  or `null` if unlimited), `memory_bytes` (int or `null` if unlimited),
+  `cgroup_version` (1 or 2). Returns `{}` on non-Linux systems or when the
+  cgroup filesystem is unavailable.
+
+  ```python
+  class Bench(MicroBench, MBSlurmInfo, MBCgroupLimits):
+      pass
+  ```
+
+  ```json
+  {
+    "cgroup_limits": {
+      "cpu_cores": 4.0,
+      "memory_bytes": 17179869184,
+      "cgroup_version": 2
+    }
+  }
+  ```
+
 - **`bench.time(name)` sub-timing API**: label phases inside a single benchmark
   record with named timing sections. Sub-timings accumulate in `mb_timings` as
   `[{"name": ..., "duration": ...}, ...]` in call order. Compatible with

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -30,6 +30,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBPeakMemory` | `peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
 | `MBLoadedModules` | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
+| `MBCgroupLimits` | `cgroup_limits` dict with `cpu_cores`, `memory_bytes`, `cgroup_version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
 | `MBGitInfo` | `git_info` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `package_versions` for every installed package | — |
@@ -138,7 +139,7 @@ process(list(range(1_000_000, 0, -1)))
     sampling of memory, CPU, and other metrics *while the function runs*,
     see [Periodic monitoring](monitoring.md).
 
-## HPC / SLURM
+## HPC and containers
 
 ### `MBSlurmInfo`
 
@@ -217,6 +218,53 @@ string as the version. Hierarchical module names such as
 This mixin reads the `LOADEDMODULES` environment variable, which is the
 standard set by both Lmod and Environment Modules. No subprocess is
 required and there are no extra dependencies.
+
+### `MBCgroupLimits`
+
+Captures the CPU quota and memory limit enforced by the Linux control groups
+(cgroups). Works for SLURM jobs and Kubernetes pods, on both cgroup v1 and
+cgroup v2 systems, with no external dependencies. Unlike `MBHostCpuCores` and
+`MBHostRamTotal` (which report the physical node's total resources),
+`MBCgroupLimits` reports what the scheduler actually allocated to this job or
+container — the number that determines your benchmark's resource budget.
+
+```python
+from microbench import MicroBench, MBSlurmInfo, MBCgroupLimits
+
+class Bench(MicroBench, MBSlurmInfo, MBCgroupLimits):
+    pass
+
+bench = Bench()
+```
+
+Each record will contain:
+
+```json
+{
+  "cgroup_limits": {
+    "cpu_cores": 4.0,
+    "memory_bytes": 17179869184,
+    "cgroup_version": 2
+  }
+}
+```
+
+**`cpu_cores`** is derived from the cgroup CPU quota and period
+(`quota_us / period_us`), so it represents effective CPU parallelism rather than
+a physical core count. A SLURM job launched with `--cpus-per-task=4` will
+typically report `cpu_cores: 4.0`.
+
+**`memory_bytes`** is the hard memory limit in bytes. A job allocated `--mem=16G`
+will typically report `memory_bytes: 17179869184`.
+
+Both fields are `null` when no limit is set (the scheduler granted unlimited
+access to that resource). `cgroup_limits` is an empty dict on non-Linux
+platforms or when the cgroup filesystem is unavailable.
+
+!!! tip
+    Pair with `MBSlurmInfo` for full HPC context — `MBSlurmInfo` captures
+    scheduler metadata (job ID, node list, etc.) while `MBCgroupLimits` captures
+    the kernel-enforced resource limits.
 
 ## Code provenance
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -32,6 +32,7 @@ except ImportError:
 from ._encoding import _UNENCODABLE_PLACEHOLDER_VALUE, JSONEncoder, JSONEncodeWarning
 from ._output import FileOutput, Output, RedisOutput
 from .mixins import (
+    MBCgroupLimits,
     MBCondaPackages,
     MBFileHash,
     MBFunctionCall,
@@ -80,6 +81,7 @@ __all__ = [
     'MBPeakMemory',
     'MBSlurmInfo',
     'MBLoadedModules',
+    'MBCgroupLimits',
     'MBGitInfo',
     'MBFileHash',
     'MBGlobalPackages',

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -169,6 +169,127 @@ class MBLoadedModules:
         bm_data['loaded_modules'] = modules
 
 
+def _read_cgroup_v2():
+    """Read CPU quota and memory limit from a cgroup v2 hierarchy."""
+    cgroup_path = None
+    with open('/proc/self/cgroup') as f:
+        for line in f:
+            parts = line.strip().split(':', 2)
+            if len(parts) == 3 and parts[0] == '0':
+                cgroup_path = parts[2]
+                break
+    if not cgroup_path:
+        return {}
+
+    base = os.path.join('/sys/fs/cgroup', cgroup_path.lstrip('/'))
+    cpu_cores = None
+    memory_bytes = None
+
+    cpu_max = os.path.join(base, 'cpu.max')
+    if os.path.exists(cpu_max):
+        with open(cpu_max) as f:
+            parts = f.read().split()
+        if len(parts) == 2 and parts[0] != 'max':
+            cpu_cores = int(parts[0]) / int(parts[1])
+
+    mem_max = os.path.join(base, 'memory.max')
+    if os.path.exists(mem_max):
+        with open(mem_max) as f:
+            content = f.read().strip()
+        if content != 'max':
+            memory_bytes = int(content)
+
+    return {'cpu_cores': cpu_cores, 'memory_bytes': memory_bytes, 'cgroup_version': 2}
+
+
+def _read_cgroup_v1():
+    """Read CPU quota and memory limit from a cgroup v1 hierarchy."""
+    cpu_path = None
+    memory_path = None
+    with open('/proc/self/cgroup') as f:
+        for line in f:
+            parts = line.strip().split(':', 2)
+            if len(parts) != 3:
+                continue
+            _, controllers, path = parts
+            controllers_list = controllers.split(',')
+            if 'cpu' in controllers_list and cpu_path is None:
+                cpu_path = path
+            if 'memory' in controllers_list and memory_path is None:
+                memory_path = path
+
+    cpu_cores = None
+    memory_bytes = None
+
+    if cpu_path is not None:
+        quota_path = '/sys/fs/cgroup/cpu' + cpu_path + '/cpu.cfs_quota_us'
+        period_path = '/sys/fs/cgroup/cpu' + cpu_path + '/cpu.cfs_period_us'
+        if os.path.exists(quota_path) and os.path.exists(period_path):
+            with open(quota_path) as f:
+                quota = int(f.read().strip())
+            with open(period_path) as f:
+                period = int(f.read().strip())
+            if quota != -1:
+                cpu_cores = quota / period
+
+    if memory_path is not None:
+        limit_path = '/sys/fs/cgroup/memory' + memory_path + '/memory.limit_in_bytes'
+        if os.path.exists(limit_path):
+            with open(limit_path) as f:
+                limit = int(f.read().strip())
+            if limit < 2**62:
+                memory_bytes = limit
+
+    return {'cpu_cores': cpu_cores, 'memory_bytes': memory_bytes, 'cgroup_version': 1}
+
+
+class MBCgroupLimits:
+    """Capture CPU quota and memory limit from the Linux cgroup filesystem.
+
+    Works for SLURM jobs and Kubernetes pods (cgroup v1 and v2). Results
+    are stored in the ``cgroup_limits`` field as a dict containing:
+
+    - ``cpu_cores``: effective CPU parallelism as a float (quota ÷ period),
+      or ``None`` if unlimited or unavailable.
+    - ``memory_bytes``: memory limit in bytes as an int, or ``None`` if
+      unlimited or unavailable.
+    - ``cgroup_version``: ``1`` or ``2``.
+
+    On non-Linux systems or when the cgroup filesystem is unavailable,
+    ``cgroup_limits`` is an empty dict.
+
+    Note:
+        ``cpu_cores`` is derived from the cgroup CPU quota and period, so it
+        represents effective CPU parallelism, not a physical core count. A
+        SLURM job launched with ``--cpus-per-task=4`` will typically report
+        ``cpu_cores: 4.0``.
+
+    Example output::
+
+        {
+            "cgroup_limits": {
+                "cpu_cores": 4.0,
+                "memory_bytes": 17179869184,
+                "cgroup_version": 2
+            }
+        }
+    """
+
+    cli_compatible = True
+
+    def capture_cgroup_limits(self, bm_data):
+        if sys.platform != 'linux':
+            bm_data['cgroup_limits'] = {}
+            return
+        try:
+            if os.path.exists('/sys/fs/cgroup/cgroup.controllers'):
+                bm_data['cgroup_limits'] = _read_cgroup_v2()
+            else:
+                bm_data['cgroup_limits'] = _read_cgroup_v1()
+        except (OSError, ValueError, ZeroDivisionError):
+            bm_data['cgroup_limits'] = {}
+
+
 class MBGitInfo:
     """Capture git repository information.
 

--- a/microbench/tests/test_mixins.py
+++ b/microbench/tests/test_mixins.py
@@ -1,11 +1,12 @@
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pandas
 import pytest
 
 from microbench import (
+    MBCgroupLimits,
     MBFileHash,
     MBGitInfo,
     MBInstalledPackages,
@@ -602,3 +603,211 @@ def test_record_mblineprofiler_raises():
     with pytest.raises(NotImplementedError, match='MBLineProfiler'):
         with bench.record('block'):
             pass
+
+
+# ---------------------------------------------------------------------------
+# MBCgroupLimits
+# ---------------------------------------------------------------------------
+
+
+def _make_cgroup_open(file_map):
+    """Return a side_effect for builtins.open that serves canned file contents."""
+
+    def _open(path, *args, **kwargs):
+        if path in file_map:
+            return mock_open(read_data=file_map[path])()
+        raise FileNotFoundError(f'No mock for {path!r}')
+
+    return _open
+
+
+def test_cgroup_limits_non_linux():
+    """Returns {} on non-Linux platforms."""
+
+    class Bench(MicroBench, MBCgroupLimits):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with patch('sys.platform', 'win32'):
+        noop()
+
+    assert bench.get_results()['cgroup_limits'][0] == {}
+
+
+def test_cgroup_limits_v2_limited():
+    """cgroup v2: both CPU and memory limits set returns correct float and int."""
+
+    class Bench(MicroBench, MBCgroupLimits):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    cgroup_path = '/system.slice/job_123'
+    file_map = {
+        '/proc/self/cgroup': f'0::{cgroup_path}\n',
+        f'/sys/fs/cgroup{cgroup_path}/cpu.max': '400000 100000\n',
+        f'/sys/fs/cgroup{cgroup_path}/memory.max': '17179869184\n',
+    }
+    exists_map = {
+        '/sys/fs/cgroup/cgroup.controllers': True,
+        f'/sys/fs/cgroup{cgroup_path}/cpu.max': True,
+        f'/sys/fs/cgroup{cgroup_path}/memory.max': True,
+    }
+
+    with (
+        patch('sys.platform', 'linux'),
+        patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+    ):
+        noop()
+
+    result = bench.get_results()['cgroup_limits'][0]
+    assert result['cpu_cores'] == 4.0
+    assert result['memory_bytes'] == 17179869184
+    assert result['cgroup_version'] == 2
+
+
+def test_cgroup_limits_v2_unlimited():
+    """cgroup v2: 'max' for both limits stores None for each field."""
+
+    class Bench(MicroBench, MBCgroupLimits):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    cgroup_path = '/system.slice/job_456'
+    file_map = {
+        '/proc/self/cgroup': f'0::{cgroup_path}\n',
+        f'/sys/fs/cgroup{cgroup_path}/cpu.max': 'max 100000\n',
+        f'/sys/fs/cgroup{cgroup_path}/memory.max': 'max\n',
+    }
+    exists_map = {
+        '/sys/fs/cgroup/cgroup.controllers': True,
+        f'/sys/fs/cgroup{cgroup_path}/cpu.max': True,
+        f'/sys/fs/cgroup{cgroup_path}/memory.max': True,
+    }
+
+    with (
+        patch('sys.platform', 'linux'),
+        patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+    ):
+        noop()
+
+    result = bench.get_results()['cgroup_limits'][0]
+    assert result['cpu_cores'] is None
+    assert result['memory_bytes'] is None
+    assert result['cgroup_version'] == 2
+
+
+def test_cgroup_limits_v1_limited():
+    """cgroup v1: CPU quota and memory limit set returns correct values."""
+
+    class Bench(MicroBench, MBCgroupLimits):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    job_path = '/slurm/uid_1000/job_99'
+    file_map = {
+        '/proc/self/cgroup': (f'9:cpuacct,cpu:{job_path}\n10:memory:{job_path}\n'),
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_quota_us': '200000\n',
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_period_us': '100000\n',
+        f'/sys/fs/cgroup/memory{job_path}/memory.limit_in_bytes': '8589934592\n',
+    }
+    exists_map = {
+        '/sys/fs/cgroup/cgroup.controllers': False,
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_quota_us': True,
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_period_us': True,
+        f'/sys/fs/cgroup/memory{job_path}/memory.limit_in_bytes': True,
+    }
+
+    with (
+        patch('sys.platform', 'linux'),
+        patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+    ):
+        noop()
+
+    result = bench.get_results()['cgroup_limits'][0]
+    assert result['cpu_cores'] == 2.0
+    assert result['memory_bytes'] == 8589934592
+    assert result['cgroup_version'] == 1
+
+
+def test_cgroup_limits_v1_unlimited_cpu():
+    """cgroup v1: quota -1 means unlimited CPU; cpu_cores is None."""
+
+    class Bench(MicroBench, MBCgroupLimits):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    job_path = '/slurm/uid_1000/job_100'
+    file_map = {
+        '/proc/self/cgroup': f'9:cpuacct,cpu:{job_path}\n10:memory:{job_path}\n',
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_quota_us': '-1\n',
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_period_us': '100000\n',
+        f'/sys/fs/cgroup/memory{job_path}/memory.limit_in_bytes': '4294967296\n',
+    }
+    exists_map = {
+        '/sys/fs/cgroup/cgroup.controllers': False,
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_quota_us': True,
+        f'/sys/fs/cgroup/cpu{job_path}/cpu.cfs_period_us': True,
+        f'/sys/fs/cgroup/memory{job_path}/memory.limit_in_bytes': True,
+    }
+
+    with (
+        patch('sys.platform', 'linux'),
+        patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+    ):
+        noop()
+
+    result = bench.get_results()['cgroup_limits'][0]
+    assert result['cpu_cores'] is None
+    assert result['memory_bytes'] == 4294967296
+    assert result['cgroup_version'] == 1
+
+
+def test_cgroup_limits_unavailable():
+    """Returns {} when the cgroup filesystem is not present."""
+
+    class Bench(MicroBench, MBCgroupLimits):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with (
+        patch('sys.platform', 'linux'),
+        patch('os.path.exists', return_value=False),
+        patch('builtins.open', side_effect=FileNotFoundError('/proc/self/cgroup')),
+    ):
+        noop()
+
+    assert bench.get_results()['cgroup_limits'][0] == {}

--- a/microbench/tests/test_mixins.py
+++ b/microbench/tests/test_mixins.py
@@ -610,12 +610,18 @@ def test_record_mblineprofiler_raises():
 # ---------------------------------------------------------------------------
 
 
+def _norm(path):
+    """Normalise path separators to '/' so cgroup mocks work on Windows too."""
+    return path.replace('\\', '/')
+
+
 def _make_cgroup_open(file_map):
     """Return a side_effect for builtins.open that serves canned file contents."""
 
     def _open(path, *args, **kwargs):
-        if path in file_map:
-            return mock_open(read_data=file_map[path])()
+        norm = _norm(path)
+        if norm in file_map:
+            return mock_open(read_data=file_map[norm])()
         raise FileNotFoundError(f'No mock for {path!r}')
 
     return _open
@@ -666,7 +672,7 @@ def test_cgroup_limits_v2_limited():
     with (
         patch('sys.platform', 'linux'),
         patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
-        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(_norm(p), False)),
     ):
         noop()
 
@@ -703,7 +709,7 @@ def test_cgroup_limits_v2_unlimited():
     with (
         patch('sys.platform', 'linux'),
         patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
-        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(_norm(p), False)),
     ):
         noop()
 
@@ -742,7 +748,7 @@ def test_cgroup_limits_v1_limited():
     with (
         patch('sys.platform', 'linux'),
         patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
-        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(_norm(p), False)),
     ):
         noop()
 
@@ -781,7 +787,7 @@ def test_cgroup_limits_v1_unlimited_cpu():
     with (
         patch('sys.platform', 'linux'),
         patch('builtins.open', side_effect=_make_cgroup_open(file_map)),
-        patch('os.path.exists', side_effect=lambda p: exists_map.get(p, False)),
+        patch('os.path.exists', side_effect=lambda p: exists_map.get(_norm(p), False)),
     ):
         noop()
 


### PR DESCRIPTION
## Summary

- Adds `MBCgroupLimits` mixin that reads allocated CPU quota and memory limit from the Linux cgroup filesystem (v1 and v2)
- Reports what the scheduler actually allocated to the job/container (not the node's physical totals) — works for SLURM jobs and Kubernetes pods with no extra dependencies
- Returns `{}` on non-Linux or when the cgroup fs is unavailable
- Renames the "HPC / SLURM" docs section to "HPC and containers" to reflect broader applicability