### PR TITLE
feat!: results API — get_results(format, flat) and summary()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to microbench are documented here.
 
 ### Breaking changes
 
+- **`get_results()` now returns a list of dicts by default**: The default
+  `format='dict'` returns a list of plain Python dicts and requires no
+  dependencies. Pass `format='df'` to get a pandas DataFrame (previous
+  behaviour). Update existing callers: `bench.get_results()` →
+  `bench.get_results(format='df')`.
+
 - **`telemetry` renamed to `monitor`** (#51): The background sampling thread
   has been renamed throughout the API to better reflect its intent (continuous
   monitoring, not data transmission).
@@ -38,6 +44,40 @@ All notable changes to microbench are documented here.
   ```
 
 ### New features
+
+- **`get_results(format=..., flat=...)`**: `get_results` now accepts two
+  keyword arguments.
+  - `format='dict'` (default) — returns a list of dicts; no pandas required.
+  - `format='df'` — returns a pandas DataFrame (previous default behaviour).
+  - `flat=True` — flattens nested dict fields (e.g. `slurm`, `cgroup_limits`,
+    `git_info`) into dot-notation keys (`slurm.job_id`). Works for both
+    formats without requiring pandas.
+
+- **`summary(results)` / `bench.summary()`**: prints min / mean / median /
+  max / stdev of `run_durations` across all results. No dependencies required
+  beyond the Python standard library. `bench.summary()` is a one-liner
+  convenience that calls `bench.get_results()` internally. The module-level
+  `summary(results)` accepts any list of dicts and can be composed with other
+  results-processing steps.
+
+  ```python
+  from microbench import MicroBench, summary
+
+  bench = MicroBench()
+
+  @bench
+  def my_function():
+      ...
+
+  for _ in range(10):
+      my_function()
+
+  bench.summary()
+  # n=10  min=0.000031  mean=0.000038  median=0.000036  max=0.000059  stdev=0.000008
+
+  # or with explicit results list:
+  summary(bench.get_results())
+  ```
 
 - **`MBCgroupLimits`**: captures the CPU quota and memory limit enforced by
   the Linux cgroup filesystem. Works for SLURM jobs and Kubernetes pods (cgroup

--- a/README.md
+++ b/README.md
@@ -54,10 +54,19 @@ def my_function(n):
     return sum(range(n))
 
 my_function(1_000_000)
+
+# list of dicts — no extra dependencies:
 results = bench.get_results()
+
+# pandas DataFrame:
+results = bench.get_results(format='df')
+
+# quick stats printout — no dependencies:
+bench.summary()
 ```
 
-Each call produces one record. `results` is a pandas DataFrame:
+Each call produces one record. `results` from `get_results(format='df')` is
+a pandas DataFrame:
 
 ```
    mb_run_id                             mb_version  function_name  run_durations  experiment

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,6 +4,8 @@
 
 ::: microbench.MicroBench
 
+::: microbench.summary
+
 ## Output sinks
 
 ::: microbench.Output

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,10 +20,18 @@ my_function(42)
 ```
 
 By default results are captured into an in-memory buffer. Read them back as
-a pandas DataFrame:
+a list of dicts:
 
 ```python
-results = bench.get_results()
+results = bench.get_results()          # list of dicts — no extra dependencies
+results = bench.get_results(format='df')  # pandas DataFrame
+```
+
+Or print a quick stats summary without any dependencies:
+
+```python
+bench.summary()
+# n=1  min=0.000042  mean=0.000042  median=0.000042  max=0.000042  stdev=nan
 ```
 
 Every record contains these fields automatically:
@@ -114,18 +122,27 @@ results = pandas.read_json('/home/user/results.jsonl', lines=True)
 Or via `get_results()`, which works regardless of the output destination:
 
 ```python
-results = bench.get_results()
+results = bench.get_results()              # list of dicts — no extra dependencies
+results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
 ## Analysing results
 
-Load results into a pandas DataFrame and use its full range of aggregation
-and filtering capabilities:
+For a quick stats overview with no extra dependencies:
 
 ```python
-import pandas
+bench.summary()
+# n=3  min=0.049512  mean=0.049821  median=0.049823  max=0.050128  stdev=0.000312
 
-results = pandas.read_json('/home/user/my-benchmarks.jsonl', lines=True)
+# or pass any list of result dicts:
+from microbench import summary
+summary(bench.get_results())
+```
+
+Load into a pandas DataFrame for full aggregation and filtering:
+
+```python
+results = bench.get_results(format='df')
 
 # run_durations is a list of per-iteration times; sum for total call time
 results['total_duration'] = results['run_durations'].apply(sum)
@@ -135,6 +152,16 @@ results.groupby('python_version')['total_duration'].mean()
 
 # Correlate records from the same process run
 results.groupby('mb_run_id')['total_duration'].describe()
+```
+
+Use `flat=True` to flatten nested mixin fields (e.g. `slurm`, `git_info`,
+`cgroup_limits`) into dot-notation columns — useful when loading into pandas
+or a spreadsheet:
+
+```python
+results = bench.get_results(flat=True)          # list of flat dicts
+results = bench.get_results(format='df', flat=True)  # flat DataFrame
+# 'slurm' dict becomes columns: slurm.job_id, slurm.cpus_on_node, ...
 ```
 
 See the [pandas documentation](https://pandas.pydata.org/docs/) for more.

--- a/docs/user-guide/output.md
+++ b/docs/user-guide/output.md
@@ -21,17 +21,39 @@ file with `O_APPEND`, which guarantees atomic appends on POSIX filesystems.
 Multiple processes can safely write to the same file simultaneously — a
 common pattern when running benchmark jobs across cluster nodes.
 
-Read results back with pandas:
+Read results back via `get_results()`:
 
 ```python
+results = bench.get_results()              # list of dicts — no extra dependencies
+results = bench.get_results(format='df')  # pandas DataFrame
+
+# or read directly with pandas:
 import pandas
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 ```
 
-Or via `get_results()`:
+Pass `flat=True` to flatten nested mixin fields (e.g. `slurm`, `git_info`,
+`cgroup_limits`) into dot-notation keys:
 
 ```python
-results = bench.get_results()
+results = bench.get_results(flat=True)
+# {'function_name': 'noop', 'slurm.job_id': '12345', 'slurm.cpus_on_node': '8', ...}
+```
+
+## Quick summary
+
+Print min/mean/median/max/stdev of `run_durations` with no extra dependencies:
+
+```python
+bench.summary()
+# n=10  min=0.000031  mean=0.000038  median=0.000036  max=0.000059  stdev=0.000008
+```
+
+The module-level `summary()` accepts any list of result dicts:
+
+```python
+from microbench import summary
+summary(bench.get_results())
 ```
 
 ## In-memory buffer
@@ -49,7 +71,8 @@ def my_function():
 
 my_function()
 
-results = bench.get_results()
+results = bench.get_results()              # list of dicts
+results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
 ## Multiple output sinks
@@ -67,7 +90,8 @@ bench = MicroBench(outputs=[
 ])
 ```
 
-`get_results()` reads from the first sink that supports it.
+`get_results()` reads from the first sink that supports it. The `format` and
+`flat` arguments work the same as with `FileOutput`.
 
 ## Redis output
 
@@ -88,7 +112,8 @@ def my_function():
 
 my_function()
 
-results = bench.get_results()
+results = bench.get_results()              # list of dicts
+results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
 Results are appended to a Redis list using `RPUSH` and read back with

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import os
 import signal
+import statistics as _statistics
 import sys
 import threading
 import time
@@ -67,6 +68,7 @@ _active_bm_data: contextvars.ContextVar = contextvars.ContextVar(
 __all__ = [
     # Core
     'MicroBench',
+    'summary',
     # Output sinks
     'Output',
     'FileOutput',
@@ -93,6 +95,47 @@ __all__ = [
     'JSONEncoder',
     'JSONEncodeWarning',
 ]
+
+
+def summary(results):
+    """Print summary statistics for ``run_durations`` across a list of results.
+
+    Requires no dependencies beyond the Python standard library.
+
+    Args:
+        results (list[dict]): Result dicts as returned by
+            :meth:`MicroBench.get_results` (default ``format='dict'``).
+
+    Example::
+
+        bench = MicroBench()
+
+        @bench
+        def my_function():
+            ...
+
+        my_function()
+        summary(bench.get_results())
+        # n=1  min=0.000042  mean=0.000042  median=0.000042  max=0.000042  stdev=nan
+    """
+    durations = []
+    for r in results:
+        durations.extend(r.get('run_durations', []))
+
+    n = len(durations)
+    if n == 0:
+        print('No run_durations found in results.')
+        return
+
+    stdev = _statistics.stdev(durations) if n > 1 else float('nan')
+    print(
+        f'n={n}  '
+        f'min={min(durations):.6f}  '
+        f'mean={_statistics.mean(durations):.6f}  '
+        f'median={_statistics.median(durations):.6f}  '
+        f'max={max(durations):.6f}  '
+        f'stdev={stdev:.6f}'
+    )
 
 
 class MicroBench:
@@ -281,17 +324,41 @@ class MicroBench:
         for output in self._outputs:
             output.write(bm_str)
 
-    def get_results(self):
-        """Return results from the first output sink that supports it."""
+    def get_results(self, format='dict', flat=False):
+        """Return results from the first output sink that supports it.
+
+        Args:
+            format (str): ``'dict'`` (default) returns a list of dicts;
+                ``'df'`` returns a pandas DataFrame (requires pandas).
+            flat (bool): If *True*, flatten nested dict fields into
+                dot-notation keys (e.g. ``slurm.job_id``). Works for
+                both formats and does not require pandas.
+
+        Returns:
+            list[dict] or pandas.DataFrame
+
+        Raises:
+            RuntimeError: If no configured sink supports reading results.
+            ImportError: If *format* is ``'df'`` and pandas is not installed.
+            ValueError: If *format* is not ``'dict'`` or ``'df'``.
+        """
         for output in self._outputs:
             try:
-                return output.get_results()
+                return output.get_results(format=format, flat=flat)
             except NotImplementedError:
                 continue
         raise RuntimeError(
             'None of the configured output sinks support get_results(). '
             'Use FileOutput or RedisOutput.'
         )
+
+    def summary(self):
+        """Print summary statistics for ``run_durations`` across all results.
+
+        Requires no dependencies beyond the Python standard library.
+        Reads results via :meth:`get_results`.
+        """
+        summary(self.get_results())
 
     def __call__(self, func):
         if inspect.iscoroutinefunction(func):

--- a/microbench/_output.py
+++ b/microbench/_output.py
@@ -1,9 +1,28 @@
 import io
+import json
 
 try:
     import pandas
 except ImportError:
     pandas = None
+
+
+def _flatten_dict(d, sep='.', _prefix=''):
+    """Recursively flatten a nested dict using dot-notation keys.
+
+    Example::
+
+        >>> _flatten_dict({'a': {'b': 1}, 'c': 2})
+        {'a.b': 1, 'c': 2}
+    """
+    out = {}
+    for k, v in d.items():
+        key = f'{_prefix}{sep}{k}' if _prefix else k
+        if isinstance(v, dict):
+            out.update(_flatten_dict(v, sep=sep, _prefix=key))
+        else:
+            out[key] = v
+    return out
 
 
 class Output:
@@ -28,12 +47,20 @@ class Output:
         """
         raise NotImplementedError
 
-    def get_results(self):
-        """Return all stored results as a pandas DataFrame.
+    def get_results(self, format='dict', flat=False):
+        """Return all stored results.
+
+        Args:
+            format (str): ``'dict'`` (default) returns a list of dicts;
+                ``'df'`` returns a pandas DataFrame (requires pandas).
+            flat (bool): If *True*, flatten nested dict fields into
+                dot-notation keys (e.g. ``slurm.job_id``). Works for
+                both formats and does not require pandas.
 
         Raises:
             NotImplementedError: If this sink does not support reading results.
-            ImportError: If pandas is not installed.
+            ImportError: If *format* is ``'df'`` and pandas is not installed.
+            ValueError: If *format* is not ``'dict'`` or ``'df'``.
         """
         raise NotImplementedError(
             f'{type(self).__name__} does not support get_results()'
@@ -69,12 +96,32 @@ class FileOutput(Output):
         else:
             self.outfile.write(bm_str)
 
-    def get_results(self):
-        if not pandas:
+    def get_results(self, format='dict', flat=False):
+        if format not in ('dict', 'df'):
+            raise ValueError(f"format must be 'dict' or 'df', got {format!r}")
+        if format == 'df' and not pandas:
             raise ImportError('This functionality requires the "pandas" package')
+
         if hasattr(self.outfile, 'seek'):
             self.outfile.seek(0)
-        return pandas.read_json(self.outfile, lines=True)
+            content = self.outfile.read()
+        else:
+            with open(self.outfile) as f:
+                content = f.read()
+
+        if format == 'df' and not flat:
+            return pandas.read_json(io.StringIO(content), lines=True)
+
+        lines = [line for line in content.splitlines() if line.strip()]
+        records = [json.loads(line) for line in lines]
+
+        if flat:
+            records = [_flatten_dict(r) for r in records]
+
+        if format == 'dict':
+            return records
+        else:  # format == 'df' and flat
+            return pandas.DataFrame(records)
 
 
 class RedisOutput(Output):
@@ -105,9 +152,25 @@ class RedisOutput(Output):
     def write(self, bm_json_str):
         self.rclient.rpush(self.redis_key, bm_json_str)
 
-    def get_results(self):
-        if not pandas:
+    def get_results(self, format='dict', flat=False):
+        if format not in ('dict', 'df'):
+            raise ValueError(f"format must be 'dict' or 'df', got {format!r}")
+        if format == 'df' and not pandas:
             raise ImportError('This functionality requires the "pandas" package')
+
         redis_data = self.rclient.lrange(self.redis_key, 0, -1)
-        json_data = '\n'.join(r.decode('utf8') for r in redis_data)
-        return pandas.read_json(io.StringIO(json_data), lines=True)
+        lines = [r.decode('utf8') for r in redis_data]
+
+        if format == 'df' and not flat:
+            json_data = '\n'.join(lines)
+            return pandas.read_json(io.StringIO(json_data), lines=True)
+
+        records = [json.loads(line) for line in lines]
+
+        if flat:
+            records = [_flatten_dict(r) for r in records]
+
+        if format == 'dict':
+            return records
+        else:  # format == 'df' and flat
+            return pandas.DataFrame(records)

--- a/microbench/tests/test_conda.py
+++ b/microbench/tests/test_conda.py
@@ -27,7 +27,7 @@ def _run_conda_bench(**cls_attrs):
     ):
         noop()
 
-    return bench.get_results()
+    return bench.get_results(format='df')
 
 
 def test_conda_no_channel_doubling():

--- a/microbench/tests/test_core.py
+++ b/microbench/tests/test_core.py
@@ -38,7 +38,7 @@ def test_mb_run_id_and_version():
     noop()
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
 
     # mb_run_id is a valid UUID and consistent across calls
     uuid_re = re.compile(
@@ -67,8 +67,8 @@ def test_mb_run_id_shared_across_instances():
     func_a()
     func_b()
 
-    run_id_a = bench_a.get_results()['mb_run_id'][0]
-    run_id_b = bench_b.get_results()['mb_run_id'][0]
+    run_id_a = bench_a.get_results(format='df')['mb_run_id'][0]
+    run_id_b = bench_b.get_results(format='df')['mb_run_id'][0]
     assert run_id_a == run_id_b
 
 
@@ -91,7 +91,7 @@ def test_function():
     for _ in range(3):
         assert my_function() == 499999500000
 
-    results = benchmark.get_results()
+    results = benchmark.get_results(format='df')
     assert (results['function_name'] == 'my_function').all()
     assert results['package_versions'][0]['pandas'] == pandas.__version__
     runtimes = results['finish_time'] - results['start_time']
@@ -116,7 +116,7 @@ def test_multi_iterations():
     # call the function
     my_function()
 
-    results = benchmark.get_results()
+    results = benchmark.get_results(format='df')
     assert (results['function_name'] == 'my_function').all()
     runtimes = results['finish_time'] - results['start_time']
     assert (runtimes >= datetime.timedelta(0)).all()
@@ -146,7 +146,7 @@ def test_capture_optional_records_errors():
 
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     errors = results['mb_capture_errors'][0]
     assert len(errors) == 1
     assert errors[0]['method'] == 'capture_will_fail'
@@ -168,7 +168,7 @@ def test_capture_optional_no_errors_no_field():
 
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'mb_capture_errors' not in results.columns
 
 
@@ -206,7 +206,7 @@ def test_capture_optional_capturepost():
 
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     errors = results['mb_capture_errors'][0]
     assert any(e['method'] == 'capturepost_will_fail' for e in errors)
 
@@ -226,7 +226,7 @@ def test_warmup():
     # 3 warmup + 2 recorded iterations = 5 total calls
     assert call_count == 5
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     # Only one record (one decorated call), with 2 run_durations
     assert len(results) == 1
     assert len(results['run_durations'][0]) == 2
@@ -254,7 +254,7 @@ def test_local_timezone():
 
     noop()
 
-    results = benchmark.get_results()
+    results = benchmark.get_results(format='df')
     expected_offset = datetime.datetime.now().astimezone().utcoffset()
     assert results['start_time'][0].utcoffset() == expected_offset
     assert results['finish_time'][0].utcoffset() == expected_offset
@@ -279,7 +279,7 @@ def test_monitor():
     assert not monitor_bench._monitor_thread.is_alive()
 
     # Check some monitor data was captured
-    results = monitor_bench.get_results()
+    results = monitor_bench.get_results(format='df')
     assert len(results['monitor']) > 0
 
 
@@ -341,7 +341,7 @@ def test_monitor_multiple_samples():
 
     slow_function()
 
-    results = monitor_bench.get_results()
+    results = monitor_bench.get_results(format='df')
     assert len(results['monitor'][0]) >= 2, 'Expected at least 2 monitor samples'
 
 
@@ -363,7 +363,7 @@ def test_functioncall_args_not_double_encoded():
 
     dummy(42, {'key': 'value'}, kw_str='hello')
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     args = results['args'][0]
     kwargs = results['kwargs'][0]
 
@@ -385,7 +385,7 @@ def test_record_standard_fields():
     with bench.record('my_block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     row = results.iloc[0]
     assert row['function_name'] == 'my_block'
@@ -403,7 +403,7 @@ def test_record_no_name_defaults():
     with bench.record():
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results.iloc[0]['function_name'] == '<record>'
 
 
@@ -414,7 +414,7 @@ def test_record_static_fields():
     with bench.record('block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results.iloc[0]['experiment'] == 'run-1'
     assert results.iloc[0]['trial'] == 3
 
@@ -430,7 +430,7 @@ def test_record_mixin_fields():
     with bench.record('block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'hostname' in results.columns
     assert 'operating_system' in results.columns
 
@@ -444,7 +444,7 @@ def test_record_multiple_records():
     with bench.record('second'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 2
     assert list(results['function_name']) == ['first', 'second']
 
@@ -457,7 +457,7 @@ def test_record_exception_captured_and_reraised():
         with bench.record('block'):
             raise ValueError('oops')
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     exc = results.iloc[0]['exception']
     assert exc['type'] == 'ValueError'
@@ -471,7 +471,7 @@ def test_record_no_exception_field_on_success():
     with bench.record('block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'exception' not in results.columns
 
 
@@ -488,7 +488,7 @@ def test_record_coexists_with_decorator():
 
     decorated()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 2
     assert set(results['function_name']) == {'ctx', 'decorated'}
 
@@ -509,7 +509,7 @@ def test_decorator_exception_captured_and_reraised():
     with pytest.raises(RuntimeError, match='boom'):
         failing()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     exc = results.iloc[0]['exception']
     assert exc['type'] == 'RuntimeError'
@@ -526,7 +526,7 @@ def test_decorator_no_exception_field_on_success():
 
     ok()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'exception' not in results.columns
 
 
@@ -546,7 +546,7 @@ def test_decorator_exception_stops_iterations():
     with pytest.raises(ValueError):
         sometimes_fails()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert call_count == 2
     assert len(results.iloc[0]['run_durations']) == 2
 
@@ -566,7 +566,7 @@ def test_decorator_return_value_mixin_skipped_on_exception():
     with pytest.raises(TypeError):
         failing()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'return_value' not in results.columns
 
 
@@ -586,7 +586,7 @@ def test_record_mbfunctioncall_produces_empty_args():
     with bench.record('block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results.iloc[0]['args'] == []
     assert results.iloc[0]['kwargs'] == {}
 
@@ -602,7 +602,7 @@ def test_record_mbreturnvalue_ignored():
     with bench.record('block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'return_value' not in results.columns
 
 
@@ -614,7 +614,7 @@ def test_record_mbreturnvalue_ignored():
 def _invoke_record_on_exit(bench):
     """Directly call the registered exit handler and return its results."""
     bench._record_on_exit_handler()
-    return bench.get_results()
+    return bench.get_results(format='df')
 
 
 def test_record_on_exit_standard_fields():
@@ -733,7 +733,7 @@ def test_record_on_exit_sigterm_writes_record():
         # Invoke the handler but prevent it from re-killing the process.
         with patch('os.kill'), patch('signal.signal'):
             handler(_signal.SIGTERM, None)
-        results = bench.get_results()
+        results = bench.get_results(format='df')
     finally:
         sys.excepthook = orig_excepthook
         _signal.signal(_signal.SIGTERM, orig_sigterm)
@@ -764,7 +764,7 @@ def test_record_on_exit_double_fire_prevention():
         bench.record_on_exit('sim')
         bench._record_on_exit_handler()
         bench._record_on_exit_handler()
-        results = bench.get_results()
+        results = bench.get_results(format='df')
     finally:
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
@@ -788,7 +788,7 @@ def test_record_on_exit_re_registration_replaces_first():
         assert first_handler is not second_handler
 
         second_handler()
-        results = bench.get_results()
+        results = bench.get_results(format='df')
     finally:
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
@@ -860,7 +860,7 @@ async def test_async_decorator_standard_fields():
 
     await async_noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     assert results.iloc[0]['function_name'] == 'async_noop'
     assert 'start_time' in results.columns
@@ -880,7 +880,7 @@ async def test_async_decorator_iterations():
 
     await async_noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results.iloc[0]['run_durations']) == 3
 
 
@@ -900,7 +900,7 @@ async def test_async_decorator_warmup():
 
     # 2 warmup + 3 recorded = 5 total
     assert call_count == 5
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results.iloc[0]['run_durations']) == 3
 
 
@@ -916,7 +916,7 @@ async def test_async_decorator_exception():
     with pytest.raises(ValueError, match='async boom'):
         await async_fail()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     exc = results.iloc[0]['exception']
     assert exc['type'] == 'ValueError'
@@ -939,7 +939,7 @@ async def test_async_decorator_return_value():
     result = await async_compute()
 
     assert result == 42
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results.iloc[0]['return_value'] == 42
 
 
@@ -958,7 +958,7 @@ async def test_async_decorator_functioncall():
 
     await async_fn(1, y=2)
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results.iloc[0]['args'] == [1]
     assert results.iloc[0]['kwargs'] == {'y': 2}
 
@@ -971,7 +971,7 @@ async def test_async_arecord_standard_fields():
     async with bench.arecord('my_block'):
         await asyncio.sleep(0)
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     row = results.iloc[0]
     assert row['function_name'] == 'my_block'
@@ -988,7 +988,7 @@ async def test_async_arecord_no_name_defaults():
     async with bench.arecord():
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results.iloc[0]['function_name'] == '<record>'
 
 
@@ -1001,7 +1001,7 @@ async def test_async_arecord_exception():
         async with bench.arecord('block'):
             raise RuntimeError('async oops')
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     exc = results.iloc[0]['exception']
     assert exc['type'] == 'RuntimeError'
@@ -1041,7 +1041,7 @@ async def test_async_monitor_thread():
     await async_noop()
 
     assert not monitor_bench._monitor_thread.is_alive()
-    results = monitor_bench.get_results()
+    results = monitor_bench.get_results(format='df')
     assert len(results['monitor'][0]) > 0
 
 
@@ -1060,7 +1060,7 @@ async def test_monitor_with_arecord():
         await asyncio.sleep(0)
 
     assert not bench._monitor_thread.is_alive()
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 1
     assert len(results.iloc[0]['monitor']) > 0
 
@@ -1148,7 +1148,7 @@ def test_time_with_record():
         with bench.time('transform'):
             pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'parse'
@@ -1170,7 +1170,7 @@ def test_time_with_decorator():
 
     pipeline()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'step_a'
@@ -1191,7 +1191,7 @@ async def test_time_with_async_decorator():
 
     await async_pipeline()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'fetch'
@@ -1209,7 +1209,7 @@ async def test_time_with_arecord():
         with bench.time('save'):
             pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'load'
@@ -1248,7 +1248,7 @@ def test_time_noop_outside_benchmark():
         pass
 
     # Nothing written
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 0
 
 
@@ -1259,7 +1259,7 @@ def test_time_absent_when_not_used():
     with bench.record('block'):
         pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'mb_timings' not in results.columns
 
 
@@ -1274,7 +1274,7 @@ def test_time_multiple_iterations():
 
     pipeline()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 3
     assert all(t['name'] == 'step' for t in timings)
@@ -1289,7 +1289,7 @@ def test_time_exception_closes_segment():
             with bench.time('risky'):
                 raise ValueError('fail')
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 1
     assert timings[0]['name'] == 'risky'
@@ -1306,7 +1306,7 @@ def test_time_ordering_preserved():
             with bench.time(n):
                 pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert [t['name'] for t in timings] == names
 
@@ -1320,7 +1320,7 @@ def test_time_same_name_multiple_times():
             with bench.time('repeat'):
                 pass
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     timings = results.iloc[0]['mb_timings']
     assert len(timings) == 3
     assert all(t['name'] == 'repeat' for t in timings)
@@ -1343,7 +1343,7 @@ async def test_time_concurrent_arecord():
 
     await asyncio.gather(task_a(), task_b())
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert len(results) == 2
     by_name = {row['function_name']: row for _, row in results.iterrows()}
 

--- a/microbench/tests/test_line_profiler.py
+++ b/microbench/tests/test_line_profiler.py
@@ -41,7 +41,7 @@ def test_line_profiler():
     for _ in range(3):
         assert my_function() == 499999500000
 
-    results = lpbench.get_results()
+    results = lpbench.get_results(format='df')
     lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])
     assert lp.__class__.__name__ == 'LineStats'
     MBLineProfiler.print_line_profile(results['line_profiler'][0])

--- a/microbench/tests/test_mixins.py
+++ b/microbench/tests/test_mixins.py
@@ -41,7 +41,7 @@ def test_mb_slurm_info():
     with patch.dict(os.environ, slurm_env, clear=False):
         noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     slurm = results['slurm'][0]
     assert slurm['job_id'] == '12345'
     assert slurm['array_task_id'] == '3'
@@ -66,7 +66,7 @@ def test_mb_slurm_info_empty():
     with patch.dict(os.environ, clean_env, clear=True):
         noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['slurm'][0] == {}
 
 
@@ -89,7 +89,7 @@ def test_mb_loaded_modules():
     ):
         noop()
 
-    modules = bench.get_results()['loaded_modules'][0]
+    modules = bench.get_results(format='df')['loaded_modules'][0]
     assert modules['gcc'] == '12.2.0'
     assert modules['openmpi'] == '4.1.5'
     assert modules['python'] == '3.10.4'
@@ -111,7 +111,7 @@ def test_mb_loaded_modules_empty():
     with patch.dict(os.environ, clean_env, clear=True):
         noop()
 
-    assert bench.get_results()['loaded_modules'][0] == {}
+    assert bench.get_results(format='df')['loaded_modules'][0] == {}
 
 
 def test_mb_loaded_modules_no_version():
@@ -129,7 +129,7 @@ def test_mb_loaded_modules_no_version():
     with patch.dict(os.environ, {'LOADEDMODULES': 'null:gcc/12.2.0'}, clear=False):
         noop()
 
-    modules = bench.get_results()['loaded_modules'][0]
+    modules = bench.get_results(format='df')['loaded_modules'][0]
     assert modules['null'] == ''
     assert modules['gcc'] == '12.2.0'
 
@@ -154,7 +154,7 @@ def test_mb_loaded_modules_version_with_slash():
     ):
         noop()
 
-    modules = bench.get_results()['loaded_modules'][0]
+    modules = bench.get_results(format='df')['loaded_modules'][0]
     assert modules['GCC'] == '12.2.0-GCCcore-12.2.0'
 
 
@@ -165,7 +165,7 @@ def test_capture_global_packages():
 
     noop()
 
-    results = globals_bench.get_results()
+    results = globals_bench.get_results(format='df')
 
     # We should've captured microbench and pandas versions from top level
     # imports in this file
@@ -185,7 +185,7 @@ def test_capture_packages_importlib():
 
     noop()
 
-    results = pkg_bench.get_results()
+    results = pkg_bench.get_results(format='df')
     assert pandas.__version__ == results['package_versions'][0]['pandas']
 
 
@@ -210,7 +210,7 @@ def test_capture_packages_self_imports_metadata():
 
         noop()
 
-        results = bench.get_results()
+        results = bench.get_results(format='df')
         assert isinstance(results['package_versions'][0], dict)
         assert len(results['package_versions'][0]) > 0
     finally:
@@ -230,7 +230,7 @@ def test_mb_peak_memory():
 
     allocate()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['peak_memory_bytes'][0] > 0
 
 
@@ -273,7 +273,7 @@ def test_mb_peak_memory_preserves_existing_trace():
         noop()
 
         assert tracemalloc.is_tracing()
-        results = bench.get_results()
+        results = bench.get_results(format='df')
         assert 'peak_memory_bytes' in results.columns
     finally:
         tracemalloc.stop()
@@ -319,7 +319,7 @@ def test_mb_git_info():
     with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_CLEAN)):
         noop()
 
-    git_info = bench.get_results()['git_info'][0]
+    git_info = bench.get_results(format='df')['git_info'][0]
     assert git_info['repo'] == '/home/user/project'
     assert git_info['commit'] == 'abc123def456abc123def456abc123def456abc1'
     assert git_info['branch'] == 'main'
@@ -341,7 +341,7 @@ def test_mb_git_info_dirty():
     with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_DIRTY)):
         noop()
 
-    assert bench.get_results()['git_info'][0]['dirty'] is True
+    assert bench.get_results(format='df')['git_info'][0]['dirty'] is True
 
 
 def test_mb_git_info_detached_head():
@@ -359,7 +359,7 @@ def test_mb_git_info_detached_head():
     with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_DETACHED)):
         noop()
 
