### PR TITLE
feat: add MBWorkingDir mixin and include in CLI defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ All notable changes to microbench are documented here.
   kebab-case names without the `MB` prefix (e.g. `host-info`,
   `python-version`); original MB-prefixed names are also accepted. Use
   `--mixin MIXIN [MIXIN ...]` to select metadata to capture (defaults to
-  `host-info`, `slurm-info`, and `loaded-modules`); use `--show-mixins` to
+  `host-info`, `slurm-info`, `loaded-modules`, and `working-dir`); use `--show-mixins` to
   list all available mixins with descriptions; use `--field KEY=VALUE` to
   attach extra labels; use `--iterations N` and `--warmup N` for repeat
   timing; use `--stdout[=suppress]` and `--stderr[=suppress]` to capture
@@ -214,7 +214,12 @@ All notable changes to microbench are documented here.
   to version string (e.g. `{"gcc": "12.2.0", "openmpi": "4.1.5"}`). Reads
   the standard `LOADEDMODULES` environment variable — no subprocess, no
   extra dependencies. Empty dict when no modules are loaded. Included in
-  the CLI defaults alongside `MBHostInfo` and `MBSlurmInfo`.
+  the CLI defaults alongside `MBHostInfo`, `MBSlurmInfo`, and `MBWorkingDir`.
+
+- **`MBWorkingDir` mixin**: captures the absolute path of the working
+  directory at benchmark time into `working_dir`. No dependencies. Included
+  in the CLI defaults — useful for reproducibility when comparing results
+  across nodes or directories.
 
 - **`MBGitInfo` mixin**: captures the repository root path, current commit
   hash, branch name, and dirty flag (uncommitted changes present) via

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,11 +46,12 @@ Every record contains the standard fields (`start_time`, `finish_time`,
 
 ## Default mixins
 
-When no `--mixin` is specified, `host-info`, `slurm-info`, and
-`loaded-modules` are included automatically, capturing hostname,
-operating system, all `SLURM_*` environment variables, and the loaded
-Lmod/Environment Modules software stack. All three degrade gracefully
-to empty dicts outside of their respective environments.
+When no `--mixin` is specified, `host-info`, `slurm-info`,
+`loaded-modules`, and `working-dir` are included automatically, capturing
+hostname, operating system, all `SLURM_*` environment variables, the loaded
+Lmod/Environment Modules software stack, and the current working directory.
+All four degrade gracefully or produce stable values outside their respective
+environments.
 
 Mixin names use a short kebab-case form without the `MB` prefix
 (e.g. `host-info` instead of `MBHostInfo`). MB-prefixed names are also

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -30,6 +30,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBPeakMemory` | `peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
 | `MBLoadedModules` | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
+| `MBWorkingDir` | `working_dir` — absolute path of the working directory at benchmark time | — |
 | `MBCgroupLimits` | `cgroup_limits` dict with `cpu_cores`, `memory_bytes`, `cgroup_version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
 | `MBGitInfo` | `git_info` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
@@ -218,6 +219,31 @@ string as the version. Hierarchical module names such as
 This mixin reads the `LOADEDMODULES` environment variable, which is the
 standard set by both Lmod and Environment Modules. No subprocess is
 required and there are no extra dependencies.
+
+### `MBWorkingDir`
+
+Captures the absolute path of the working directory at benchmark time into `working_dir`:
+
+```python
+from microbench import MicroBench, MBWorkingDir
+
+class Bench(MicroBench, MBWorkingDir):
+    pass
+
+bench = Bench()
+```
+
+Each record will contain:
+
+```json
+{
+  "working_dir": "/home/user/experiments/run-42"
+}
+```
+
+Useful for reproducibility — records exactly which directory was current when
+the benchmark ran, so results from different nodes or directories can be
+distinguished. Included in the CLI defaults.
 
 ### `MBCgroupLimits`
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -50,6 +50,7 @@ from .mixins import (
     MBPythonVersion,
     MBReturnValue,
     MBSlurmInfo,
+    MBWorkingDir,
     _MonitorThread,
 )
 
@@ -83,6 +84,7 @@ __all__ = [
     'MBPeakMemory',
     'MBSlurmInfo',
     'MBLoadedModules',
+    'MBWorkingDir',
     'MBCgroupLimits',
     'MBGitInfo',
     'MBFileHash',

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -37,7 +37,7 @@ def _get_mixin_map():
     }
 
 
-_DEFAULT_MIXINS = ('host-info', 'slurm-info', 'loaded-modules')
+_DEFAULT_MIXINS = ('host-info', 'slurm-info', 'loaded-modules', 'working-dir')
 
 _CAPTURE_CHOICES = ('capture', 'suppress')
 

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -250,6 +250,15 @@ class MBLoadedModules:
         bm_data['loaded_modules'] = modules
 
 
+class MBWorkingDir:
+    """Capture the working directory at benchmark time."""
+
+    cli_compatible = True
+
+    def capture_working_dir(self, bm_data):
+        bm_data['working_dir'] = os.getcwd()
+
+
 def _read_cgroup_v2():
     """Read CPU quota and memory limit from a cgroup v2 hierarchy."""
     cgroup_path = None

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -95,6 +95,14 @@ def test_cli_default_mixins_include_loaded_modules():
     assert 'loaded_modules' in record
 
 
+def test_cli_default_mixins_include_working_dir():
+    """Default configuration includes MBWorkingDir (working_dir field)."""
+    _, record, _ = _run_main(['--', 'true'])
+
+    assert 'working_dir' in record
+    assert record['working_dir'] == os.getcwd()
+
+
 def test_cli_explicit_mixin_replaces_defaults():
     """Specifying --mixin replaces the default mixin set."""
     _, record, _ = _run_main(['--mixin', 'MBPythonVersion', '--', 'true'])

--- a/microbench/tests/test_mixins.py
+++ b/microbench/tests/test_mixins.py
@@ -14,6 +14,7 @@ from microbench import (
     MBLoadedModules,
     MBPeakMemory,
     MBSlurmInfo,
+    MBWorkingDir,
     MicroBench,
 )
 from microbench import __version__ as microbench_version
@@ -156,6 +157,24 @@ def test_mb_loaded_modules_version_with_slash():
 
     modules = bench.get_results(format='df')['loaded_modules'][0]
     assert modules['GCC'] == '12.2.0-GCCcore-12.2.0'
+
+
+def test_mb_working_dir():
+    """working_dir captures the current working directory."""
+
+    class Bench(MicroBench, MBWorkingDir):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+
+    result = bench.get_results()[0]
+    assert result['working_dir'] == os.getcwd()
 
 
 def test_capture_global_packages():


### PR DESCRIPTION
## Summary

- Adds `MBWorkingDir` mixin that records `working_dir` (absolute path of the working directory at benchmark time)
- Adds `working-dir` to the CLI default mixins alongside `host-info`, `slurm-info`, and `loaded-modules`
- Documents the new mixin in `docs/user-guide/mixins.md` and updates `docs/cli.md` and `CHANGELOG.md`