### PR TITLE
feat: kebab-case mixin names and --show-mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,17 +169,20 @@ All notable changes to microbench are documented here.
   command and record host metadata alongside timing without writing Python
   code. Useful for SLURM jobs, shell scripts, and compiled executables.
   Records `command`, `returncode` (list, one per timed iteration),
-  alongside the standard timing fields. Use `--mixin MIXIN [MIXIN ...]` to
-  select metadata to capture (defaults to `MBHostInfo` and `MBSlurmInfo`); use
-  `--field KEY=VALUE` to attach extra labels; use `--iterations N` and
-  `--warmup N` for repeat timing; use `--stdout[=suppress]` and
-  `--stderr[=suppress]` to capture subprocess output into the record
-  (output is re-printed to the terminal unless `=suppress` is given);
-  use `--monitor-interval SECONDS` to sample child process CPU and memory
-  over time (see below). Capture failures are non-fatal by default
-  (`capture_optional = True`), making the CLI safe across heterogeneous
-  cluster nodes. The process exits with the highest returncode seen across
-  all timed iterations.
+  alongside the standard timing fields. Mixins are specified by short
+  kebab-case names without the `MB` prefix (e.g. `host-info`,
+  `python-version`); original MB-prefixed names are also accepted. Use
+  `--mixin MIXIN [MIXIN ...]` to select metadata to capture (defaults to
+  `host-info`, `slurm-info`, and `loaded-modules`); use `--show-mixins` to
+  list all available mixins with descriptions; use `--field KEY=VALUE` to
+  attach extra labels; use `--iterations N` and `--warmup N` for repeat
+  timing; use `--stdout[=suppress]` and `--stderr[=suppress]` to capture
+  subprocess output into the record (output is re-printed to the terminal
+  unless `=suppress` is given); use `--monitor-interval SECONDS` to sample
+  child process CPU and memory over time (see below). Capture failures are
+  non-fatal by default (`capture_optional = True`), making the CLI safe
+  across heterogeneous cluster nodes. The process exits with the highest
+  returncode seen across all timed iterations.
 
 - **CLI subprocess monitoring** (`--monitor-interval SECONDS`): periodically
   sample the child process's CPU usage and resident memory (RSS) while it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,7 @@ python -m microbench [options] -- COMMAND [ARGS...]
 |---|---|
 | `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
 | `--mixin MIXIN [MIXIN ...]` / `-m MIXIN [MIXIN ...]` | One or more mixins to include. Replaces defaults when specified. |
+| `--show-mixins` | List all available mixins with descriptions and exit. |
 | `--all` / `-a` | Include all available mixins. |
 | `--no-mixin` | Disable all mixins including defaults. Records only timing and command fields. |
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
@@ -45,27 +46,31 @@ Every record contains the standard fields (`start_time`, `finish_time`,
 
 ## Default mixins
 
-When no `--mixin` is specified, `MBHostInfo`, `MBSlurmInfo`, and
-`MBLoadedModules` are included automatically, capturing hostname,
+When no `--mixin` is specified, `host-info`, `slurm-info`, and
+`loaded-modules` are included automatically, capturing hostname,
 operating system, all `SLURM_*` environment variables, and the loaded
 Lmod/Environment Modules software stack. All three degrade gracefully
 to empty dicts outside of their respective environments.
+
+Mixin names use a short kebab-case form without the `MB` prefix
+(e.g. `host-info` instead of `MBHostInfo`). MB-prefixed names are also
+accepted for convenience. Run `--show-mixins` to list all available
+mixins with descriptions:
+
+```bash
+python -m microbench --show-mixins
+```
 
 Specifying `--mixin` replaces the defaults entirely. Use `--no-mixin` to
 disable all mixins and record only timing and command fields:
 
 ```bash
 # Only Python version — no host info or SLURM
-python -m microbench --mixin MBPythonVersion -- ./job.sh
+python -m microbench --mixin python-version -- ./job.sh
 
 # No mixins at all — timing and command only
 python -m microbench --no-mixin -- ./job.sh
 ```
-
-Available mixins (those marked `cli_compatible`):
-`MBCondaPackages`, `MBFileHash`, `MBGitInfo`, `MBHostCpuCores`,
-`MBHostInfo`, `MBHostRamTotal`, `MBInstalledPackages`, `MBLoadedModules`,
-`MBNvidiaSmi`, `MBPythonVersion`, `MBSlurmInfo`.
 
 See [Mixins](user-guide/mixins.md) for details on each.
 
@@ -87,7 +92,7 @@ A typical SLURM job script:
 
 python -m microbench \
     --outfile /scratch/$USER/results.jsonl \
-    --mixin MBHostInfo MBSlurmInfo MBHostCpuCores \
+    --mixin host-info slurm-info host-cpu-cores \
     --field experiment=baseline \
     -- ./run_simulation.sh --steps 10000
 ```

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -5,33 +5,69 @@ Run an external command and record benchmark metadata:
     python -m microbench [options] -- COMMAND [ARGS...]
 
 Results are written in JSONL format to stdout (default) or a file with
