### PR TITLE
fix: make --all and --no-mixin mutually exclusive

### DIFF
--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -174,14 +174,15 @@ def _build_parser(mixin_map):
         action='store_true',
         help='List available mixins with descriptions and exit.',
     )
-    parser.add_argument(
+    mixin_scope = parser.add_mutually_exclusive_group()
+    mixin_scope.add_argument(
         '--all',
         '-a',
         action='store_true',
         dest='all_mixins',
         help='Include all available mixins. Overrides --mixin.',
     )
-    parser.add_argument(
+    mixin_scope.add_argument(
         '--no-mixin',
         action='store_true',
         dest='no_mixins',

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -475,6 +475,13 @@ def test_cli_no_mixin_overrides_mixin():
     assert 'hostname' not in record
 
 
+def test_cli_all_and_no_mixin_are_mutually_exclusive():
+    """--all and --no-mixin cannot be used together."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--all', '--no-mixin', '--', 'true'])
+    assert exc.value.code != 0
+
+
 # ---------------------------------------------------------------------------
 # --monitor-interval tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `--all` and `--no-mixin` are now in an `argparse` mutually exclusive group, so passing both exits with an error
- Adds a test covering this case