### PR TITLE
feat: autodiscover mixin CLI args (CLIArg); add --git-repo and --hash-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,10 +179,18 @@ All notable changes to microbench are documented here.
   timing; use `--stdout[=suppress]` and `--stderr[=suppress]` to capture
   subprocess output into the record (output is re-printed to the terminal
   unless `=suppress` is given); use `--monitor-interval SECONDS` to sample
-  child process CPU and memory over time (see below). Capture failures are
-  non-fatal by default (`capture_optional = True`), making the CLI safe
-  across heterogeneous cluster nodes. The process exits with the highest
-  returncode seen across all timed iterations.
+  child process CPU and memory over time (see below). Some mixins expose
+  their own configuration flags (shown in `--show-mixins` and `--help`):
+  `git-info` adds `--git-repo DIR` (default: current working directory),
+  and `file-hash` adds `--hash-file FILE [FILE ...]` (default: the
+  benchmarked command) and `--hash-algorithm ALGORITHM` (default:
+  `sha256`). Mixin flags are validated before the subprocess runs — passing
+  a non-existent path or a directory where a file is expected is caught
+  immediately. Supplying a mixin flag without loading the corresponding
+  mixin is an error. Capture failures are non-fatal by default
+  (`capture_optional = True`), making the CLI safe across heterogeneous
+  cluster nodes. The process exits with the highest returncode seen across
+  all timed iterations.
 
 - **CLI subprocess monitoring** (`--monitor-interval SECONDS`): periodically
   sample the child process's CPU usage and resident memory (RSS) while it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,39 @@ python -m microbench --no-mixin -- ./job.sh
 
 See [Mixins](user-guide/mixins.md) for details on each.
 