-    assert bench.get_results()['git_info'][0]['branch'] == ''
+    assert bench.get_results(format='df')['git_info'][0]['branch'] == ''
 
 
 def test_mb_git_info_no_git_raises():
@@ -457,7 +457,7 @@ def test_mb_file_hash_specific_file(tmp_path):
 
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['file_hashes'][0] == {str(target): expected}
 
 
@@ -482,7 +482,7 @@ def test_mb_file_hash_multiple_files(tmp_path):
 
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['file_hashes'][0] == files
 
 
@@ -508,7 +508,7 @@ def test_mb_file_hash_custom_algorithm(tmp_path):
 
     noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['file_hashes'][0] == {str(target): expected}
 
 
@@ -534,7 +534,7 @@ def test_mb_file_hash_default_uses_argv(tmp_path):
     with patch.object(sys, 'argv', [str(script)]):
         noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['file_hashes'][0] == {str(script): expected}
 
 
@@ -553,7 +553,7 @@ def test_mb_file_hash_no_argv_empty(tmp_path):
     with patch.object(sys, 'argv', []):
         noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['file_hashes'][0] == {}
 
 
@@ -572,7 +572,7 @@ def test_mb_file_hash_interactive_argv_empty_string(tmp_path):
     with patch.object(sys, 'argv', ['']):
         noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['file_hashes'][0] == {}
 
 
