### PR TITLE
feat: microbench entry point, MBPythonInfo, MicroBenchBase, conda improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to microbench are documented here.
 
 ## [2.0.0] - unreleased
 
-### Breaking changes
+### Breaking changes (vs v1.1.0)
 
 - **`get_results()` now returns a list of dicts by default**: The default
   `format='dict'` returns a list of plain Python dicts and requires no
@@ -164,6 +164,35 @@ All notable changes to microbench are documented here.
   written before the exception propagates. An `exception` field is added
   containing `{"type": ..., "message": ...}`. The exception is always
   re-raised. With `--iterations N`, timing stops at the first exception.
+
+- **`microbench` console entry point**: `microbench` is now available as a
+  shell command after installation — no need to spell out `python -m microbench`.
+  `python -m microbench` remains fully equivalent and is still the recommended
+  form when you need to select a specific Python interpreter explicitly.
+
+- **`MBPythonInfo` mixin** replaces `MBPythonVersion`: records a `python` dict
+  with `version`, `prefix` (`sys.prefix`), and `executable` (`sys.executable`),
+  giving a complete picture of the running interpreter in one field. `MBPythonVersion`
+  is deprecated and will be removed in a future release. `MBPythonInfo` is included
+  in :class:`MicroBench` by default (Python API) and in the CLI default mixin set;
+  `--no-mixin` suppresses it on the CLI as usual.
+
+- **`MicroBenchBase`**: the core benchmarking machinery is now exposed as
+  `MicroBenchBase` (no default mixins). `MicroBench` inherits from both
+  `MicroBenchBase` and `MBPythonInfo`. Subclass `MicroBenchBase` directly when
+  you need a completely bare benchmark class with no automatic captures.
+
+- **`MBCondaPackages` improvements**:
+  - Queries the environment identified by `CONDA_PREFIX` (the shell's active conda
+    environment) rather than `sys.prefix`. Falls back to `sys.prefix` when
+    `CONDA_PREFIX` is not set.
+  - Falls back to `CONDA_EXE` if `conda` is not on `PATH` (common in non-interactive
+    SLURM batch scripts where conda is activated but its `bin/` is not on `PATH`).
+  - Replaces the separate `conda_versions` field with a unified `conda` dict
+    containing `name` (`CONDA_DEFAULT_ENV`), `path` (`CONDA_PREFIX`), and
+    `packages` (the version dict). Either of `name`/`path` may be `None` if
+    the corresponding variable is unset. With `get_results(flat=True)` these
+    expand to `conda.name`, `conda.path`, `conda.packages.<pkg>` etc.
 
 - **Command-line interface** (`python -m microbench`): wrap any external
   command and record host metadata alongside timing without writing Python

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,16 +4,19 @@ Microbench can wrap any external command and record host metadata
 alongside timing, without writing any Python code:
 
 ```bash
-python -m microbench --outfile results.jsonl -- ./run_simulation.sh
+microbench --outfile results.jsonl -- ./run_simulation.sh
 ```
 
 This is particularly useful for SLURM jobs, shell scripts, or compiled
 executables where adding a Python decorator is not practical.
 
+`python -m microbench` is equivalent and can be used when you need to
+select a specific Python interpreter explicitly.
+
 ## Usage
 
 ```
-python -m microbench [options] -- COMMAND [ARGS...]
+microbench [options] -- COMMAND [ARGS...]
 ```
 
 | Option | Description |