+## Mixin options
+
+Some mixins expose their own CLI flags for configuration. These are shown
+under each mixin in `--show-mixins` output and in `--help`. A mixin flag
+may only be used when its mixin is loaded; passing one without the
+corresponding mixin is an error.
+
+### `git-info` options
+
+| Option | Description |
+|---|---|
+| `--git-repo DIR` | Directory to inspect for git information. |
+
+**CLI default:** current working directory.
+
+**Python API default:** directory of the running script (`sys.argv[0]`).
+When using the CLI, `sys.argv[0]` points to the microbench package itself,
+so the CLI defaults to the working directory instead.
+
+### `file-hash` options
+
+| Option | Description |
+|---|---|
+| `--hash-file FILE [FILE ...]` | File(s) to hash. |
+| `--hash-algorithm ALGORITHM` | Hash algorithm (e.g. `sha256`, `md5`). Default: `sha256`. |
+
+**CLI default for `--hash-file`:** the benchmarked command executable
+(`cmd[0]`), e.g. `./run_simulation.sh`.
+
+**Python API default:** the running script (`sys.argv[0]`). The same
+`sys.argv[0]` issue applies here, so the CLI defaults to hashing the
+command being benchmarked instead.
+
 ## Capture failures
 
 Metadata capture failures (e.g. `nvidia-smi` not installed on this node,

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -257,6 +257,67 @@ them are found and called regardless of MRO order. The MRO only matters if
 two mixins define a method with the *same* name, in which case the
 leftmost class in the inheritance list wins.
 
+### Making a mixin CLI-compatible
+
+A mixin with `cli_compatible = True` appears in `--show-mixins` and can be
+selected with `--mixin`. That attribute alone is enough for mixins that need
+no configuration:
+
+```python
+class MBMachineType:
+    """Capture the machine architecture (e.g. x86_64, arm64)."""
+
+    cli_compatible = True
+
+    def capture_machine_type(self, bm_data):
+        import platform
+        bm_data['machine_type'] = platform.machine()
+```
+
+To expose configurable attributes as CLI flags, add a `cli_args` list of
+`CLIArg` instances. The CLI picks them up automatically — no changes to
+`__main__.py` are needed:
+
+```python
+from microbench.mixins import CLIArg, _UNSET
+
+class MBOutputDir:
+    """Record the output directory for this run."""
+
+    cli_compatible = True
+    cli_args = [
+        CLIArg(
+            flags=['--output-dir'],
+            dest='output_dir',
+            metavar='DIR',
+            help='Output directory to record. CLI default: current working directory.',
+            cli_default=lambda cmd: os.getcwd(),
+        ),
+    ]
+
+    def capture_output_dir(self, bm_data):
+        bm_data['output_dir'] = getattr(self, 'output_dir', None)
+```
+
+`CLIArg` parameters:
+
+| Parameter | Description |
+|---|---|
+| `flags` | Flag strings, e.g. `['--output-dir']`. |
+| `dest` | Mixin attribute name to set, e.g. `'output_dir'`. |
+| `help` | Help text shown in `--help` and `--show-mixins`. |
+| `metavar` | Display name for the value in help (e.g. `'DIR'`). |
+| `type` | Callable to convert and validate the raw string. Defaults to `str`. Raise `ValueError` to reject a value. |
+| `nargs` | Number of arguments, e.g. `'+'` for one or more. |
+| `cli_default` | Default when the flag is not supplied on the CLI. A callable receives the command list (`cmd`) and returns the default value. Use `_UNSET` (the default) to fall back to the mixin's own Python-API default logic instead. |
+
+If a `cli_default` differs from the Python API default — for example because
+`sys.argv[0]` points to a different file in CLI context — document both
+defaults in the `help` string and in the mixin's docstring.
+
+Mixin flags are only accepted when their mixin is active. Passing a flag
+without `--mixin <name>` (or `--all`) is an error.
+
 ## Tailing output in real time
 
 `LiveStream` tails a JSONL output file in a background thread and fires

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -201,7 +201,9 @@ keeping the happy-path output clean.
 
 Microbench serialises records as JSON. If a captured value is not
 JSON-serialisable (e.g. a custom object), microbench replaces it with a
-placeholder and emits a `JSONEncodeWarning`.
+placeholder and emits a `JSONEncodeWarning`. Common places for this to
+occur are when capturing function arguments or return values via
+`MBFunctionCall` and `MBReturnValue` respectively.
 
 To handle custom types, subclass `JSONEncoder`:
 
@@ -229,94 +231,6 @@ make_graph()  # no warning
 
 `JSONEncoder` already handles `datetime`, `timedelta`, `timezone`, and
 numpy scalar/array types by default.
-
-## Writing a mixin
-
-A mixin is simply a class with one or more `capture_` or `capturepost_`
-methods. Define it as a standalone class, then combine it with `MicroBench`
-via multiple inheritance:
-
-```python
-class MBMachineType:
-    """Capture the machine architecture (e.g. x86_64, arm64)."""
-
-    def capture_machine_type(self, bm_data):
-        import platform
-        bm_data['machine_type'] = platform.machine()
-
-
-class MyBench(MicroBench, MBMachineType, MBPythonVersion):
-    pass
-```
-
-Mixins have no required base class. Python's **Method Resolution Order
-(MRO)** determines the order in which base classes are searched for
-methods — a deterministic left-to-right traversal that visits each class
-exactly once. Because every `capture_` method has a unique name, all of
-them are found and called regardless of MRO order. The MRO only matters if
-two mixins define a method with the *same* name, in which case the
-leftmost class in the inheritance list wins.
-
-### Making a mixin CLI-compatible
-
-A mixin with `cli_compatible = True` appears in `--show-mixins` and can be
-selected with `--mixin`. That attribute alone is enough for mixins that need
-no configuration:
-
-```python
-class MBMachineType:
-    """Capture the machine architecture (e.g. x86_64, arm64)."""
-
-    cli_compatible = True
-
-    def capture_machine_type(self, bm_data):
-        import platform
-        bm_data['machine_type'] = platform.machine()
-```
-
-To expose configurable attributes as CLI flags, add a `cli_args` list of
-`CLIArg` instances. The CLI picks them up automatically — no changes to
-`__main__.py` are needed:
-
-```python
-from microbench.mixins import CLIArg, _UNSET
-
-class MBOutputDir:
-    """Record the output directory for this run."""
-
-    cli_compatible = True
-    cli_args = [
-        CLIArg(
-            flags=['--output-dir'],
-            dest='output_dir',
-            metavar='DIR',
-            help='Output directory to record. CLI default: current working directory.',
-            cli_default=lambda cmd: os.getcwd(),
-        ),
-    ]
-
-    def capture_output_dir(self, bm_data):
-        bm_data['output_dir'] = getattr(self, 'output_dir', None)
-```
-
-`CLIArg` parameters:
-
-| Parameter | Description |
-|---|---|
-| `flags` | Flag strings, e.g. `['--output-dir']`. |
-| `dest` | Mixin attribute name to set, e.g. `'output_dir'`. |
-| `help` | Help text shown in `--help` and `--show-mixins`. |
-| `metavar` | Display name for the value in help (e.g. `'DIR'`). |
-| `type` | Callable to convert and validate the raw string. Defaults to `str`. Raise `ValueError` to reject a value. |
-| `nargs` | Number of arguments, e.g. `'+'` for one or more. |
-| `cli_default` | Default when the flag is not supplied on the CLI. A callable receives the command list (`cmd`) and returns the default value. Use `_UNSET` (the default) to fall back to the mixin's own Python-API default logic instead. |
-
-If a `cli_default` differs from the Python API default — for example because
-`sys.argv[0]` points to a different file in CLI context — document both
-defaults in the `help` string and in the mixin's docstring.
-
-Mixin flags are only accepted when their mixin is active. Passing a flag
-without `--mixin <name>` (or `--all`) is an error.
 
 ## Tailing output in real time
 

--- a/docs/user-guide/extending.md
+++ b/docs/user-guide/extending.md
@@ -1,6 +1,94 @@
 # Extending microbench
 
-## Custom capture methods
+## Writing a mixin
+
+A mixin is simply a class with one or more `capture_` or `capturepost_`
+methods. Define it as a standalone class, then combine it with `MicroBench`
+via multiple inheritance:
+
+```python
+class MBMachineType:
+    """Capture the machine architecture (e.g. x86_64, arm64)."""
+
+    def capture_machine_type(self, bm_data):
+        import platform
+        bm_data['machine_type'] = platform.machine()
+
+
+class MyBench(MicroBench, MBMachineType, MBPythonVersion):
+    pass
+```
+
+Mixins have no required base class. Python's **Method Resolution Order
+(MRO)** determines the order in which base classes are searched for
+methods — a deterministic left-to-right traversal that visits each class
+exactly once. Because every `capture_` method has a unique name, all of
+them are found and called regardless of MRO order. The MRO only matters if
+two mixins define a method with the *same* name, in which case the
+leftmost class in the inheritance list wins.
+
+### Making a mixin CLI-compatible
+
+A mixin with `cli_compatible = True` appears in `--show-mixins` and can be
+selected with `--mixin`. That attribute alone is enough for mixins that need
+no configuration:
+
+```python
+class MBMachineType:
+    """Capture the machine architecture (e.g. x86_64, arm64)."""
+
+    cli_compatible = True
+
+    def capture_machine_type(self, bm_data):
+        import platform
+        bm_data['machine_type'] = platform.machine()
+```
+
+To expose configurable attributes as CLI flags, add a `cli_args` list of
+`CLIArg` instances. The CLI picks them up automatically — no changes to
+`__main__.py` are needed:
+
+```python
+from microbench.mixins import CLIArg, _UNSET
+
+class MBOutputDir:
+    """Record the output directory for this run."""
+
+    cli_compatible = True
+    cli_args = [
+        CLIArg(
+            flags=['--output-dir'],
+            dest='output_dir',
+            metavar='DIR',
+            help='Output directory to record. CLI default: current working directory.',
+            cli_default=lambda cmd: os.getcwd(),
+        ),
+    ]
+
+    def capture_output_dir(self, bm_data):
+        bm_data['output_dir'] = getattr(self, 'output_dir', None)
+```
+
+`CLIArg` parameters:
+
+| Parameter | Description |
+|---|---|
+| `flags` | Flag strings, e.g. `['--output-dir']`. |
+| `dest` | Mixin attribute name to set, e.g. `'output_dir'`. |
+| `help` | Help text shown in `--help` and `--show-mixins`. |
+| `metavar` | Display name for the value in help (e.g. `'DIR'`). |
+| `type` | Callable to convert and validate the raw string. Defaults to `str`. Raise `ValueError` to reject a value. |
+| `nargs` | Number of arguments, e.g. `'+'` for one or more. |
+| `cli_default` | Default when the flag is not supplied on the CLI. A callable receives the command list (`cmd`) and returns the default value. Use `_UNSET` (the default) to fall back to the mixin's own Python-API default logic instead. |
+
+If a `cli_default` differs from the Python API default — for example because
+`sys.argv[0]` points to a different file in CLI context — document both
+defaults in the `help` string and in the mixin's docstring.
+
+Mixin flags are only accepted when their mixin is active. Passing a flag
+without `--mixin <name>` (or `--all`) is an error.
+
+### Custom capture methods
 
 Add methods prefixed with `capture_` to run before the function starts, or
 `capturepost_` to run after it returns. Each receives `bm_data`, the

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -61,6 +61,7 @@ def _show_mixins(mixin_map):
     """Print a table of available CLI-compatible mixins and their descriptions."""
     default_set = set(_DEFAULT_MIXINS)
     width = max(len(name) for name in mixin_map)
+    arg_indent = ' ' * (4 + width + 2)
     print('Available mixins (* = included by default):\n')
     for name in sorted(mixin_map):
         cls = mixin_map[name]
@@ -68,6 +69,17 @@ def _show_mixins(mixin_map):
         summary = doc.splitlines()[0] if doc else ''
         marker = '*' if name in default_set else ' '
         print(f'  {marker} {name:<{width}}  {summary}')
+        for arg in getattr(cls, 'cli_args', []):
+            flag = arg.flags[0]
+            if arg.metavar:
+                flag_display = (
+                    f'{flag} {arg.metavar} [{arg.metavar} ...]'
+                    if arg.nargs == '+'
+                    else f'{flag} {arg.metavar}'
+                )
+            else:
+                flag_display = flag
+            print(f'{arg_indent}{flag_display}')
 
 
 class _SubprocessMonitorThread(threading.Thread):
@@ -239,6 +251,21 @@ def _build_parser(mixin_map):
         nargs=argparse.REMAINDER,
         help='Command to benchmark (use -- to separate from microbench options).',
     )