@@ -642,7 +642,7 @@ def test_cgroup_limits_non_linux():
     with patch('sys.platform', 'win32'):
         noop()
 
-    assert bench.get_results()['cgroup_limits'][0] == {}
+    assert bench.get_results(format='df')['cgroup_limits'][0] == {}
 
 
 def test_cgroup_limits_v2_limited():
@@ -676,7 +676,7 @@ def test_cgroup_limits_v2_limited():
     ):
         noop()
 
-    result = bench.get_results()['cgroup_limits'][0]
+    result = bench.get_results(format='df')['cgroup_limits'][0]
     assert result['cpu_cores'] == 4.0
     assert result['memory_bytes'] == 17179869184
     assert result['cgroup_version'] == 2
@@ -713,7 +713,7 @@ def test_cgroup_limits_v2_unlimited():
     ):
         noop()
 
-    result = bench.get_results()['cgroup_limits'][0]
+    result = bench.get_results(format='df')['cgroup_limits'][0]
     assert result['cpu_cores'] is None
     assert result['memory_bytes'] is None
     assert result['cgroup_version'] == 2
@@ -752,7 +752,7 @@ def test_cgroup_limits_v1_limited():
     ):
         noop()
 
-    result = bench.get_results()['cgroup_limits'][0]
+    result = bench.get_results(format='df')['cgroup_limits'][0]
     assert result['cpu_cores'] == 2.0
     assert result['memory_bytes'] == 8589934592
     assert result['cgroup_version'] == 1