@@ -46,11 +49,12 @@ Every record contains the standard fields (`start_time`, `finish_time`,
 
 ## Default mixins
 
-When no `--mixin` is specified, `host-info`, `slurm-info`,
+When no `--mixin` is specified, `python-info`, `host-info`, `slurm-info`,
 `loaded-modules`, and `working-dir` are included automatically, capturing
-hostname, operating system, all `SLURM_*` environment variables, the loaded
-Lmod/Environment Modules software stack, and the current working directory.
-All four degrade gracefully or produce stable values outside their respective
+the Python interpreter version, prefix, and executable path; hostname and
+operating system; all `SLURM_*` environment variables; the loaded
+Lmod/Environment Modules software stack; and the current working directory.
+All five degrade gracefully or produce stable values outside their respective
 environments.
 
 Mixin names use a short kebab-case form without the `MB` prefix
@@ -59,19 +63,32 @@ accepted for convenience. Run `--show-mixins` to list all available
 mixins with descriptions:
 
 ```bash
-python -m microbench --show-mixins
+microbench --show-mixins
 ```
 
 Specifying `--mixin` replaces the defaults entirely. Use `--no-mixin` to
 disable all mixins and record only timing and command fields:
 
 ```bash
-# Only Python version — no host info or SLURM
-python -m microbench --mixin python-version -- ./job.sh
+# Only Python info — no host info or SLURM
+microbench --mixin python-info -- ./job.sh
 
 # No mixins at all — timing and command only
-python -m microbench --no-mixin -- ./job.sh
+microbench --no-mixin -- ./job.sh
 ```
+
+!!! note "Python-environment mixins"
+    `python-info` and `installed-packages` capture the **microbench
+    process's** Python interpreter. In typical usage (microbench installed
+    in the same environment as the benchmarked code) this is exactly what
+    you want. If you need to target a different interpreter, invoke
+    microbench via it: `python -m microbench --mixin python-info -- ./job.sh`.
+
+    `conda-packages` queries the environment identified by `CONDA_PREFIX`
+    (the shell's active conda environment), not `sys.prefix`, so it
+    captures the correct environment even when microbench's Python lives
+    elsewhere (e.g. in base). Package versions are stored under
+    `conda.packages` alongside `conda.name` and `conda.path`.
 
 See [Mixins](user-guide/mixins.md) for details on each.
 
@@ -124,7 +141,7 @@ A typical SLURM job script:
 #SBATCH --job-name=my-sim
 #SBATCH --output=slurm-%j.out
 
-python -m microbench \
+microbench \
     --outfile /scratch/$USER/results.jsonl \
     --mixin host-info slurm-info host-cpu-cores \
     --field experiment=baseline \
@@ -151,7 +168,7 @@ This is useful when the command is short-lived and you want to amortise
 per-record overhead or reduce timing noise:
 
 ```bash
-python -m microbench --iterations 10 --warmup 2 -- ./run_simulation.sh
+microbench --iterations 10 --warmup 2 -- ./run_simulation.sh
 ```
 
 With 10 iterations and 2 warmup runs, the record contains:
@@ -172,7 +189,7 @@ Warmup runs are excluded from all three lists. The process exits with
     unbuffering flag (e.g. `python -u`) if you need per-line flushing:
 
     ```bash
-    python -m microbench --stdout -- stdbuf -oL ./run_simulation.sh
+    microbench --stdout -- stdbuf -oL ./run_simulation.sh
     ```
 
 To detect failed iterations when analysing results with pandas:
@@ -186,7 +203,7 @@ results['any_failed'] = results['returncode'].apply(lambda rc: max(rc) != 0)
 Use `--field` to attach experiment labels or other fixed values:
 
 ```bash
-python -m microbench \
+microbench \
     --outfile results.jsonl \
     --field experiment=ablation-1 \
     --field dataset=large \
@@ -202,7 +219,7 @@ while it runs. This requires the [`psutil`](https://psutil.readthedocs.io/)
 package (`pip install psutil`).
 
 ```bash
-python -m microbench \
+microbench \
     --outfile results.jsonl \
     --monitor-interval 5 \
     -- ./run_simulation.sh --steps 10000

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -4,11 +4,16 @@ Mixins are classes that add metadata capture to a benchmark suite via
 multiple inheritance. Combine any number of mixins with `MicroBench`:
 
 ```python
-from microbench import MicroBench, MBPythonVersion, MBHostInfo, MBHostCpuCores
+from microbench import MicroBench, MBHostInfo, MBHostCpuCores
 
-class MyBench(MicroBench, MBPythonVersion, MBHostInfo, MBHostCpuCores):
+class MyBench(MicroBench, MBHostInfo, MBHostCpuCores):
     pass
 ```
+
+`MicroBench` already includes `MBPythonInfo` by default, so a `python` dict
+is present in every record without any extra mixin. Subclass
+`MicroBenchBase` instead if you want a completely bare benchmark class with
+no default captures.
 
 Python resolves method calls across multiple base classes using the **Method
 Resolution Order (MRO)** — a deterministic left-to-right search that ensures
@@ -23,7 +28,8 @@ combine any number of microbench mixins without conflicts, and their
 | *(none)* | `mb_run_id`, `mb_version`, `start_time`, `finish_time`, `run_durations`, `function_name`, `timestamp_tz`, `duration_counter` | — |
 | `MBFunctionCall` | `args`, `kwargs` | — |
 | `MBReturnValue` | `return_value` | — |
-| `MBPythonVersion` | `python_version`, `python_executable` | — |
+| `MBPythonInfo` | `python` dict: `version`, `prefix`, `executable` — **included in `MicroBench` by default** | — |
+| `MBPythonVersion` | `python_version`, `python_executable` — *deprecated, use `MBPythonInfo`* | — |
 | `MBHostInfo` | `hostname`, `operating_system` | — |
 | `MBHostCpuCores` | `cpu_cores_logical`, `cpu_cores_physical` | psutil |
 | `MBHostRamTotal` | `ram_total` (bytes) | psutil |
@@ -35,7 +41,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBGitInfo` | `git_info` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `package_versions` for every installed package | — |
-| `MBCondaPackages` | `conda_versions` for every package in the active conda environment | `conda` on PATH |
+| `MBCondaPackages` | `conda` dict with `name`, `path`, and `packages` (version dict) | `conda` on PATH or `CONDA_EXE` set |
 | `MBNvidiaSmi` | `nvidia_<attr>` per GPU (see below) | `nvidia-smi` on PATH |
 | `MBLineProfiler` | `line_profiler` (base64-encoded profile, see below) | line_profiler |
 | `MBFileHash` | `file_hashes` — SHA-256 checksum of each specified file | — |
@@ -444,7 +450,18 @@ class Bench(MicroBench, MBInstalledPackages):
 
 ### `MBCondaPackages`
 
-Captures all packages in the active conda environment using the `conda` CLI.
+Captures the active conda environment's identity and package list using the
+`conda` CLI. The active environment is determined by the `CONDA_PREFIX`
+environment variable, falling back to `sys.prefix` when it is unset.
+If `conda` is not on `PATH`, the `CONDA_EXE` environment variable is tried.
+
+Records two fields:
+
+A single `conda` dict with three keys:
+
+- `name` (`CONDA_DEFAULT_ENV`) — may be `None` if unset.
+- `path` (`CONDA_PREFIX`) — may be `None` if unset.
+- `packages` — dict mapping package name to version string.
 
 ```python
 class Bench(MicroBench, MBCondaPackages):

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -47,6 +47,7 @@ from .mixins import (
     MBLoadedModules,
     MBNvidiaSmi,
     MBPeakMemory,
+    MBPythonInfo,
     MBPythonVersion,
     MBReturnValue,
     MBSlurmInfo,
@@ -68,6 +69,7 @@ _active_bm_data: contextvars.ContextVar = contextvars.ContextVar(
 
 __all__ = [
     # Core
+    'MicroBenchBase',
     'MicroBench',
     'summary',
     # Output sinks
@@ -77,6 +79,7 @@ __all__ = [
     # Mixins
     'MBFunctionCall',
     'MBReturnValue',
+    'MBPythonInfo',
     'MBPythonVersion',
     'MBHostInfo',
     'MBHostCpuCores',
@@ -140,7 +143,7 @@ def summary(results):
     )
 
 
-class MicroBench:
+class MicroBenchBase:
     def __init__(
         self,
         outfile=None,
@@ -839,3 +842,11 @@ class _TimingSection:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         return self.__exit__(exc_type, exc_val, exc_tb)
+
+
+class MicroBench(MBPythonInfo, MicroBenchBase):
+    """Benchmark suite with :class:`MBPythonInfo` included by default.
+
+    Subclass this for typical usage. If you need a completely bare benchmark
+    class with no default mixins, subclass :class:`MicroBenchBase` instead.
+    """

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -33,11 +33,17 @@ def _get_mixin_map():
         _mb_name_to_cli(name): getattr(_mb, name)
         for name in _mb.__all__
         if isinstance(getattr(_mb, name, None), type)
-        and getattr(getattr(_mb, name), 'cli_compatible', False)
+        and getattr(_mb, name).__dict__.get('cli_compatible', False)
     }
 
 
-_DEFAULT_MIXINS = ('host-info', 'slurm-info', 'loaded-modules', 'working-dir')
+_DEFAULT_MIXINS = (
+    'python-info',
+    'host-info',
+    'slurm-info',
+    'loaded-modules',
+    'working-dir',
+)
 
 _CAPTURE_CHOICES = ('capture', 'suppress')
 

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import platform
 import re
+import shutil
 import signal
 import socket
 import subprocess
@@ -151,7 +152,12 @@ class MBReturnValue:
 
 
 class MBPythonVersion:
-    """Capture the Python version and location of the Python executable."""
+    """Capture the Python version and location of the Python executable.
+
+    .. deprecated::
+        Use :class:`MBPythonInfo` instead. ``MBPythonVersion`` will be
+        removed in a future release.
+    """
 
     cli_compatible = True
 
@@ -160,6 +166,29 @@ class MBPythonVersion:
 
     def capture_python_executable(self, bm_data):
         bm_data['python_executable'] = sys.executable
+
+
+class MBPythonInfo:
+    """Capture the Python interpreter version, prefix, and executable path.
+
+    Records a ``python`` dict with three keys:
+
+    - ``version``: the Python version string (e.g. ``"3.12.4"``)
+    - ``prefix``: ``sys.prefix`` — the environment root
+    - ``executable``: ``sys.executable`` — the absolute interpreter path
+
+    This mixin is included in :class:`MicroBench` by default (Python API)
+    and in the CLI default mixin set. It supersedes :class:`MBPythonVersion`.
+    """
+
+    cli_compatible = True
+
+    def capture_python_info(self, bm_data):
+        bm_data['python'] = {
+            'version': platform.python_version(),
+            'prefix': sys.prefix,
+            'executable': sys.executable,
+        }
 
 
 class MBHostInfo:
@@ -334,7 +363,7 @@ def _read_cgroup_v1():
 
 
 class MBCgroupLimits:
-    """Capture CPU quota and memory limit from the Linux cgroup filesystem.
+    """Capture CPU quota and memory limit from Linux cgroups.
 
     Works for SLURM jobs and Kubernetes pods (cgroup v1 and v2). Results
     are stored in the ``cgroup_limits`` field as a dict containing:
@@ -587,10 +616,21 @@ class MBGlobalPackages:
 
 
 class MBCondaPackages:
-    """Capture conda packages using the conda CLI.
+    """Capture conda packages and active environment metadata.
 
-    Requires ``conda`` to be available on ``PATH``. Captures all packages
-    in the active conda environment (determined by ``sys.prefix``).
+    Runs ``conda list --prefix PREFIX`` where PREFIX is taken from the
+    ``CONDA_PREFIX`` environment variable (the active conda environment).
+    Falls back to ``sys.prefix`` when ``CONDA_PREFIX`` is not set (e.g.
+    when running inside the base environment without explicit activation).
+
+    If ``conda`` is not on ``PATH``, the ``CONDA_EXE`` environment variable
+    is tried as a fallback before raising an error.
+
+    Records a single ``conda`` dict with three keys:
+
+    - ``name`` (from ``CONDA_DEFAULT_ENV``) — may be ``None`` if unset.
+    - ``path`` (from ``CONDA_PREFIX``) — may be ``None`` if unset.
+    - ``packages`` — dict mapping package name to version string.
 
     Attributes:
         include_builds (bool): Include the build string in the version.
@@ -604,11 +644,18 @@ class MBCondaPackages:
     include_channels = False
 
     def capture_conda_packages(self, bm_data):
-        pkg_list = subprocess.check_output(
-            ['conda', 'list', '--prefix', sys.prefix]
-        ).decode('utf8')
+        conda_prefix = os.environ.get('CONDA_PREFIX', sys.prefix)
+        bm_data['conda'] = {
+            'name': os.environ.get('CONDA_DEFAULT_ENV'),
+            'path': os.environ.get('CONDA_PREFIX'),
+            'packages': {},
+        }
 
-        bm_data['conda_versions'] = {}
+        conda_prefix = os.environ.get('CONDA_PREFIX', sys.prefix)
+        conda_exe = shutil.which('conda') or os.environ.get('CONDA_EXE', 'conda')
+        pkg_list = subprocess.check_output(
+            [conda_exe, 'list', '--prefix', conda_prefix]
+        ).decode('utf8')
 
         for pkg in pkg_list.splitlines():
             if pkg.startswith('#') or not pkg.strip():
@@ -620,7 +667,7 @@ class MBCondaPackages:
                 pkg_version += pkg_data[2]
             if self.include_channels and len(pkg_data) == 4:
                 pkg_version += '(' + pkg_data[3] + ')'
-            bm_data['conda_versions'][pkg_name] = pkg_version
+            bm_data['conda']['packages'][pkg_name] = pkg_version
 
 
 class MBInstalledPackages:

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -103,11 +103,21 @@ def test_cli_default_mixins_include_working_dir():
     assert record['working_dir'] == os.getcwd()
 
 
+def test_cli_default_mixins_include_python_info():
+    """Default configuration includes MBPythonInfo (python field)."""
+    _, record, _ = _run_main(['--', 'true'])
+
+    assert 'python' in record
+    assert 'version' in record['python']
+    assert 'prefix' in record['python']
+    assert 'executable' in record['python']
+
+
 def test_cli_explicit_mixin_replaces_defaults():
     """Specifying --mixin replaces the default mixin set."""
-    _, record, _ = _run_main(['--mixin', 'MBPythonVersion', '--', 'true'])
+    _, record, _ = _run_main(['--mixin', 'python-info', '--', 'true'])
 
-    assert 'python_version' in record
+    assert 'python' in record
     # Default mixins should not be present
     assert 'hostname' not in record
     assert 'slurm' not in record

--- a/microbench/tests/test_conda.py
+++ b/microbench/tests/test_conda.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 from microbench import MBCondaPackages, MicroBench
@@ -11,7 +12,7 @@ pandas                    2.0.3            py311h9a0d8c7_0
 """
 
 
-def _run_conda_bench(**cls_attrs):
+def _run_conda_bench(env=None, **cls_attrs):
     attrs = {'include_builds': True, 'include_channels': True}
     attrs.update(cls_attrs)
     CondaBench = type('CondaBench', (MicroBench, MBCondaPackages), attrs)
@@ -21,9 +22,17 @@ def _run_conda_bench(**cls_attrs):
     def noop():
         pass
 
-    with patch(
-        'subprocess.check_output',
-        return_value=SAMPLE_CONDA_LIST.encode('utf8'),
+    conda_env = {'CONDA_PREFIX': '/opt/conda/envs/myenv', 'CONDA_DEFAULT_ENV': 'myenv'}
+    if env is not None:
+        conda_env.update(env)
+
+    with (
+        patch('shutil.which', return_value='conda'),
+        patch(
+            'subprocess.check_output',
+            return_value=SAMPLE_CONDA_LIST.encode('utf8'),
+        ),
+        patch.dict(os.environ, conda_env, clear=False),
     ):
         noop()
 
@@ -33,25 +42,166 @@ def _run_conda_bench(**cls_attrs):
 def test_conda_no_channel_doubling():
     """include_channels=True must not double the version string (B1 fix)."""
     results = _run_conda_bench(include_builds=True, include_channels=True)
-    versions = results['conda_versions'][0]
+    packages = results['conda'][0]['packages']
     # numpy has a channel: expect "version+build(channel)", not doubled version
-    assert versions['numpy'] == '1.24.3py311ha0bc626_0(conda-forge)', (
-        f'Got: {versions["numpy"]!r}'
+    assert packages['numpy'] == '1.24.3py311ha0bc626_0(conda-forge)', (
+        f'Got: {packages["numpy"]!r}'
     )
     # pandas has no channel: expect "version+build"
-    assert versions['pandas'] == '2.0.3py311h9a0d8c7_0', f'Got: {versions["pandas"]!r}'
+    assert packages['pandas'] == '2.0.3py311h9a0d8c7_0', f'Got: {packages["pandas"]!r}'
 
 
 def test_conda_include_builds_false():
     """include_builds=False should omit build string."""
     results = _run_conda_bench(include_builds=False, include_channels=False)
-    versions = results['conda_versions'][0]
-    assert versions['numpy'] == '1.24.3'
-    assert versions['pandas'] == '2.0.3'
+    packages = results['conda'][0]['packages']
+    assert packages['numpy'] == '1.24.3'
+    assert packages['pandas'] == '2.0.3'
 
 
 def test_conda_skip_comments_and_blanks():
-    """Comment lines and blank lines should not appear in conda_versions."""
+    """Comment lines and blank lines should not appear in conda.packages."""
     results = _run_conda_bench()
-    versions = results['conda_versions'][0]
-    assert not any(k.startswith('#') for k in versions)
+    packages = results['conda'][0]['packages']
+    assert not any(k.startswith('#') for k in packages)
+
+
+def test_conda_field_populated():
+    """conda field contains name and path from CONDA_DEFAULT_ENV and CONDA_PREFIX."""
+    results = _run_conda_bench()
+    conda = results['conda'][0]
+    assert conda['name'] == 'myenv'
+    assert conda['path'] == '/opt/conda/envs/myenv'
+
+
+def test_conda_packages_nested_under_conda():
+    """conda.packages holds the version dict, not a separate top-level field."""
+    results = _run_conda_bench()
+    result = results['conda'][0]
+    assert 'packages' in result
+    assert isinstance(result['packages'], dict)
+    assert 'numpy' in result['packages']
+    assert 'conda_versions' not in results.columns
+
+
+def test_conda_field_none_when_vars_unset():
+    """conda.name and conda.path are None when env vars are absent."""
+    CondaBench = type('CondaBench', (MicroBench, MBCondaPackages), {})
+    bench = CondaBench()
+
+    @bench
+    def noop():
+        pass
+
+    clean_env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ('CONDA_PREFIX', 'CONDA_DEFAULT_ENV')
+    }
+    with (
+        patch('shutil.which', return_value='conda'),
+        patch(
+            'subprocess.check_output',
+            return_value=SAMPLE_CONDA_LIST.encode('utf8'),
+        ),
+        patch.dict(os.environ, clean_env, clear=True),
+    ):
+        noop()
+
+    conda = bench.get_results()[0]['conda']
+    assert conda['name'] is None
+    assert conda['path'] is None
+
+
+def test_conda_uses_conda_prefix_for_list():
+    """conda list is invoked with --prefix CONDA_PREFIX, not sys.prefix."""
+    CondaBench = type('CondaBench', (MicroBench, MBCondaPackages), {})
+    bench = CondaBench()
+
+    @bench
+    def noop():
+        pass
+
+    with (
+        patch('shutil.which', return_value='conda'),
+        patch(
+            'subprocess.check_output',
+            return_value=SAMPLE_CONDA_LIST.encode('utf8'),
+        ) as mock_co,
+        patch.dict(
+            os.environ,
+            {'CONDA_PREFIX': '/opt/conda/envs/myenv', 'CONDA_DEFAULT_ENV': 'myenv'},
+            clear=False,
+        ),
+    ):
+        noop()
+
+    args = mock_co.call_args[0][0]
+    assert '--prefix' in args
+    assert args[args.index('--prefix') + 1] == '/opt/conda/envs/myenv'
+
+
+def test_conda_falls_back_to_conda_exe():
+    """When conda is not on PATH, CONDA_EXE is used as the conda executable."""
+    CondaBench = type('CondaBench', (MicroBench, MBCondaPackages), {})
+    bench = CondaBench()
+
+    @bench
+    def noop():
+        pass
+
+    with (
+        patch('shutil.which', return_value=None),
+        patch(
+            'subprocess.check_output',
+            return_value=SAMPLE_CONDA_LIST.encode('utf8'),
+        ) as mock_co,
+        patch.dict(
+            os.environ,
+            {
+                'CONDA_PREFIX': '/opt/conda/envs/myenv',
+                'CONDA_DEFAULT_ENV': 'myenv',
+                'CONDA_EXE': '/opt/conda/bin/conda',
+            },
+            clear=False,
+        ),
+    ):
+        noop()
+
+    exe = mock_co.call_args[0][0][0]
+    assert exe == '/opt/conda/bin/conda'
+
+
+def test_conda_flat_results():
+    """get_results(flat=True) flattens conda.packages.* to dot-notation keys."""
+    CondaBench = type(
+        'CondaBench',
+        (MicroBench, MBCondaPackages),
+        {'include_builds': False, 'include_channels': False},
+    )
+    bench = CondaBench()
+
+    @bench
+    def noop():
+        pass
+
+    with (
+        patch('shutil.which', return_value='conda'),
+        patch(
+            'subprocess.check_output',
+            return_value=SAMPLE_CONDA_LIST.encode('utf8'),
+        ),
+        patch.dict(
+            os.environ,
+            {'CONDA_PREFIX': '/opt/conda/envs/myenv', 'CONDA_DEFAULT_ENV': 'myenv'},
+            clear=False,
+        ),
+    ):
+        noop()
+
+    flat = bench.get_results(flat=True)[0]
+    assert flat['conda.name'] == 'myenv'
+    assert flat['conda.path'] == '/opt/conda/envs/myenv'
+    assert flat['conda.packages.numpy'] == '1.24.3'
+    assert flat['conda.packages.pandas'] == '2.0.3'
+    assert 'conda' not in flat  # fully expanded, no residual dict key

--- a/microbench/tests/test_core.py
+++ b/microbench/tests/test_core.py
@@ -16,9 +16,9 @@ from microbench import (
     MBFunctionCall,
     MBHostInfo,
     MBLineProfiler,
-    MBPythonVersion,
     MBReturnValue,
     MicroBench,
+    MicroBenchBase,
     Output,
 )
 
@@ -51,6 +51,31 @@ def test_mb_run_id_and_version():
     assert (results['mb_version'] == microbench.__version__).all()
 
 
+def test_microbench_includes_python_info_by_default():
+    """MicroBench records a python dict; MicroBenchBase does not."""
+    import sys
+
+    bench = MicroBench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+    result = bench.get_results()[0]
+    assert 'python' in result
+    assert result['python']['executable'] == sys.executable
+
+    base_bench = MicroBenchBase()
+
+    @base_bench
+    def noop_base():
+        pass
+
+    noop_base()
+    assert 'python' not in base_bench.get_results()[0]
+
+
 def test_mb_run_id_shared_across_instances():
     """All MicroBench instances in the same process share the same mb_run_id."""
     bench_a = MicroBench()
@@ -73,7 +98,7 @@ def test_mb_run_id_shared_across_instances():
 
 
 def test_function():
-    class MyBench(MicroBench, MBFunctionCall, MBPythonVersion, MBHostInfo):
+    class MyBench(MicroBench, MBFunctionCall, MBHostInfo):
         capture_versions = (pandas, io)
         env_vars = ('TEST_NON_EXISTENT', 'HOME')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
     "Programming Language :: Python",
 ]
 
+[project.scripts]
+microbench = "microbench.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/alubbock/microbench"
 


### PR DESCRIPTION
## Summary

- **`microbench` console entry point** — `microbench` is now available as a shell command after `pip install`; `python -m microbench` remains equivalent
- **`MBPythonInfo` mixin** — replaces `MBPythonVersion`; records a `python` dict with `version`, `prefix`, and `executable`; included in `MicroBench` by default and added to the CLI default mixin set; `MBPythonVersion` is deprecated
- **`MicroBenchBase`** — core machinery with no default mixins; `MicroBench` now inherits from `MBPythonInfo` + `MicroBenchBase`; users who want a bare class can subclass `MicroBenchBase`
- **`_get_mixin_map` fix** — checks `__dict__` for `cli_compatible` so subclasses that inherit the attribute (e.g. `MicroBench` itself) are not mistakenly included in the CLI mixin map
- **`MBCondaPackages` improvements**:
  - Uses `CONDA_PREFIX` env var instead of `sys.prefix` to identify the active conda environment
  - Falls back to `CONDA_EXE` when `conda` is not on `PATH` (common in non-interactive SLURM scripts)
  - Consolidates output into a single `conda` dict with `name`, `path`, and `packages` keys; `get_results(flat=True)` expands to `conda.name`, `conda.path`, `conda.packages.<pkg>`