### PR TITLE
feat: --mixin accepts multiple space-separated values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,8 +169,8 @@ All notable changes to microbench are documented here.
   command and record host metadata alongside timing without writing Python
   code. Useful for SLURM jobs, shell scripts, and compiled executables.
   Records `command`, `returncode` (list, one per timed iteration),
-  alongside the standard timing fields. Use `--mixin` to select metadata
-  to capture (defaults to `MBHostInfo` and `MBSlurmInfo`); use
+  alongside the standard timing fields. Use `--mixin MIXIN [MIXIN ...]` to
+  select metadata to capture (defaults to `MBHostInfo` and `MBSlurmInfo`); use
   `--field KEY=VALUE` to attach extra labels; use `--iterations N` and
   `--warmup N` for repeat timing; use `--stdout[=suppress]` and
   `--stderr[=suppress]` to capture subprocess output into the record

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,7 @@ python -m microbench [options] -- COMMAND [ARGS...]
 | Option | Description |
 |---|---|
 | `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
-| `--mixin MIXIN` / `-m MIXIN` | Mixin to include. Replaces defaults when specified. Can be repeated. |
+| `--mixin MIXIN [MIXIN ...]` / `-m MIXIN [MIXIN ...]` | One or more mixins to include. Replaces defaults when specified. |
 | `--all` / `-a` | Include all available mixins. |
 | `--no-mixin` | Disable all mixins including defaults. Records only timing and command fields. |
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
@@ -87,9 +87,7 @@ A typical SLURM job script:
 
 python -m microbench \
     --outfile /scratch/$USER/results.jsonl \
-    --mixin MBHostInfo \
-    --mixin MBSlurmInfo \
-    --mixin MBHostCpuCores \
+    --mixin MBHostInfo MBSlurmInfo MBHostCpuCores \
     --field experiment=baseline \
     -- ./run_simulation.sh --steps 10000
 ```

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -110,13 +110,13 @@ def _build_parser(mixin_names):
     parser.add_argument(
         '--mixin',
         '-m',
-        action='append',
+        nargs='+',
         dest='mixins',
         metavar='MIXIN',
         choices=sorted(mixin_names),
         help=(
-            'Mixin to include. Replaces defaults when specified. '
-            'Can be repeated. Available: %(choices)s.'
+            'One or more mixins to include. Replaces defaults when specified. '
+            'Available: %(choices)s.'
         ),
     )
     parser.add_argument(

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -235,10 +235,8 @@ def test_cli_returncode_is_max_across_iterations():
 
 
 def test_cli_multiple_mixins():
-    """Multiple --mixin flags all take effect."""
-    _, record, _ = _run_main(
-        ['--mixin', 'MBHostInfo', '--mixin', 'MBPythonVersion', '--', 'true']
-    )
+    """Multiple space-separated mixins all take effect."""
+    _, record, _ = _run_main(['--mixin', 'MBHostInfo', 'MBPythonVersion', '--', 'true'])
 
     assert 'hostname' in record
     assert 'python_version' in record


### PR DESCRIPTION
## Summary

- Changes `--mixin` from `action='append'` (repeat the flag) to `nargs='+'` (space-separated values after a single flag)
- `--mixin MBHostInfo --mixin MBSlurmInfo` becomes `--mixin MBHostInfo MBSlurmInfo`
- Updates docs, CHANGELOG entry (unreleased), and test for multiple mixins