@@ -791,7 +791,7 @@ def test_cgroup_limits_v1_unlimited_cpu():
     ):
         noop()
 
-    result = bench.get_results()['cgroup_limits'][0]
+    result = bench.get_results(format='df')['cgroup_limits'][0]
     assert result['cpu_cores'] is None
     assert result['memory_bytes'] == 4294967296
     assert result['cgroup_version'] == 1
@@ -816,4 +816,4 @@ def test_cgroup_limits_unavailable():
     ):
         noop()
 
-    assert bench.get_results()['cgroup_limits'][0] == {}
+    assert bench.get_results(format='df')['cgroup_limits'][0] == {}

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -29,7 +29,7 @@ def test_nvidia():
 
     test()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'nvidia_gpu_name' in results.columns
     assert 'nvidia_memory.total' in results.columns
 
@@ -49,7 +49,7 @@ def test_nvidia_custom_attributes():
     with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_SMI_OUTPUT):
         noop()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert 'nvidia_gpu_name' in results.columns
 
 

--- a/microbench/tests/test_output.py
+++ b/microbench/tests/test_output.py
@@ -18,7 +18,9 @@ from microbench import (
     MicroBench,
     Output,
     RedisOutput,
+    summary,
 )
+from microbench._output import _flatten_dict
 
 
 def test_env_vars_not_iterable():