+    # Mixin-specific arguments, auto-discovered from cli_args on each mixin class.
+    for cli_name, cls in sorted(mixin_map.items()):
+        for arg in getattr(cls, 'cli_args', []):
+            kwargs = {
+                'dest': arg.dest,
+                'default': None,
+                'help': f'[{cli_name}] {arg.help}',
+            }
+            if arg.metavar is not None:
+                kwargs['metavar'] = arg.metavar
+            if arg.nargs is not None:
+                kwargs['nargs'] = arg.nargs
+            if arg.type is not str:
+                kwargs['type'] = arg.type
+            parser.add_argument(*arg.flags, **kwargs)
     return parser
 
 
@@ -272,6 +299,18 @@ def main(argv=None):
         mixin_names = list(dict.fromkeys(args.mixins))
     else:
         mixin_names = list(_DEFAULT_MIXINS)
+
+    # Validate: mixin-specific args require their mixin to be loaded.
+    mixin_names_set = set(mixin_names)
+    for cli_name, cls in mixin_map.items():
+        if cli_name not in mixin_names_set:
+            for arg in getattr(cls, 'cli_args', []):
+                if getattr(args, arg.dest, None) is not None:
+                    parser.error(
+                        f'{arg.flags[0]}: the {cli_name!r} mixin is not loaded. '
+                        f'Add it with --mixin {cli_name} or use --all.'
+                    )
+
     mixins = [mixin_map[name] for name in mixin_names]
 
     extra_fields = {}