---outfile. By default MBHostInfo and MBSlurmInfo are included; use
---mixin to override.
+--outfile. By default host-info, slurm-info, and loaded-modules are
+included; use --mixin to override, --show-mixins to list all available.
 """
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import threading
 from datetime import datetime, timezone
 
 
+def _mb_name_to_cli(name):
+    """Convert 'MBFooBar' -> 'foo-bar' (strip MB prefix, CamelCase to kebab-case)."""
+    if name.startswith('MB'):
+        name = name[2:]
+    return re.sub(r'(?<=[a-z0-9])([A-Z])', r'-\1', name).lower()
+
+
 def _get_mixin_map():
-    """Return {name: class} for all CLI-compatible mixins."""
+    """Return {cli_name: class} for all CLI-compatible mixins."""
     import microbench as _mb
 
     return {
-        name: getattr(_mb, name)
+        _mb_name_to_cli(name): getattr(_mb, name)
         for name in _mb.__all__
         if isinstance(getattr(_mb, name, None), type)
         and getattr(getattr(_mb, name), 'cli_compatible', False)
     }
 
 
-_DEFAULT_MIXINS = ('MBHostInfo', 'MBSlurmInfo', 'MBLoadedModules')
+_DEFAULT_MIXINS = ('host-info', 'slurm-info', 'loaded-modules')
 
 _CAPTURE_CHOICES = ('capture', 'suppress')
+
+
+def _make_mixin_type(mixin_map):
+    """Return an argparse type function that normalises and validates mixin names."""
+
+    def _parse(value):
+        canonical = _mb_name_to_cli(value) if value.startswith('MB') else value
+        if canonical not in mixin_map:
+            valid = ', '.join(sorted(mixin_map))
+            raise argparse.ArgumentTypeError(
+                f'unknown mixin {value!r}. Available: {valid}'
+            )
+        return canonical
+
+    return _parse
+
+
+def _show_mixins(mixin_map):
+    """Print a table of available CLI-compatible mixins and their descriptions."""
+    default_set = set(_DEFAULT_MIXINS)
+    width = max(len(name) for name in mixin_map)
+    print('Available mixins (* = included by default):\n')
+    for name in sorted(mixin_map):
+        cls = mixin_map[name]
+        doc = (cls.__doc__ or '').strip()
+        summary = doc.splitlines()[0] if doc else ''
+        marker = '*' if name in default_set else ' '
+        print(f'  {marker} {name:<{width}}  {summary}')
 
 
 class _SubprocessMonitorThread(threading.Thread):
@@ -89,13 +125,14 @@ def _int_at_least(minimum):
     return _parse
 
 
-def _build_parser(mixin_names):
+def _build_parser(mixin_map):
     parser = argparse.ArgumentParser(
         prog='python -m microbench',
         description=(
             'Run an external command and record benchmark metadata to JSONL.\n\n'
-            'By default captures MBHostInfo and MBSlurmInfo. '
-            'Specifying --mixin replaces the defaults. '
+            'By default captures host-info, slurm-info, and loaded-modules. '
+            'Specifying --mixin replaces the defaults; use --show-mixins to '
+            'list all available mixins. '
             'Metadata capture failures are recorded in mb_capture_errors '
             'rather than aborting the run.'
         ),
@@ -113,11 +150,17 @@ def _build_parser(mixin_names):
         nargs='+',
         dest='mixins',
         metavar='MIXIN',
-        choices=sorted(mixin_names),
+        type=_make_mixin_type(mixin_map),
         help=(
             'One or more mixins to include. Replaces defaults when specified. '
-            'Available: %(choices)s.'
+            'Use --show-mixins to list available options. '
+            'MB-prefixed names (e.g. MBHostInfo) are also accepted.'
         ),
+    )
+    parser.add_argument(
+        '--show-mixins',
+        action='store_true',
+        help='List available mixins with descriptions and exit.',
     )
     parser.add_argument(
         '--all',
@@ -204,6 +247,10 @@ def main(argv=None):
     parser = _build_parser(mixin_map)
     args = parser.parse_args(argv)
 
+    if args.show_mixins:
+        _show_mixins(mixin_map)
+        sys.exit(0)
+
     cmd = args.command
     if cmd and cmd[0] == '--':
         cmd = cmd[1:]
@@ -222,7 +269,7 @@ def main(argv=None):
     elif args.no_mixins:
         mixin_names = []
     elif args.mixins is not None:
-        mixin_names = args.mixins
+        mixin_names = list(dict.fromkeys(args.mixins))
     else:
         mixin_names = list(_DEFAULT_MIXINS)
     mixins = [mixin_map[name] for name in mixin_names]

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -128,6 +128,18 @@ def test_cli_no_command_exits_with_error():
     assert exc.value.code != 0
 
 
+def test_cli_show_mixins():
+    """--show-mixins lists available mixins and exits cleanly."""
+    buf = io.StringIO()
+    with patch('sys.stdout', buf):
+        with pytest.raises(SystemExit) as exc:
+            main(['--show-mixins'])
+    assert exc.value.code == 0
+    output = buf.getvalue()
+    assert 'host-info' in output
+    assert 'python-version' in output
+
+
 def test_cli_capture_optional_on_by_default():
     """Capture failures are recorded in mb_capture_errors, not raised."""
 


### PR DESCRIPTION
## Summary

- Mixin names on the CLI now use short kebab-case without the `MB` prefix — `host-info` instead of `MBHostInfo`, `python-version` instead of `MBPythonVersion`, etc. MB-prefixed names are still accepted for convenience.
- Adds `--show-mixins` flag: lists all available mixins with their descriptions (first docstring line) and marks the three defaults with `*`. Exits cleanly with code 0.
- Duplicate mixin names passed to `--mixin` (including mixed-case variants like `host-info MBHostInfo`) are silently deduplicated, avoiding a raw `TypeError` from Python's class machinery.
- Updates CLI docs and the unreleased CHANGELOG entry.