@@ -92,14 +94,26 @@ def test_outfile_string_path():
 
 
 def test_get_results_without_pandas():
-    """get_results raises ImportError when pandas is unavailable."""
+    """get_results(format='df') raises ImportError when pandas is unavailable."""
     import microbench._output
 
     bench = MicroBench()
 
+    @bench
+    def noop():
+        pass
+
+    noop()
+
     with patch.object(microbench._output, 'pandas', None):
+        # Default format='dict' works without pandas
+        results = bench.get_results()
+        assert isinstance(results, list)
+        assert results[0]['function_name'] == 'noop'
+
+        # format='df' raises ImportError
         with pytest.raises(ImportError, match='pandas'):
-            bench.get_results()
+            bench.get_results(format='df')
 
 
 def test_multi_sink_output():
@@ -125,7 +139,7 @@ def test_multi_sink_output():
     noop()
 
     assert len(sink_a.records) == 2
-    results = sink_b.get_results()
+    results = sink_b.get_results(format='df')
     assert len(results) == 2
     assert (results['function_name'] == 'noop').all()
 
@@ -181,7 +195,7 @@ def test_redis_output_get_results():
 
         noop()
 
-        results = bench.get_results()
+        results = bench.get_results(format='df')
         assert results['function_name'][0] == 'noop'
         assert 'start_time' in results.columns
         assert 'finish_time' in results.columns