@@ -314,6 +353,23 @@ def main(argv=None):
         (MicroBench, _MBSubprocessResult, *mixins),
         {'capture_optional': True},
     )
+
+    # Apply mixin-specific CLI arguments, using cli_defaults where not supplied.
+    from microbench.mixins import _UNSET
+
+    for name in mixin_names:
+        for arg in getattr(mixin_map[name], 'cli_args', []):
+            user_value = getattr(args, arg.dest, None)
+            if user_value is not None:
+                setattr(BenchClass, arg.dest, user_value)
+            elif arg.cli_default is not _UNSET:
+                setattr(
+                    BenchClass,
+                    arg.dest,
+                    arg.cli_default(cmd)
+                    if callable(arg.cli_default)
+                    else arg.cli_default,
+                )
 
     output = FileOutput(args.outfile) if args.outfile else FileOutput(sys.stdout)
     bench = BenchClass(

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -1,3 +1,4 @@
+import argparse
 import base64
 import inspect
 import os
@@ -27,6 +28,66 @@ except ImportError:
     numpy = None
 
 from ._encoding import _UNENCODABLE_PLACEHOLDER_VALUE, JSONEncodeWarning
+
+_UNSET = object()
+
+
+def _existing_file(value):
+    """argparse type: accept an existing file path, reject directories."""
+    if os.path.isdir(value):
+        raise argparse.ArgumentTypeError(f'{value!r} is a directory')
+    if not os.path.isfile(value):
+        raise argparse.ArgumentTypeError(f'file not found: {value!r}')
+    return value
+
+
+def _existing_dir(value):
+    """argparse type: accept an existing directory path."""
+    if not os.path.isdir(value):
+        raise argparse.ArgumentTypeError(f'directory not found: {value!r}')
+    return value
+
+
+class CLIArg:
+    """Declares a CLI argument that sets a mixin attribute.
+
+    Attach a list of ``CLIArg`` instances to a mixin class as ``cli_args``
+    to expose configurable attributes through ``python -m microbench``.
+    Arguments are added to the parser automatically; no changes to the CLI
+    code are needed when adding new configurable mixins.
+
+    Args:
+        flags: Flag strings for the argument, e.g. ``['--git-repo']``.
+        dest: Mixin attribute name to set, e.g. ``'git_repo'``.
+        help: Help text shown in ``--help`` and ``--show-mixins``.
+        metavar: Display name for the value in help text.
+        type: Callable to convert the raw string. Defaults to ``str``.
+        nargs: Number of arguments (e.g. ``'+'`` for one or more).
+        cli_default: Default when the flag is not given on the CLI.
+            If callable, called with the command list (``cmd``) to
+            compute the default at run time (e.g. ``lambda cmd:
+            [cmd[0]]``). Use ``_UNSET`` (the default) to fall back to
+            the mixin's own Python-API default logic instead.
+    """
+
+    def __init__(
+        self,
+        flags,
+        dest,
+        help,
+        *,
+        metavar=None,
+        type=str,
+        nargs=None,
+        cli_default=_UNSET,
+    ):
+        self.flags = flags
+        self.dest = dest
+        self.help = help
+        self.metavar = metavar
+        self.type = type
+        self.nargs = nargs
+        self.cli_default = cli_default
 
 
 class MBFunctionCall:
@@ -70,7 +131,7 @@ class MBReturnValue:
 
 
 class MBPythonVersion:
-    """Capture the Python version and location of the Python executable"""
+    """Capture the Python version and location of the Python executable."""
 
     cli_compatible = True
 
@@ -82,7 +143,7 @@ class MBPythonVersion:
 
 
 class MBHostInfo:
-    """Capture the hostname and operating system"""
+    """Capture the hostname and operating system."""
 
     cli_compatible = True
 
@@ -305,6 +366,11 @@ class MBGitInfo:
     useful when the script and the repository root are in different
     locations.
 
+    **CLI usage** (``python -m microbench``): the default is the current
+    working directory rather than the script directory, since
+    ``sys.argv[0]`` points to the microbench package itself. Use
+    ``--git-repo DIR`` to override.
+
     Attributes:
         git_repo (str, optional): Directory to inspect. Defaults to the
             directory of the running script, or the shell's working
@@ -323,6 +389,20 @@ class MBGitInfo:
     """
 
     cli_compatible = True
+    cli_args = [
+        CLIArg(
+            flags=['--git-repo'],
+            dest='git_repo',
+            metavar='DIR',
+            type=_existing_dir,
+            help=(
+                'Directory to inspect for git info. '
+                'CLI default: current working directory. '
+                'Python API default: directory of the running script.'
+            ),
+            cli_default=lambda cmd: os.getcwd(),
+        ),
+    ]
 
     def capture_git_info(self, bm_data):
         if hasattr(self, 'git_repo'):
@@ -378,6 +458,12 @@ class MBFileHash:
     instead. Files are read in 64 KB chunks, so large files are handled
     without loading them fully into memory.
 
+    **CLI usage** (``python -m microbench``): the default is the
+    benchmarked command executable (``cmd[0]``) rather than the running
+    script, since ``sys.argv[0]`` points to the microbench package
+    itself. Use ``--hash-file FILE [FILE ...]`` to override, and
+    ``--hash-algorithm`` to change the algorithm.
+
     Attributes:
         hash_files (iterable of str, optional): File paths to hash.
             Defaults to ``[sys.argv[0]]``.
@@ -396,6 +482,27 @@ class MBFileHash:
     """
 
     cli_compatible = True
+    cli_args = [
+        CLIArg(
+            flags=['--hash-file'],
+            dest='hash_files',
+            metavar='FILE',
+            nargs='+',
+            type=_existing_file,
+            help=(
+                'File(s) to hash with the file-hash mixin. '
+                'CLI default: the benchmarked command executable. '
+                'Python API default: the running script.'
+            ),
+            cli_default=lambda cmd: [cmd[0]],
+        ),
+        CLIArg(
+            flags=['--hash-algorithm'],
+            dest='hash_algorithm',
+            metavar='ALGORITHM',
+            help='Hash algorithm for the file-hash mixin (e.g. sha256, md5). Default: sha256.',  # noqa: E501
+        ),
+    ]
 
     def capture_file_hashes(self, bm_data):
         import hashlib
@@ -556,7 +663,7 @@ class _NeedsPsUtil:
 
 
 class MBHostCpuCores(_NeedsPsUtil):
-    """Capture the number of logical CPU cores"""
+    """Capture the number of logical CPU cores."""
 
     cli_compatible = True
 
@@ -567,7 +674,7 @@ class MBHostCpuCores(_NeedsPsUtil):
 
 
 class MBHostRamTotal(_NeedsPsUtil):
-    """Capture the total host RAM in bytes"""
+    """Capture the total host RAM in bytes."""
 
     cli_compatible = True
 

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -32,6 +32,26 @@ from ._encoding import _UNENCODABLE_PLACEHOLDER_VALUE, JSONEncodeWarning
 _UNSET = object()
 
 
+def _resolve_cmd_path(cmd):
+    """Resolve cmd[0] to an absolute file path for use as a hash target.
+
+    Tries ``shutil.which`` first (handles bare command names like ``echo``
+    by searching PATH), then falls back to checking whether the string is
+    itself an existing file (handles relative and absolute paths that may
+    not be executable). Returns a one-element list with the resolved path,
+    or an empty list if the command cannot be resolved to a file.
+    """
+    import shutil
+
+    path = cmd[0]
+    resolved = shutil.which(path)
+    if resolved:
+        return [resolved]
+    if os.path.isfile(path):
+        return [path]
+    return []
+
+
 def _existing_file(value):
     """argparse type: accept an existing file path, reject directories."""
     if os.path.isdir(value):
@@ -494,7 +514,7 @@ class MBFileHash:
                 'CLI default: the benchmarked command executable. '
                 'Python API default: the running script.'
             ),