@@ -202,7 +216,7 @@ def test_redis_output_get_results_without_pandas():
 
         with patch.object(microbench._output, 'pandas', None):
             with pytest.raises(ImportError, match='pandas'):
-                bench.get_results()
+                bench.get_results(format='df')
 
 
 def test_redis_output_multiple_results():
@@ -224,7 +238,7 @@ def test_redis_output_multiple_results():
         func_a()
         func_b()
 
-        results = bench.get_results()
+        results = bench.get_results(format='df')
         assert len(results) == 2
         assert list(results['function_name']) == ['func_a', 'func_b']
 
@@ -248,7 +262,7 @@ def test_unjsonencodable_arg_kwarg_retval():
         assert len(w) == 3
         assert all(issubclass(w_.category, JSONEncodeWarning) for w_ in w)
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['args'][0] == [_UNENCODABLE_PLACEHOLDER_VALUE]
     assert results['kwargs'][0] == {'arg2': _UNENCODABLE_PLACEHOLDER_VALUE}
     assert results['return_value'][0] == _UNENCODABLE_PLACEHOLDER_VALUE
@@ -286,7 +300,7 @@ def test_custom_jsonencoder():
 
     dummy()
 
-    results = bench.get_results()
+    results = bench.get_results(format='df')
     assert results['return_value'][0] == str(obj)
 
 
@@ -305,3 +319,174 @@ def test_jsonencoder_timedelta_and_timezone():
     tz = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
     tz_str = encoder.default(tz)
     assert '05:30' in tz_str
+
+
+# ---------------------------------------------------------------------------
+# get_results format and flat tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_results_default_returns_list_of_dicts():
+    """get_results() default returns a list of dicts without requiring pandas."""
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+    noop()
+
+    results = bench.get_results()
+    assert isinstance(results, list)
+    assert len(results) == 2
+    assert all(isinstance(r, dict) for r in results)
+    assert results[0]['function_name'] == 'noop'
+
+
+def test_get_results_format_df_returns_dataframe():
+    """get_results(format='df') returns a pandas DataFrame."""
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    results = bench.get_results(format='df')
+    assert hasattr(results, 'columns')  # DataFrame duck-type check
+    assert results['function_name'][0] == 'noop'
+
+
+def test_get_results_invalid_format_raises():
+    """get_results() raises ValueError for an unrecognised format."""
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    with pytest.raises(ValueError, match='format'):
+        bench.get_results(format='csv')
+
+
+def test_flatten_dict_basic():
+    """_flatten_dict flattens nested dicts with dot-notation keys."""
+    d = {'a': {'b': 1, 'c': {'d': 2}}, 'e': 3}
+    assert _flatten_dict(d) == {'a.b': 1, 'a.c.d': 2, 'e': 3}
+
+
+def test_flatten_dict_non_dict_values_unchanged():
+    """_flatten_dict leaves non-dict values (lists, scalars) intact."""
+    d = {'a': [1, 2, 3], 'b': {'c': 'hello'}}
+    assert _flatten_dict(d) == {'a': [1, 2, 3], 'b.c': 'hello'}
+
+
+def test_get_results_flat_dict():
+    """get_results(flat=True) flattens nested fields into dot-notation keys."""
+    import unittest.mock
+
+    from microbench import MBSlurmInfo
+
+    class Bench(MicroBench, MBSlurmInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with unittest.mock.patch.dict(
+        os.environ, {'SLURM_JOB_ID': '42', 'SLURM_CPUS_ON_NODE': '8'}
+    ):
+        noop()
+
+    results = bench.get_results(flat=True)
+    assert isinstance(results, list)
+    # MBSlurmInfo strips SLURM_ prefix and lowercases; nested dict should be flattened
+    assert 'slurm.job_id' in results[0]
+    assert results[0]['slurm.job_id'] == '42'
+    assert 'slurm' not in results[0]
+
+
+def test_get_results_flat_df():
+    """get_results(format='df', flat=True) returns a flattened DataFrame."""
+    import unittest.mock
+
+    from microbench import MBSlurmInfo
+
+    class Bench(MicroBench, MBSlurmInfo):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    with unittest.mock.patch.dict(os.environ, {'SLURM_JOB_ID': '99'}):
+        noop()
+
+    results = bench.get_results(format='df', flat=True)
+    assert 'slurm.job_id' in results.columns
+    assert results['slurm.job_id'][0] == '99'
+
+
+# ---------------------------------------------------------------------------
+# summary tests
+# ---------------------------------------------------------------------------
+
+
+def test_summary_function_prints(capsys):
+    """summary() prints min/mean/median/max/stdev of run_durations."""
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+    noop()
+
+    summary(bench.get_results())
+    out = capsys.readouterr().out
+    assert 'n=2' in out
+    assert 'min=' in out
+    assert 'mean=' in out
+    assert 'median=' in out
+    assert 'max=' in out
+    assert 'stdev=' in out
+
+
+def test_summary_function_no_results(capsys):
+    """summary() prints a message when there are no run_durations."""
+    summary([{'function_name': 'noop'}])
+    out = capsys.readouterr().out
+    assert 'No run_durations' in out
+
+
+def test_summary_single_result_no_stdev(capsys):
+    """summary() prints nan for stdev when there is only one duration."""
+    summary([{'run_durations': [0.5]}])
+    out = capsys.readouterr().out
+    assert 'n=1' in out
+    assert 'stdev=nan' in out
+
+
+def test_bench_summary_method(capsys):
+    """bench.summary() is a convenience wrapper around summary()."""
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    bench.summary()
+    out = capsys.readouterr().out
+    assert 'n=1' in out

--- a/microbench/tests/test_psutil.py
+++ b/microbench/tests/test_psutil.py
@@ -17,7 +17,7 @@ def test_psutil():
 
     test_func()
 
-    results = mybench.get_results()
+    results = mybench.get_results(format='df')
     # psutil.cpu_count(logical=True) can return None on some platforms
     # (e.g. macOS with psutil 7.x), so check that at least one is set
     logical = results['cpu_cores_logical'][0]


### PR DESCRIPTION
## Summary

- **Breaking:** `get_results()` now returns a list of dicts by default (`format='dict'`); pass `format='df'` for the previous pandas DataFrame behaviour
- `get_results(flat=True)` flattens nested mixin fields (`slurm`, `git_info`, `cgroup_limits`, etc.) into dot-notation keys — works for both formats, no pandas required
- `summary(results)` / `bench.summary()` prints min/mean/median/max/stdev of `run_durations` using stdlib only