-            cli_default=lambda cmd: [cmd[0]],
+            cli_default=_resolve_cmd_path,
         ),
         CLIArg(
             flags=['--hash-algorithm'],

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -138,6 +139,8 @@ def test_cli_show_mixins():
     output = buf.getvalue()
     assert 'host-info' in output
     assert 'python-version' in output
+    assert '--hash-file' in output  # mixin-specific arg shown under file-hash
+    assert '--git-repo' in output  # mixin-specific arg shown under git-info
 
 
 def test_cli_capture_optional_on_by_default():
@@ -691,3 +694,123 @@ def test_cli_monitor_interval_with_stdout_capture():
     record = json.loads(buf.getvalue())
     assert record['stdout'] == ['hello\n']
     assert record['subprocess_monitor'][0][0]['cpu_percent'] == 8.0
+
+
+# ---------------------------------------------------------------------------
+# Mixin CLI args: MBGitInfo and MBFileHash
+# ---------------------------------------------------------------------------
+
+
+def test_cli_mixin_arg_without_mixin_errors():
+    """Supplying a mixin arg without the corresponding mixin loaded is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'host-info', '--hash-file', 'data.txt', '--', 'echo'])
+    assert exc.value.code != 0
+
+
+def test_cli_git_repo_without_mixin_errors():
+    """--git-repo without the git-info mixin is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--git-repo', '/some/path', '--', 'echo'])
+    assert exc.value.code != 0
+
+
+def test_cli_mixin_arg_accepted_with_all_flag(tmp_path):
+    """Mixin args are accepted when --all is used (all mixins loaded)."""
+    target = tmp_path / 'f.txt'
+    target.write_bytes(b'x')
+    with patch('subprocess.check_output', side_effect=_fake_git_output):
+        _, record, _ = _run_main(['--all', '--hash-file', str(target), '--', 'true'])
+    assert str(target) in record.get('file_hashes', {})
+
+
+def test_cli_hash_file_rejects_directory(tmp_path):
+    """--hash-file rejects a directory before the subprocess runs."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'file-hash', '--hash-file', str(tmp_path), '--', 'echo'])
+    assert exc.value.code != 0
+
+
+def test_cli_hash_file_rejects_nonexistent():
+    """--hash-file rejects a path that does not exist."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'file-hash', '--hash-file', 'no_such_file.txt', '--', 'echo'])
+    assert exc.value.code != 0
+
+
+def test_cli_git_repo_rejects_nonexistent():
+    """--git-repo rejects a path that does not exist."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'git-info', '--git-repo', '/no/such/dir', '--', 'echo'])
+    assert exc.value.code != 0
+
+
+def _fake_git_output(cmd, **kwargs):
+    """Mock for subprocess.check_output that returns minimal valid git output."""
+    cwd = kwargs.get('cwd') or os.getcwd()
+    if 'rev-parse' in cmd:
+        return (cwd + '\n').encode()
+    # git status --porcelain=v2 --branch
+    return b'# branch.oid abc123\n# branch.head main\n'
+
+
+def test_cli_git_repo_explicit(tmp_path):
+    """--git-repo passes the given directory to git."""
+    with patch('subprocess.check_output', side_effect=_fake_git_output) as mock_co:
+        _, record, _ = _run_main(
+            ['--mixin', 'git-info', '--git-repo', str(tmp_path), '--', 'true']
+        )
+    assert record.get('git_info', {}).get('repo') == str(tmp_path)
+    for call in mock_co.call_args_list:
+        assert call.kwargs.get('cwd') == str(tmp_path)
+
+
+def test_cli_git_repo_default_cwd():
+    """git-info defaults to the current working directory when --git-repo is omitted."""
+    with patch('subprocess.check_output', side_effect=_fake_git_output):
+        _, record, _ = _run_main(['--mixin', 'git-info', '--', 'true'])
+    assert record.get('git_info', {}).get('repo') == os.getcwd()
+
+
+def test_cli_hash_file_explicit(tmp_path):
+    """--hash-file hashes the specified file and records it."""
+    target = tmp_path / 'data.txt'
+    target.write_bytes(b'hello')
+    _, record, _ = _run_main(
+        ['--mixin', 'file-hash', '--hash-file', str(target), '--', 'true']
+    )
+    assert str(target) in record.get('file_hashes', {})
+
+
+def test_cli_hash_file_default_cmd(tmp_path):
+    """file-hash defaults to hashing cmd[0] when --hash-file is not given."""
+    target = tmp_path / 'script.sh'
+    target.write_bytes(b'#!/bin/sh')
+    _, record, _ = _run_main(['--mixin', 'file-hash', '--', str(target)])
+    assert str(target) in record.get('file_hashes', {})
+
+
+def test_cli_hash_algorithm(tmp_path):
+    """--hash-algorithm changes the digest algorithm used by file-hash."""
+    target = tmp_path / 'data.txt'
+    target.write_bytes(b'hello')
+    _, r256, _ = _run_main(
+        ['--mixin', 'file-hash', '--hash-file', str(target), '--', 'true']
+    )
+    _, rmd5, _ = _run_main(
+        [
+            '--mixin',
+            'file-hash',
+            '--hash-file',
+            str(target),
+            '--hash-algorithm',
+            'md5',
+            '--',
+            'true',
+        ]
+    )
+    sha256_hex = r256['file_hashes'][str(target)]
+    md5_hex = rmd5['file_hashes'][str(target)]
+    assert len(sha256_hex) == 64  # sha256 produces a 64-char hex digest
+    assert len(md5_hex) == 32  # md5 produces a 32-char hex digest
+    assert sha256_hex != md5_hex

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -790,6 +790,23 @@ def test_cli_hash_file_default_cmd(tmp_path):
     assert str(target) in record.get('file_hashes', {})
 
 
+def test_cli_hash_file_default_resolves_bare_command(tmp_path):
+    """file-hash resolves bare command names via PATH for the default hash target."""
+    fake_bin = tmp_path / 'myapp'
+    fake_bin.write_bytes(b'#!/bin/sh')
+    with patch('shutil.which', return_value=str(fake_bin)):
+        _, record, _ = _run_main(['--mixin', 'file-hash', '--', 'myapp'])
+    assert str(fake_bin) in record.get('file_hashes', {})
+
+
+def test_cli_hash_file_default_unresolvable_cmd():
+    """file-hash records empty file_hashes without error when cmd cannot be resolved."""
+    with patch('shutil.which', return_value=None):
+        _, record, _ = _run_main(['--mixin', 'file-hash', '--', 'ghost_cmd'])
+    assert 'mb_capture_errors' not in record
+    assert record.get('file_hashes') == {}
+
+
 def test_cli_hash_algorithm(tmp_path):
     """--hash-algorithm changes the digest algorithm used by file-hash."""
     target = tmp_path / 'data.txt'


### PR DESCRIPTION
## Summary

Introduces a `CLIArg` descriptor class that lets any `cli_compatible` mixin expose configurable attributes as CLI flags, auto-discovered by the CLI with no changes to `__main__.py` needed.

- **`CLIArg`** in `mixins.py`: declare `cli_args = [CLIArg(...)]` on a mixin to add flags. Supports `type=` for argparse validation, `nargs`, `metavar`, and `cli_default` (a value or `lambda cmd: ...` for command-dependent defaults).
- **`MBGitInfo`**: adds `--git-repo DIR` — CLI default is the current working directory (the Python API default of `sys.argv[0]`'s directory is wrong in CLI context where `sys.argv[0]` points to the microbench package).
- **`MBFileHash`**: adds `--hash-file FILE [FILE ...]` (CLI default: `cmd[0]`) and `--hash-algorithm ALGORITHM` (default: `sha256`). Shell-expanded globs that include directories are caught early: `--hash-file __pycache__` gives a clean error rather than an `IsADirectoryError` buried in the JSON output.
- **`existing_file` / `existing_dir`**: argparse type functions that validate paths before the subprocess runs.
- **Mixin flag validation**: passing a mixin flag without loading that mixin is an error.
- **`--help` prefix**: mixin flags are labelled `[mixin-name]` in the help output.
- **`--show-mixins`**: now lists each mixin's flags beneath its description.
- **Docs**: new "Mixin options" section in `cli.md`; new "Making a mixin CLI-compatible" subsection in `advanced.md`.