### PR TITLE
feat!: restructure record fields into consistent namespaces (2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ All notable changes to microbench are documented here.
 
 ### Breaking changes (vs v1.1.0)
 
+- **Namespace restructuring of record fields**: All benchmark record fields are
+  now grouped into top-level namespace dicts, making records self-documenting
+  and easier to query. The complete rename table is below.
+
+  **Core fields** move into `mb` (static config) and `call` (per-call data):
+
+  | Old key | New key |
+  |---|---|
+  | `mb_run_id` | `mb.run_id` |
+  | `mb_version` | `mb.version` |
+  | `timestamp_tz` | `mb.timezone` |
+  | `duration_counter` | `mb.duration_counter` |
+  | `start_time` | `call.start_time` |
+  | `finish_time` | `call.finish_time` |
+  | `run_durations` | `call.durations` |
+  | `function_name` | `call.name` |
+  | `mb_timings` | `call.timings` |
+  | `mb_capture_errors` | `call.capture_errors` |
+  | `monitor` | `call.monitor` |
+  | `env_*` (flat keys) | `env.*` (dict) |
+  | `package_versions` (from `capture_versions`) | `python.loaded_packages` |
+
+  **Mixin fields** move to typed namespaces:
+
+  | Old key | New key |
+  |---|---|
+  | `hostname` | `host.hostname` |
+  | `operating_system` | `host.os` |
+  | `cpu_cores_logical` | `host.cpu_cores_logical` |
+  | `cpu_cores_physical` | `host.cpu_cores_physical` |
+  | `ram_total` | `host.ram_total` |
+  | `working_dir` | `call.working_dir` |
+  | `peak_memory_bytes` | `call.peak_memory_bytes` |
+  | `args` | `call.args` |
+  | `kwargs` | `call.kwargs` |
+  | `return_value` | `call.return_value` |
+  | `line_profiler` | `call.line_profiler` |
+  | `package_versions` (MBGlobalPackages) | `python.loaded_packages` |
+  | `package_versions` (MBInstalledPackages) | `python.installed_packages` |
+  | `package_paths` | `python.installed_package_paths` |
+  | `git_info` | `git` |
+  | `cgroup_limits` | `cgroups` (inner keys also renamed: `cpu_cores` → `cpu_cores_limit`, `memory_bytes` → `memory_bytes_limit`, `cgroup_version` → `version`) |
+  | `nvidia_<attr>` (multiple flat dicts) | `nvidia` (list of per-GPU dicts with `uuid` key) |
+
+  **CLI fields** also move into `call`:
+
+  | Old key | New key |
+  |---|---|
+  | `function_name` (basename) | `call.name` |
+  | `command` | `call.command` |
+  | `returncode` | `call.returncode` |
+  | `stdout` | `call.stdout` |
+  | `stderr` | `call.stderr` |
+  | `subprocess_monitor` | `call.monitor` |
+
+  A new `call.invocation` field is always present: `'Python'` for the Python
+  API and `'CLI'` for the command-line interface.
+
+  Unchanged namespaces: `slurm`, `loaded_modules`, `conda`, `file_hashes`,
+  `exception` (top-level), `exit_signal` (top-level).
+
+  **Migration:** Use `get_results(flat=True)` to access fields via dot-notation
+  keys (`call.name`, `mb.run_id`, `host.hostname`, etc.) in pandas or scripts
+  without rewriting nested dict access. Alternatively, update field access to
+  the new nested structure: `result['call']['name']`, `result['mb']['run_id']`,
+  `result['host']['hostname']`, etc.
+
 - **`get_results()` now returns a list of dicts by default**: The default
   `format='dict'` returns a list of plain Python dicts and requires no
   dependencies. Pass `format='df'` to get a pandas DataFrame (previous
@@ -49,12 +116,12 @@ All notable changes to microbench are documented here.
   keyword arguments.
   - `format='dict'` (default) — returns a list of dicts; no pandas required.
   - `format='df'` — returns a pandas DataFrame (previous default behaviour).
-  - `flat=True` — flattens nested dict fields (e.g. `slurm`, `cgroup_limits`,
-    `git_info`) into dot-notation keys (`slurm.job_id`). Works for both
+  - `flat=True` — flattens nested dict fields (e.g. `slurm`, `cgroups`,
+    `git`) into dot-notation keys (`slurm.job_id`, `call.name`). Works for both
     formats without requiring pandas.
 
 - **`summary(results)` / `bench.summary()`**: prints min / mean / median /
-  max / stdev of `run_durations` across all results. No dependencies required
+  max / stdev of `call.durations` across all results. No dependencies required
   beyond the Python standard library. `bench.summary()` is a one-liner
   convenience that calls `bench.get_results()` internally. The module-level
   `summary(results)` accepts any list of dicts and can be composed with other
@@ -81,9 +148,9 @@ All notable changes to microbench are documented here.
 
 - **`MBCgroupLimits`**: captures the CPU quota and memory limit enforced by
   the Linux cgroup filesystem. Works for SLURM jobs and Kubernetes pods (cgroup
-  v1 and v2). Fields in `cgroup_limits`: `cpu_cores` (float — quota ÷ period,
-  or `null` if unlimited), `memory_bytes` (int or `null` if unlimited),
-  `cgroup_version` (1 or 2). Returns `{}` on non-Linux systems or when the
+  v1 and v2). Fields in `cgroups`: `cpu_cores_limit` (float — quota ÷ period,
+  or `null` if unlimited), `memory_bytes_limit` (int or `null` if unlimited),
+  `version` (1 or 2). Returns `{}` on non-Linux systems or when the
   cgroup filesystem is unavailable.
 
   ```python
@@ -93,20 +160,20 @@ All notable changes to microbench are documented here.
 
   ```json
   {
-    "cgroup_limits": {
-      "cpu_cores": 4.0,
-      "memory_bytes": 17179869184,
-      "cgroup_version": 2
+    "cgroups": {
+      "cpu_cores_limit": 4.0,
+      "memory_bytes_limit": 17179869184,
+      "version": 2
     }
   }
   ```
 
 - **`bench.time(name)` sub-timing API**: label phases inside a single benchmark
-  record with named timing sections. Sub-timings accumulate in `mb_timings` as
+  record with named timing sections. Sub-timings accumulate in `call.timings` as
   `[{"name": ..., "duration": ...}, ...]` in call order. Compatible with
   `bench.record()`, `bench.arecord()`, `@bench` (sync and async), and
   `bench.record_on_exit()`. Calling outside an active benchmark is a silent
-  no-op; `mb_timings` is absent when `bench.time()` is never called.
+  no-op; `call.timings` is absent when `bench.time()` is never called.
 
   ```python
   with bench.record('pipeline'):
@@ -223,8 +290,8 @@ All notable changes to microbench are documented here.
 
 - **CLI subprocess monitoring** (`--monitor-interval SECONDS`): periodically
   sample the child process's CPU usage and resident memory (RSS) while it
-  runs and record the time series in `subprocess_monitor`. Requires
-  `psutil`. Each element of `subprocess_monitor` is a list of
+  runs and record the time series in `call.monitor`. Requires
+  `psutil`. Each element of `call.monitor` is a list of
   `{"timestamp", "cpu_percent", "rss_bytes"}` dicts for one timed
   iteration; warmup iterations are excluded. Works on Linux, macOS, and
   Windows. If the process exits before the first sample fires, the field is
@@ -233,7 +300,7 @@ All notable changes to microbench are documented here.
 - **`capture_optional` class attribute**: set `capture_optional = True` on
   a benchmark class to catch exceptions from `capture_` and `capturepost_`
   methods instead of aborting the benchmark call. Failures are recorded in
-  `mb_capture_errors` (a list of `{"method": ..., "error": ...}` dicts);
+  `call.capture_errors` (a list of `{"method": ..., "error": ...}` dicts);
   the field is absent when all captures succeed. Designed for production
   jobs on heterogeneous cluster nodes where optional dependencies may not
   be present on every node.
@@ -246,17 +313,17 @@ All notable changes to microbench are documented here.
   the CLI defaults alongside `MBHostInfo`, `MBSlurmInfo`, and `MBWorkingDir`.
 
 - **`MBWorkingDir` mixin**: captures the absolute path of the working
-  directory at benchmark time into `working_dir`. No dependencies. Included
-  in the CLI defaults — useful for reproducibility when comparing results
-  across nodes or directories.
+  directory at benchmark time into `call.working_dir`. No dependencies.
+  Included in the CLI defaults — useful for reproducibility when comparing
+  results across nodes or directories.
 
 - **`MBGitInfo` mixin**: captures the repository root path, current commit
   hash, branch name, and dirty flag (uncommitted changes present) via
-  `git` ≥ 2.11 on PATH. Stored in `git_info`. Set `git_repo` to inspect
+  `git` ≥ 2.11 on PATH. Stored in `git`. Set `git_repo` to inspect
   a specific repository directory.
 
 - **`MBPeakMemory` mixin**: captures peak Python memory allocation during the
-  benchmarked function as `peak_memory_bytes` (bytes), using
+  benchmarked function as `call.peak_memory_bytes` (bytes), using
   `tracemalloc` from the standard library. No extra dependencies required.
 
 - **`MBSlurmInfo` mixin**: captures all `SLURM_*` environment variables into

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ result, the metadata shows exactly what was running.
   multiple processes
 - **Sub-timings** — label named phases inside a single record with
   `bench.time(name)`; all phases share one metadata capture pass and results
-  accumulate in `mb_timings` in call order
+  accumulate in `call.timings` in call order
 
 ## Installation
 
@@ -65,12 +65,12 @@ results = bench.get_results(format='df')
 bench.summary()
 ```
 
-Each call produces one record. `results` from `get_results(format='df')` is
-a pandas DataFrame:
+Each call produces one record. With `get_results(flat=True)` the record looks
+like:
 
 ```
-   mb_run_id                             mb_version  function_name  run_durations  experiment
-0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  2.0.0      my_function    [0.049823]     baseline
+   mb.run_id                             mb.version  call.name   call.durations  experiment
+0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  2.0.0      my_function  [0.049823]     baseline
 ```
 
 ## Extended example
@@ -100,14 +100,14 @@ myfunction(x, y)
 Mixins used:
 - `MBFunctionCall` records the supplied arguments `x` and `y`.
 - `MBPythonVersion` captures the Python version.
-- `MBHostInfo` captures `hostname` and `operating_system`.
+- `MBHostInfo` captures `host.hostname` and `host.os`.
 - `MBSlurmInfo` captures all `SLURM_` environment variables
   (used by the [SLURM](https://slurm.schedmd.com/overview.html) cluster system).
 
 Class variables:
 - `outfile` saves results to a file (one JSON object per line).
 - `capture_versions` records the versions of specified packages.
-- `env_vars` captures environment variables as `env_<NAME>` fields.
+- `env_vars` captures environment variables as `env.<NAME>` fields.
 
 Constructor arguments:
 - `iterations=3` runs the function three times, recording all three durations.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,15 +37,15 @@ Use `--` to separate microbench options from the command being benchmarked.
 
 ## Fields recorded
 
-Every record contains the standard fields (`start_time`, `finish_time`,
-`run_durations`, etc.) plus:
+Every record contains the standard `mb.*` and `call.*` fields plus:
 
 | Field | Description |
 |---|---|
-| `command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
-| `returncode` | List of exit codes, one per timed iteration (warmup excluded). The process exits with the highest value. |
-| `function_name` | Basename of the executable, e.g. `"run_sim.sh"`. |
-| `subprocess_monitor` | *(present only with `--monitor-interval`)* List of per-iteration sample lists. See [Subprocess monitoring](#subprocess-monitoring). |
+| `call.invocation` | Always `'CLI'` for records produced by the CLI. |
+| `call.name` | Basename of the executable, e.g. `"run_sim.sh"`. |
+| `call.command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
+| `call.returncode` | List of exit codes, one per timed iteration (warmup excluded). The process exits with the highest value. |
+| `call.monitor` | *(present only with `--monitor-interval`)* List of per-iteration sample lists. See [Subprocess monitoring](#subprocess-monitoring). |
 
 ## Default mixins
 
@@ -129,7 +129,7 @@ command being benchmarked instead.
 
 Metadata capture failures (e.g. `nvidia-smi` not installed on this node,
 script not in a git repository) are caught automatically and recorded in
-`mb_capture_errors` rather than aborting the run. This makes the CLI safe
+`call.capture_errors` rather than aborting the run. This makes the CLI safe
 to use across heterogeneous cluster nodes.
 
 ## SLURM example
@@ -157,8 +157,14 @@ Read the results with pandas:
 ```python
 import pandas
 results = pandas.read_json('/scratch/user/results.jsonl', lines=True)
-results['total_duration'] = results['run_durations'].apply(sum)
-results.groupby('slurm.job_id')['total_duration'].describe()
+results = results.apply(lambda r: pandas.Series(r), axis=1)  # flatten if needed
+# Or use get_results(flat=True) when reading via microbench:
+from microbench import FileOutput
+flat = FileOutput('/scratch/user/results.jsonl').get_results(flat=True)
+import pandas
+df = pandas.DataFrame(flat)
+df['total_duration'] = df['call.durations'].apply(sum)
+df.groupby('slurm.job_id')['total_duration'].describe()
 ```
 
 ## Repeated runs
@@ -173,9 +179,9 @@ microbench --iterations 10 --warmup 2 -- ./run_simulation.sh
 
 With 10 iterations and 2 warmup runs, the record contains:
 
-- `run_durations` — list of 10 wall-clock durations in seconds
-- `returncode` — list of 10 exit codes (one per timed iteration)
-- `stdout` / `stderr` — list of 10 captured strings, if `--stdout`/`--stderr` is used
+- `call.durations` — list of 10 wall-clock durations in seconds
+- `call.returncode` — list of 10 exit codes (one per timed iteration)
+- `call.stdout` / `call.stderr` — list of 10 captured strings, if `--stdout`/`--stderr` is used
 
 Warmup runs are excluded from all three lists. The process exits with
 `max(returncode)` so any failing iteration propagates to the shell.
@@ -192,10 +198,10 @@ Warmup runs are excluded from all three lists. The process exits with
     microbench --stdout -- stdbuf -oL ./run_simulation.sh
     ```
 
-To detect failed iterations when analysing results with pandas:
+To detect failed iterations when analysing results with pandas (using `flat=True`):
 
 ```python
-results['any_failed'] = results['returncode'].apply(lambda rc: max(rc) != 0)
+df['any_failed'] = df['call.returncode'].apply(lambda rc: max(rc) != 0)
 ```
 
 ## Extra metadata
@@ -225,7 +231,7 @@ microbench \
     -- ./run_simulation.sh --steps 10000
 ```
 
-The record gains a `subprocess_monitor` field: a list of per-iteration
+The record gains a `call.monitor` field: a list of per-iteration
 sample lists (one inner list per `--iterations` call, warmup excluded).
 Each sample is a dict with three keys:
 
@@ -239,12 +245,14 @@ Example record (single iteration, two samples):
 
 ```json
 {
-  "subprocess_monitor": [
-    [
-      {"timestamp": "2025-01-01T12:00:05Z", "cpu_percent": 0.0,  "rss_bytes": 52428800},
-      {"timestamp": "2025-01-01T12:00:10Z", "cpu_percent": 87.3, "rss_bytes": 61865984}
+  "call": {
+    "monitor": [
+      [
+        {"timestamp": "2025-01-01T12:00:05Z", "cpu_percent": 0.0,  "rss_bytes": 52428800},
+        {"timestamp": "2025-01-01T12:00:10Z", "cpu_percent": 87.3, "rss_bytes": 61865984}
+      ]
     ]
-  ]
+  }
 }
 ```
 
@@ -253,20 +261,20 @@ subprocesses, their CPU and memory usage are not included.
 
 If the process exits before the first sample interval fires (e.g. a very
 short-lived command with a long `--monitor-interval`), the inner list will
-be empty and `subprocess_monitor` is omitted from the record.
+be empty and `call.monitor` is omitted from the record.
 
-Analyse with pandas:
+Analyse with `get_results()`:
 
 ```python
-import pandas, json
-
-results = pandas.read_json('results.jsonl', lines=True)
+from microbench import FileOutput
+results = FileOutput('results.jsonl').get_results()
 
 # Flatten all samples for the first iteration across all records
+import pandas
 samples = pandas.DataFrame([
     s
-    for row in results['subprocess_monitor']
-    for s in row[0]          # row[0] = first iteration
+    for r in results
+    for s in r['call']['monitor'][0]   # [0] = first iteration
 ])
 samples['rss_mb'] = samples['rss_bytes'] / 1024 / 1024
 print(samples[['timestamp', 'cpu_percent', 'rss_mb']])

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,18 +34,19 @@ bench.summary()
 # n=1  min=0.000042  mean=0.000042  median=0.000042  max=0.000042  stdev=nan
 ```
 
-Every record contains these fields automatically:
+Every record contains these fields automatically (all nested under `mb` or `call`):
 
 | Field | Description |
 |---|---|
-| `mb_run_id` | UUID generated once when `microbench` is imported. Identical across all bench suites in the same process — use `groupby('mb_run_id')` to correlate records from different benchmarks in the same run. |
-| `mb_version` | Version of the `microbench` package that produced the record. |
-| `start_time` | ISO-8601 timestamp when the function was called (UTC by default). |
-| `finish_time` | ISO-8601 timestamp when the function returned. |
-| `run_durations` | List of per-iteration durations in seconds. |
-| `function_name` | Name of the decorated function. |
-| `timestamp_tz` | Timezone used for `start_time`/`finish_time`. |
-| `duration_counter` | Name of the timer function used for `run_durations`. |
+| `mb.run_id` | UUID generated once when `microbench` is imported. Identical across all bench suites in the same process — use `groupby('mb.run_id')` to correlate records from different benchmarks in the same run. |
+| `mb.version` | Version of the `microbench` package that produced the record. |
+| `mb.timezone` | Timezone used for `call.start_time`/`call.finish_time`. |
+| `mb.duration_counter` | Name of the timer function used for `call.durations`. |
+| `call.invocation` | `'Python'` for the Python API, `'CLI'` for the command-line interface. |
+| `call.name` | Name of the decorated function (or the name passed to `bench.record()`). |
+| `call.start_time` | ISO-8601 timestamp when the function was called (UTC by default). |
+| `call.finish_time` | ISO-8601 timestamp when the function returned. |
+| `call.durations` | List of per-iteration durations in seconds. |
 
 ## Extended example
 
@@ -74,14 +75,14 @@ myfunction(x, y)
 Mixins used:
 - `MBFunctionCall` records the supplied arguments `x` and `y`.
 - `MBPythonVersion` captures the Python version.
-- `MBHostInfo` captures `hostname` and `operating_system`.
+- `MBHostInfo` captures `host.hostname` and `host.os`.
 - `MBSlurmInfo` captures all `SLURM_` environment variables (used by the
   [SLURM](https://slurm.schedmd.com/overview.html) cluster system).
 
 Class variables:
 - `outfile` saves results to a file (one JSON object per line).
 - `capture_versions` records the versions of specified packages.
-- `env_vars` captures environment variables as `env_<NAME>` fields — see [Environment variables](user-guide/configuration.md#environment-variables) for more.
+- `env_vars` captures environment variables as `env.<NAME>` fields — see [Environment variables](user-guide/configuration.md#environment-variables) for more.
 
 Constructor arguments:
 - `iterations=3` runs the function three times, recording all three durations.
@@ -142,26 +143,27 @@ summary(bench.get_results())
 Load into a pandas DataFrame for full aggregation and filtering:
 
 ```python
-results = bench.get_results(format='df')
+results = bench.get_results(format='df', flat=True)
 
-# run_durations is a list of per-iteration times; sum for total call time
-results['total_duration'] = results['run_durations'].apply(sum)
+# call.durations is a list of per-iteration times; sum for total call time
+results['total_duration'] = results['call.durations'].apply(sum)
 
 # Average call time by Python version
-results.groupby('python_version')['total_duration'].mean()
+results.groupby('python.version')['total_duration'].mean()
 
 # Correlate records from the same process run
-results.groupby('mb_run_id')['total_duration'].describe()
+results.groupby('mb.run_id')['total_duration'].describe()
 ```
 
-Use `flat=True` to flatten nested mixin fields (e.g. `slurm`, `git_info`,
-`cgroup_limits`) into dot-notation columns — useful when loading into pandas
-or a spreadsheet:
+Use `flat=True` to flatten nested fields (e.g. `slurm`, `git`,
+`cgroups`, `call`, `mb`) into dot-notation columns — useful when loading
+into pandas or a spreadsheet:
 
 ```python
 results = bench.get_results(flat=True)          # list of flat dicts
 results = bench.get_results(format='df', flat=True)  # flat DataFrame
-# 'slurm' dict becomes columns: slurm.job_id, slurm.cpus_on_node, ...
+# 'call' dict becomes: call.name, call.durations, call.start_time, ...
+# 'slurm' dict becomes: slurm.job_id, slurm.cpus_on_node, ...
 ```
 
 See the [pandas documentation](https://pandas.pydata.org/docs/) for more.
@@ -188,7 +190,7 @@ with bench.record('preprocessing'):
 ```
 
 Each `with` block produces one record. The `name` argument sets the
-`function_name` field. All mixins, static fields, and output sinks
+`call.name` field. All mixins, static fields, and output sinks
 behave identically to the decorator form.
 
 If the block raises an exception the record is still written, with an

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ mixins.
 - **Extensible via mixins** — mix in exactly what you need: Python version, hostname, CPU/RAM specs, conda/pip packages, NVIDIA GPU info, line-level profiling, and more
 - **Cluster and HPC ready** — capture SLURM environment variables, psutil resource metrics, and run IDs for correlating results across nodes
 - **JSONL output** — one JSON object per call; load directly into pandas with `read_json(..., lines=True)`; no schema lock-in
-- **Automatic run correlation** — `mb_run_id` is a UUID generated once per process; all bench suites in the same run share it, enabling `groupby('mb_run_id')` across independent suites
+- **Automatic run correlation** — `mb.run_id` is a UUID generated once per process; all bench suites in the same run share it, enabling `groupby('mb.run_id')` across independent suites
 - **Flexible output** — write to a local file, an in-memory buffer, or Redis; concurrent writers safe via `O_APPEND`
 
 ## Installation
@@ -56,25 +56,36 @@ my_function(1_000_000)
 results = bench.get_results()
 ```
 
-Each call produces one record. `results` is a pandas DataFrame:
+Each call produces one record. With `get_results(flat=True)` the record looks
+like:
 
 ```
-   mb_run_id                             mb_version  function_name  run_durations  experiment
-0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  1.1.0      my_function    [0.049823]     baseline
+   mb.run_id                             mb.version  call.name   call.durations  experiment
+0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  2.0.0      my_function  [0.049823]     baseline
 ```
 
 The underlying JSON for a single record looks like:
 
 ```json
 {
-  "mb_run_id": "3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9",
-  "mb_version": "1.1.0",
-  "start_time": "2024-01-15T10:30:00.123456+00:00",
-  "finish_time": "2024-01-15T10:30:00.172279+00:00",
-  "run_durations": [0.049823],
-  "function_name": "my_function",
-  "timestamp_tz": "UTC",
-  "duration_counter": "perf_counter",
+  "mb": {
+    "run_id": "3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9",
+    "version": "2.0.0",
+    "timezone": "UTC",
+    "duration_counter": "perf_counter"
+  },
+  "call": {
+    "invocation": "Python",
+    "name": "my_function",
+    "start_time": "2024-01-15T10:30:00.123456+00:00",
+    "finish_time": "2024-01-15T10:30:00.172279+00:00",
+    "durations": [0.049823]
+  },
+  "python": {
+    "version": "3.12.4",
+    "prefix": "/opt/conda/envs/myenv",
+    "executable": "/opt/conda/envs/myenv/bin/python"
+  },
   "experiment": "baseline"
 }
 ```

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -46,7 +46,7 @@ Mixin captures run inside the exit handler. Slow or unavailable captures
 (e.g. `MBCondaPackages` when conda is not installed) can delay exit, which
 matters when operating inside a SLURM grace period. Use
 `capture_optional = True` on the benchmark class so individual capture
-failures are recorded in `mb_capture_errors` rather than aborting the
+failures are recorded in `call.capture_errors` rather than aborting the
 handler:
 
 ```python
@@ -78,21 +78,23 @@ with bench.record('pipeline'):
         write(result)
 ```
 
-Sub-timings are appended to `mb_timings` in call order:
+Sub-timings are appended to `call.timings` in call order:
 
 ```json
 {
-  "function_name": "pipeline",
-  "run_durations": [0.183],
-  "mb_timings": [
-    {"name": "parse",     "duration": 0.041},
-    {"name": "transform", "duration": 0.120},
-    {"name": "write",     "duration": 0.022}
-  ]
+  "call": {
+    "name": "pipeline",
+    "durations": [0.183],
+    "timings": [
+      {"name": "parse",     "duration": 0.041},
+      {"name": "transform", "duration": 0.120},
+      {"name": "write",     "duration": 0.022}
+    ]
+  }
 }
 ```
 
-`mb_timings` is absent from the record when `bench.time()` is never called.
+`call.timings` is absent from the record when `bench.time()` is never called.
 
 ### Compatibility
 
@@ -112,7 +114,7 @@ records nothing and raises no error.
 ### Behaviour with `iterations`
 
 With `iterations=N`, each call to the decorated function runs `N` times. Every
-`bench.time()` inside the body fires once per iteration, so `mb_timings` will
+`bench.time()` inside the body fires once per iteration, so `call.timings` will
 contain `N` entries per named phase:
 
 ```python
@@ -124,14 +126,14 @@ def pipeline():
         ...
 
 pipeline()
-# mb_timings → [{"name": "step", ...}, {"name": "step", ...}, {"name": "step", ...}]
+# call.timings → [{"name": "step", ...}, {"name": "step", ...}, {"name": "step", ...}]
 ```
 
 ### Exceptions
 
 An exception raised inside `with bench.time('phase')` closes the segment and
 records its duration before the exception propagates. The record will contain
-the partial `mb_timings` for all segments that completed or started before the
+the partial `call.timings` for all segments that completed or started before the
 exception.
 
 ## Exception capture
@@ -143,8 +145,10 @@ the error type and message:
 
 ```json
 {
-  "function_name": "risky_step",
-  "run_durations": [0.042],
+  "call": {
+    "name": "risky_step",
+    "durations": [0.042]
+  },
   "exception": {"type": "SolverError", "message": "convergence failed"}
 }
 ```
@@ -182,13 +186,15 @@ When one or more captures fail, the record contains:
 
 ```json
 {
-  "mb_capture_errors": [
-    {"method": "capture_nvidia", "error": "FileNotFoundError: [Errno 2] No such file or directory: 'nvidia-smi'"}
-  ]
+  "call": {
+    "capture_errors": [
+      {"method": "capture_nvidia", "error": "FileNotFoundError: [Errno 2] No such file or directory: 'nvidia-smi'"}
+    ]
+  }
 }
 ```
 
-`mb_capture_errors` is absent from the record when all captures succeed,
+`call.capture_errors` is absent from the record when all captures succeed,
 keeping the happy-path output clean.
 
 !!! tip "When to use `capture_optional`"
@@ -246,8 +252,9 @@ from microbench.livestream import LiveStream
 
 class MyStream(LiveStream):
     def process_alert(self, data):
-        if sum(data['run_durations']) > 10.0:
-            print(f"Slow call on {data.get('hostname')}: {data['run_durations']}")
+        if sum(data.get('call', {}).get('durations', [])) > 10.0:
+            host = data.get('host', {}).get('hostname', 'unknown')
+            print(f"Slow call on {host}: {data['call']['durations']}")
 
 stream = MyStream('/home/user/results.jsonl')
 # ... runs in background while your job continues ...
@@ -266,10 +273,13 @@ import time
 class Watcher(LiveStream):
     def filter(self, data):
         # Only show records from GPU nodes
-        return 'gpu' in data.get('hostname', '')
+        return 'gpu' in data.get('host', {}).get('hostname', '')
 
     def display(self, data):
-        print(f"{data['function_name']} | {data['hostname']} | {data['run_durations']}")
+        name = data.get('call', {}).get('name', '?')
+        host = data.get('host', {}).get('hostname', '?')
+        durs = data.get('call', {}).get('durations', [])
+        print(f"{name} | {host} | {durs}")
 
 stream = Watcher('/home/user/results.jsonl')
 try:
@@ -303,8 +313,9 @@ import pandas
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 
 # Compare the environment of the slowest and fastest calls
-slowest = results.loc[results['run_durations'].apply(sum).idxmax()]
-fastest = results.loc[results['run_durations'].apply(sum).idxmin()]
+results_flat = pandas.DataFrame(FileOutput('/home/user/results.jsonl').get_results(flat=True))
+slowest = results_flat.loc[results_flat['call.durations'].apply(sum).idxmax()]
+fastest = results_flat.loc[results_flat['call.durations'].apply(sum).idxmin()]
 
 envdiff(slowest, fastest)
 ```

--- a/docs/user-guide/async.md
+++ b/docs/user-guide/async.md
@@ -20,7 +20,7 @@ async def fetch_data(url):
     return {'rows': 42}
 
 asyncio.run(fetch_data('https://example.com/api'))
-print(bench.get_results()[['function_name', 'start_time', 'run_durations']])
+print(bench.get_results(format='df')[['call.name', 'call.start_time', 'call.durations']])
 ```
 
 The wrapper is a true `async def`, so you can `await` it, pass it to
@@ -49,7 +49,7 @@ print(bench.get_results())
 ```
 
 This is the async counterpart of `bench.record()`. All mixins and output
-sinks work identically. The `function_name` field defaults to `'<record>'`
+sinks work identically. The `call.name` field defaults to `'<record>'`
 when no name is given.
 
 ## Timing caveat

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -9,7 +9,7 @@
 | `tz` | `timezone.utc` | Timezone for `start_time` / `finish_time`. |
 | `iterations` | `1` | Number of times to run the decorated function. |
 | `warmup` | `0` | Number of unrecorded calls before timing begins. Useful for priming caches or JIT compilation. |
-| `duration_counter` | `time.perf_counter` | Callable used for `run_durations`. |
+| `duration_counter` | `time.perf_counter` | Callable used for `call.durations`. |
 
 Any additional keyword arguments are stored as extra fields in every record:
 
@@ -20,7 +20,7 @@ bench = MicroBench(experiment='run-42', node='gpu-node-03')
 ## Environment variables
 
 Set `env_vars` as a class attribute to capture specific environment
-variables into every record. Each variable is stored as `env_<NAME>`; if
+variables into every record. Each variable is stored as `env.<NAME>`; if
 the variable is unset it is recorded as `null`:
 
 ```python
@@ -44,12 +44,12 @@ class SlurmBench(MicroBench):
     )
 ```
 
-Fields are stored as `env_SLURM_JOB_ID`, `env_SLURM_ARRAY_TASK_ID`, etc.
-Combined with `mb_run_id`, this lets you group and compare results across
+Fields are stored as `env.SLURM_JOB_ID`, `env.SLURM_ARRAY_TASK_ID`, etc.
+Combined with `mb.run_id`, this lets you group and compare results across
 all tasks in a job array:
 
 ```python
-results.groupby(['mb_run_id', 'env_SLURM_ARRAY_TASK_ID'])['run_durations'].mean()
+results.groupby(['mb.run_id', 'env.SLURM_ARRAY_TASK_ID'])['call.durations'].mean()
 ```
 
 Run `env | grep SLURM` inside a job to see which variables are available
@@ -57,7 +57,7 @@ in your cluster's environment.
 
 ## Duration timings
 
-`run_durations` are measured using `time.perf_counter` by default, which
+`call.durations` are measured using `time.perf_counter` by default, which
 gives wall-clock time in fractional seconds. Override with any callable that
 returns a numeric value:
 
@@ -72,10 +72,10 @@ bench = MicroBench(duration_counter=time.perf_counter_ns)
 bench = MicroBench(duration_counter=time.monotonic)
 ```
 
-The name of the counter function is recorded in the `duration_counter` field
+The name of the counter function is recorded in the `mb.duration_counter` field
 so results remain interpretable after the code changes.
 
-When `iterations > 1`, `run_durations` is a list with one entry per
+When `iterations > 1`, `call.durations` is a list with one entry per
 iteration. The function's return value is always taken from the final
 iteration.
 
@@ -93,7 +93,7 @@ bench = MicroBench(tz=datetime.datetime.now().astimezone().tzinfo)
 ```
 
 UTC is recommended when comparing results across machines in different
-locations. The timezone is also recorded in the `timestamp_tz` field.
+locations. The timezone is also recorded in the `mb.timezone` field.
 
 ## Runtime impact
 

--- a/docs/user-guide/extending.md
+++ b/docs/user-guide/extending.md
@@ -103,13 +103,13 @@ class MyBench(MicroBench):
         bm_data['machine'] = platform.machine()  # e.g. 'x86_64'
 
     def capturepost_slow_call(self, bm_data):
-        # run_durations and finish_time are available in capturepost_ methods
-        if sum(bm_data['run_durations']) > 1.0:
+        # call.durations and call.finish_time are available in capturepost_ methods
+        if sum(bm_data['call']['durations']) > 1.0:
             bm_data['slow_call'] = True
 ```
 
-Avoid key names that clash with built-in fields (e.g. `start_time`,
-`function_name`). The `mb_` prefix is reserved for microbench internals.
+Avoid key names that clash with built-in fields (e.g. `call.start_time`,
+`call.name`). The `mb` and `call` top-level keys are reserved for microbench internals.
 
 For more advanced extension patterns — custom JSON encoding, writing
 reusable mixins, and tools for consuming benchmark output — see

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -25,25 +25,25 @@ combine any number of microbench mixins without conflicts, and their
 
 | Mixin | Fields captured | Extra requirements |
 |---|---|---|
-| *(none)* | `mb_run_id`, `mb_version`, `start_time`, `finish_time`, `run_durations`, `function_name`, `timestamp_tz`, `duration_counter` | — |
-| `MBFunctionCall` | `args`, `kwargs` | — |
-| `MBReturnValue` | `return_value` | — |
-| `MBPythonInfo` | `python` dict: `version`, `prefix`, `executable` — **included in `MicroBench` by default** | — |
+| *(none)* | `mb.run_id`, `mb.version`, `mb.timezone`, `mb.duration_counter`, `call.invocation`, `call.name`, `call.start_time`, `call.finish_time`, `call.durations` | — |
+| `MBFunctionCall` | `call.args`, `call.kwargs` | — |
+| `MBReturnValue` | `call.return_value` | — |
+| `MBPythonInfo` | `python.version`, `python.prefix`, `python.executable` — **included in `MicroBench` by default** | — |
 | `MBPythonVersion` | `python_version`, `python_executable` — *deprecated, use `MBPythonInfo`* | — |
-| `MBHostInfo` | `hostname`, `operating_system` | — |
-| `MBHostCpuCores` | `cpu_cores_logical`, `cpu_cores_physical` | psutil |
-| `MBHostRamTotal` | `ram_total` (bytes) | psutil |
-| `MBPeakMemory` | `peak_memory_bytes` | — |
+| `MBHostInfo` | `host.hostname`, `host.os` | — |
+| `MBHostCpuCores` | `host.cpu_cores_logical`, `host.cpu_cores_physical` | psutil |
+| `MBHostRamTotal` | `host.ram_total` (bytes) | psutil |
+| `MBPeakMemory` | `call.peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
 | `MBLoadedModules` | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
-| `MBWorkingDir` | `working_dir` — absolute path of the working directory at benchmark time | — |
-| `MBCgroupLimits` | `cgroup_limits` dict with `cpu_cores`, `memory_bytes`, `cgroup_version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
-| `MBGitInfo` | `git_info` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
-| `MBGlobalPackages` | `package_versions` for every package in the caller's global scope | — |
-| `MBInstalledPackages` | `package_versions` for every installed package | — |
+| `MBWorkingDir` | `call.working_dir` — absolute path of the working directory at benchmark time | — |
+| `MBCgroupLimits` | `cgroups` dict with `cpu_cores_limit`, `memory_bytes_limit`, `version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
+| `MBGitInfo` | `git` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
+| `MBGlobalPackages` | `python.loaded_packages` for every package in the caller's global scope | — |
+| `MBInstalledPackages` | `python.installed_packages` (and optionally `python.installed_package_paths`) for every installed package | — |
 | `MBCondaPackages` | `conda` dict with `name`, `path`, and `packages` (version dict) | `conda` on PATH or `CONDA_EXE` set |
-| `MBNvidiaSmi` | `nvidia_<attr>` per GPU (see below) | `nvidia-smi` on PATH |
-| `MBLineProfiler` | `line_profiler` (base64-encoded profile, see below) | line_profiler |
+| `MBNvidiaSmi` | `nvidia` — list of per-GPU dicts (see below) | `nvidia-smi` on PATH |
+| `MBLineProfiler` | `call.line_profiler` (base64-encoded profile, see below) | line_profiler |
 | `MBFileHash` | `file_hashes` — SHA-256 checksum of each specified file | — |
 
 ## Function calls and return values
@@ -66,7 +66,7 @@ def add(a, b):
     return a + b
 
 add(1, b=2)
-# record contains: {"args": [1], "kwargs": {"b": 2}, ...}
+# record contains: {"call": {"args": [1], "kwargs": {"b": 2}}, ...}
 ```
 
 ### `MBReturnValue`
@@ -86,7 +86,7 @@ def compute(n):
     return sum(range(n))
 
 compute(100)
-# record contains: {"return_value": 4950, ...}
+# record contains: {"call": {"return_value": 4950}, ...}
 ```
 
 The return value must be JSON-serialisable. If it is not, a
@@ -108,14 +108,14 @@ class Bench(MicroBench, MBHostCpuCores, MBHostRamTotal):
     pass
 ```
 
-Fields: `cpu_cores_logical`, `cpu_cores_physical`, `ram_total` (bytes).
+Fields: `host.cpu_cores_logical`, `host.cpu_cores_physical`, `host.ram_total` (bytes).
 
 ## Job resource utilisation
 
 ### `MBPeakMemory`
 
 Captures the peak Python memory allocation during the benchmarked function
-(across all iterations when `iterations > 1`) as `peak_memory_bytes` (bytes).
+(across all iterations when `iterations > 1`) as `call.peak_memory_bytes` (bytes).
 Uses [`tracemalloc`](https://docs.python.org/3/library/tracemalloc.html) from
 the standard library — no extra dependencies required.
 
@@ -132,7 +132,7 @@ def process(data):
     return sorted(data)
 
 process(list(range(1_000_000, 0, -1)))
-# record contains: {"peak_memory_bytes": 8056968, ...}
+# record contains: {"call": {"peak_memory_bytes": 8056968}, ...}
 ```
 
 !!! note
@@ -228,7 +228,7 @@ required and there are no extra dependencies.
 
 ### `MBWorkingDir`
 
-Captures the absolute path of the working directory at benchmark time into `working_dir`:
+Captures the absolute path of the working directory at benchmark time into `call.working_dir`:
 
 ```python
 from microbench import MicroBench, MBWorkingDir
@@ -243,7 +243,9 @@ Each record will contain:
 
 ```json
 {
-  "working_dir": "/home/user/experiments/run-42"
+  "call": {
+    "working_dir": "/home/user/experiments/run-42"
+  }
 }
 ```
 
@@ -273,24 +275,24 @@ Each record will contain:
 
 ```json
 {
-  "cgroup_limits": {
-    "cpu_cores": 4.0,
-    "memory_bytes": 17179869184,
-    "cgroup_version": 2
+  "cgroups": {
+    "cpu_cores_limit": 4.0,
+    "memory_bytes_limit": 17179869184,
+    "version": 2
   }
 }
 ```
 
-**`cpu_cores`** is derived from the cgroup CPU quota and period
+**`cpu_cores_limit`** is derived from the cgroup CPU quota and period
 (`quota_us / period_us`), so it represents effective CPU parallelism rather than
 a physical core count. A SLURM job launched with `--cpus-per-task=4` will
-typically report `cpu_cores: 4.0`.
+typically report `cpu_cores_limit: 4.0`.
 
-**`memory_bytes`** is the hard memory limit in bytes. A job allocated `--mem=16G`
-will typically report `memory_bytes: 17179869184`.
+**`memory_bytes_limit`** is the hard memory limit in bytes. A job allocated `--mem=16G`
+will typically report `memory_bytes_limit: 17179869184`.
 
 Both fields are `null` when no limit is set (the scheduler granted unlimited
-access to that resource). `cgroup_limits` is an empty dict on non-Linux
+access to that resource). `cgroups` is an empty dict on non-Linux
 platforms or when the cgroup filesystem is unavailable.
 
 !!! tip
@@ -317,7 +319,7 @@ Each record will contain:
 
 ```json
 {
-  "git_info": {
+  "git": {
     "repo": "/home/user/project",
     "commit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
     "branch": "main",
@@ -433,15 +435,16 @@ class Bench(MicroBench, MBGlobalPackages):
     pass
 ```
 
-The `package_versions` field will contain `{"numpy": "1.26.0", "pandas": "2.1.0", ...}`.
+The `python.loaded_packages` field will contain `{"numpy": "1.26.0", "pandas": "2.1.0", ...}`.
 
 ### `MBInstalledPackages`
 
 Captures every package available for import (from `importlib.metadata`).
-Useful for full reproducibility audits. Can be slow on environments with
-many packages.
+Results are stored in `python.installed_packages`. Useful for full
+reproducibility audits. Can be slow on environments with many packages.
 
-Set `capture_paths = True` to also record installation paths:
+Set `capture_paths = True` to also record installation paths in
+`python.installed_package_paths`:
 
 ```python
 class Bench(MicroBench, MBInstalledPackages):
@@ -472,7 +475,7 @@ class Bench(MicroBench, MBCondaPackages):
 ### `capture_versions`
 
 To capture specific package versions without a mixin, list them on the
-class:
+class. Results are stored in `python.loaded_packages`:
 
 ```python
 import numpy, pandas
@@ -496,8 +499,16 @@ class GpuBench(MicroBench, MBNvidiaSmi):
     nvidia_gpus = ('GPU-abc123',)  # UUIDs preferred; omit to capture all
 ```
 
-Results are stored as `nvidia_<attr>` dicts keyed by GPU UUID, e.g.
-`nvidia_gpu_name: {"GPU-abc123": "NVIDIA A100"}`.
+Results are stored in `nvidia` as a list of per-GPU dicts, each containing a
+`uuid` key plus one key per attribute, e.g.:
+
+```json
+{
+  "nvidia": [
+    {"uuid": "GPU-abc123", "gpu_name": "NVIDIA A100", "memory.total": "40960 MiB"}
+  ]
+}
+```
 
 Run `nvidia-smi --help-query-gpu` for the full list of available attributes.
 Run `nvidia-smi -L` to list GPU UUIDs.
@@ -525,10 +536,10 @@ def my_function():
 my_function()
 
 results = bench.get_results()
-MBLineProfiler.print_line_profile(results['line_profiler'][0])
+MBLineProfiler.print_line_profile(results[0]['call']['line_profiler'])
 ```
 
-The profile is stored as a base64-encoded pickle in the `line_profiler` field.
+The profile is stored as a base64-encoded pickle in the `call.line_profiler` field.
 Use `MBLineProfiler.decode_line_profile()` to deserialise it, or
 `MBLineProfiler.print_line_profile()` to print it directly.
 

--- a/docs/user-guide/output.md
+++ b/docs/user-guide/output.md
@@ -32,17 +32,17 @@ import pandas
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 ```
 
-Pass `flat=True` to flatten nested mixin fields (e.g. `slurm`, `git_info`,
-`cgroup_limits`) into dot-notation keys:
+Pass `flat=True` to flatten nested fields (e.g. `mb`, `call`, `slurm`, `git`,
+`cgroups`) into dot-notation keys:
 
 ```python
 results = bench.get_results(flat=True)
-# {'function_name': 'noop', 'slurm.job_id': '12345', 'slurm.cpus_on_node': '8', ...}
+# {'call.name': 'noop', 'mb.run_id': '...', 'slurm.job_id': '12345', ...}
 ```
 
 ## Quick summary
 
-Print min/mean/median/max/stdev of `run_durations` with no extra dependencies:
+Print min/mean/median/max/stdev of `call.durations` with no extra dependencies:
 
 ```python
 bench.summary()

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -103,7 +103,7 @@ __all__ = [
 
 
 def summary(results):
-    """Print summary statistics for ``run_durations`` across a list of results.
+    """Print summary statistics for ``call.durations`` across a list of results.
 
     Requires no dependencies beyond the Python standard library.
 
@@ -125,7 +125,7 @@ def summary(results):
     """
     durations = []
     for r in results:
-        durations.extend(r.get('run_durations', []))
+        durations.extend(r.get('call', {}).get('durations', []))
 
     n = len(durations)
     if n == 0:
@@ -165,15 +165,15 @@ class MicroBenchBase:
                 :class:`io.StringIO` buffer when no *outputs* are given).
             json_encoder (json.JSONEncoder, optional): JSONEncoder for
                 benchmark results. Defaults to JSONEncoder.
-            tz (timezone, optional): Timezone for start_time and finish_time.
-                Defaults to timezone.utc.
+            tz (timezone, optional): Timezone for call.start_time and
+                call.finish_time. Defaults to timezone.utc.
             iterations (int, optional): Number of iterations to run function.
                 Defaults to 1.
             warmup (int, optional): Number of unrecorded calls to make before
                 timing begins. Useful for priming caches or JIT compilation.
                 Defaults to 0.
             duration_counter (callable, optional): Timer function to use for
-                run_durations. Defaults to time.perf_counter.
+                call.durations. Defaults to time.perf_counter.
             outputs (list of Output, optional): One or more :class:`Output`
                 sinks that receive each benchmark result. Mutually exclusive
                 with *outfile*. Defaults to a single :class:`FileOutput`
@@ -210,13 +210,15 @@ class MicroBenchBase:
             self._outputs = [FileOutput()]
 
     def pre_start_triggers(self, bm_data):
-        # Store timezone
-        bm_data['timestamp_tz'] = str(self.tz)
-        # Store duration counter function name
-        bm_data['duration_counter'] = self._duration_counter.__name__
-        # Run ID and package version (added to every record automatically)
-        bm_data['mb_run_id'] = _run_id
-        bm_data['mb_version'] = __version__
+        # Store static config in mb namespace
+        mb = bm_data.setdefault('mb', {})
+        mb['timezone'] = str(self.tz)
+        mb['duration_counter'] = self._duration_counter.__name__
+        mb['run_id'] = _run_id
+        mb['version'] = __version__
+
+        # Mark as a Python API invocation (CLI overrides this to 'CLI')
+        bm_data.setdefault('call', {})['invocation'] = 'Python'
 
         # Capture environment variables
         if hasattr(self, 'env_vars'):
@@ -226,7 +228,7 @@ class MicroBenchBase:
                 )
 
             for env_var in self.env_vars:
-                bm_data[f'env_{env_var}'] = os.environ.get(env_var)
+                bm_data.setdefault('env', {})[env_var] = os.environ.get(env_var)
 
         # Capture package versions
         if hasattr(self, 'capture_versions'):
@@ -248,7 +250,9 @@ class MicroBenchBase:
                         try:
                             method(bm_data)
                         except Exception as e:
-                            bm_data.setdefault('mb_capture_errors', []).append(
+                            bm_data.setdefault('call', {}).setdefault(
+                                'capture_errors', []
+                            ).append(
                                 {
                                     'method': method_name,
                                     'error': f'{type(e).__name__}: {e}',
@@ -260,17 +264,17 @@ class MicroBenchBase:
         # Initialise monitor thread
         if hasattr(self, 'monitor'):
             interval = getattr(self, 'monitor_interval', 60)
-            bm_data['monitor'] = []
+            bm_data.setdefault('call', {})['monitor'] = []
             self._monitor_thread = _MonitorThread(
-                self.monitor, interval, bm_data['monitor'], self.tz
+                self.monitor, interval, bm_data['call']['monitor'], self.tz
             )
             self._monitor_thread.start()
 
-        bm_data['run_durations'] = []
-        bm_data['start_time'] = datetime.now(self.tz)
+        bm_data.setdefault('call', {})['durations'] = []
+        bm_data.setdefault('call', {})['start_time'] = datetime.now(self.tz)
 
     def post_finish_triggers(self, bm_data):
-        bm_data['finish_time'] = datetime.now(self.tz)
+        bm_data.setdefault('call', {})['finish_time'] = datetime.now(self.tz)
 
         # Terminate monitor thread and gather results
         if hasattr(self, '_monitor_thread'):
@@ -287,7 +291,9 @@ class MicroBenchBase:
                         try:
                             method(bm_data)
                         except Exception as e:
-                            bm_data.setdefault('mb_capture_errors', []).append(
+                            bm_data.setdefault('call', {}).setdefault(
+                                'capture_errors', []
+                            ).append(
                                 {
                                     'method': method_name,
                                     'error': f'{type(e).__name__}: {e}',
@@ -300,23 +306,24 @@ class MicroBenchBase:
         bm_data['_run_start'] = self._duration_counter()
 
     def post_run_triggers(self, bm_data):
-        bm_data['run_durations'].append(
+        bm_data['call']['durations'].append(
             self._duration_counter() - bm_data['_run_start']
         )
 
     def capture_function_name(self, bm_data):
         if '_func' in bm_data:
-            bm_data['function_name'] = bm_data['_func'].__name__
+            bm_data.setdefault('call', {})['name'] = bm_data['_func'].__name__
 
     def _capture_package_version(self, bm_data, pkg, skip_if_none=False):
-        bm_data.setdefault('package_versions', {})
         try:
             ver = pkg.__version__
         except AttributeError:
             if skip_if_none:
                 return
             ver = None
-        bm_data['package_versions'][pkg.__name__] = ver
+        bm_data.setdefault('python', {}).setdefault('loaded_packages', {})[
+            pkg.__name__
+        ] = ver
 
     def to_json(self, bm_data):
         bm_str = f'{json.dumps(bm_data, cls=self._json_encoder)}'
@@ -336,8 +343,8 @@ class MicroBenchBase:
             format (str): ``'dict'`` (default) returns a list of dicts;
                 ``'df'`` returns a pandas DataFrame (requires pandas).
             flat (bool): If *True*, flatten nested dict fields into
-                dot-notation keys (e.g. ``slurm.job_id``). Works for
-                both formats and does not require pandas.
+                dot-notation keys (e.g. ``call.name``, ``host.hostname``).
+                Works for both formats and does not require pandas.
 
         Returns:
             list[dict] or pandas.DataFrame
@@ -358,7 +365,7 @@ class MicroBenchBase:
         )
 
     def summary(self):
-        """Print summary statistics for ``run_durations`` across all results.
+        """Print summary statistics for ``call.durations`` across all results.
 
         Requires no dependencies beyond the Python standard library.
         Reads results via :meth:`get_results`.
@@ -410,7 +417,7 @@ class MicroBenchBase:
                     elif isinstance(self, MBReturnValue):
                         try:
                             self.to_json(res)
-                            bm_data['return_value'] = res
+                            bm_data.setdefault('call', {})['return_value'] = res
                         except TypeError:
                             warnings.warn(
                                 f'Return value is not JSON encodable '
@@ -418,7 +425,9 @@ class MicroBenchBase:
                                 'Extend JSONEncoder class to fix (see README).',
                                 JSONEncodeWarning,
                             )
-                            bm_data['return_value'] = _UNENCODABLE_PLACEHOLDER_VALUE
+                            bm_data.setdefault('call', {})['return_value'] = (
+                                _UNENCODABLE_PLACEHOLDER_VALUE
+                            )
 
                     # Delete any underscore-prefixed keys
                     bm_data = {
@@ -482,14 +491,16 @@ class MicroBenchBase:
                 elif isinstance(self, MBReturnValue):
                     try:
                         self.to_json(res)
-                        bm_data['return_value'] = res
+                        bm_data.setdefault('call', {})['return_value'] = res
                     except TypeError:
                         warnings.warn(
                             f'Return value is not JSON encodable (type: {type(res)}). '
                             'Extend JSONEncoder class to fix (see README).',
                             JSONEncodeWarning,
                         )
-                        bm_data['return_value'] = _UNENCODABLE_PLACEHOLDER_VALUE
+                        bm_data.setdefault('call', {})['return_value'] = (
+                            _UNENCODABLE_PLACEHOLDER_VALUE
+                        )
 
                 # Delete any underscore-prefixed keys
                 bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
@@ -509,7 +520,7 @@ class MicroBenchBase:
         """Return a context manager that times a block and writes one record.
 
         Args:
-            name (str, optional): Value for the ``function_name`` field.
+            name (str, optional): Value for the ``call.name`` field.
                 Defaults to ``'<record>'``.
 
         Example::
@@ -525,7 +536,7 @@ class MicroBenchBase:
         Use with ``async with`` inside an async function or coroutine.
 
         Args:
-            name (str, optional): Value for the ``function_name`` field.
+            name (str, optional): Value for the ``call.name`` field.
                 Defaults to ``'<record>'``.
 
         .. note::
@@ -543,7 +554,7 @@ class MicroBenchBase:
     def time(self, name: str) -> '_TimingSection':
         """Return a context manager recording a named sub-timing within a benchmark.
 
-        Sub-timings are stored in ``mb_timings`` as a list of
+        Sub-timings are stored in ``call.timings`` as a list of
         ``{"name": ..., "duration": ...}`` dicts in call order.
         Compatible with ``bench.record()``, ``bench.arecord()``,
         ``@bench`` (sync and async), and ``bench.record_on_exit()``.
@@ -566,7 +577,7 @@ class MicroBenchBase:
         previous registration and resets the start time.
 
         Args:
-            name (str, optional): Value for the ``function_name`` field.
+            name (str, optional): Value for the ``call.name`` field.
                 Defaults to ``'<process>'``.
             handle_sigterm (bool): Install a SIGTERM handler that writes the
                 record before re-delivering the signal. Only effective when
@@ -653,18 +664,18 @@ class MicroBenchBase:
 
             bm_data = dict()
             bm_data.update(self._bm_static)
-            bm_data['function_name'] = name or '<process>'
+            bm_data.setdefault('call', {})['name'] = name or '<process>'
             bm_data['_args'] = ()
             bm_data['_kwargs'] = {}
 
             self.pre_start_triggers(bm_data)
-            # pre_start_triggers sets start_time and run_durations=[]; override
+            # pre_start_triggers sets call.start_time and call.durations=[]; override
             # both with the values recorded at the call site.
-            bm_data['start_time'] = _start_time
-            bm_data['run_durations'] = [self._duration_counter() - _start_counter]
+            bm_data['call']['start_time'] = _start_time
+            bm_data['call']['durations'] = [self._duration_counter() - _start_counter]
             # Replace exit-time-only monitor samples with our full-run ones.
             if _monitor_slot is not None:
-                bm_data['monitor'] = _monitor_slot
+                bm_data['call']['monitor'] = _monitor_slot
 
             self.post_finish_triggers(bm_data)
 
@@ -679,7 +690,9 @@ class MicroBenchBase:
                 bm_data['exit_signal'] = exit_signal
 
             if self._record_on_exit_timings:
-                bm_data['mb_timings'] = list(self._record_on_exit_timings)
+                bm_data.setdefault('call', {})['timings'] = list(
+                    self._record_on_exit_timings
+                )
 
             bm_data = {k: v for k, v in bm_data.items() if not k.startswith('_')}
 
@@ -743,10 +756,10 @@ class _ContextManagerRun:
             )
         bm_data = dict()
         bm_data.update(self._bench._bm_static)
-        bm_data['function_name'] = self._name or '<record>'
+        bm_data.setdefault('call', {})['name'] = self._name or '<record>'
         # Sentinels so MBFunctionCall produces args=[], kwargs={} rather than
         # a KeyError; _func is intentionally absent so capture_function_name
-        # leaves function_name as set above.
+        # leaves call.name as set above.
         bm_data['_args'] = ()
         bm_data['_kwargs'] = {}
         self._bm_data = bm_data
@@ -786,7 +799,7 @@ class _AsyncContextManagerRun:
             )
         bm_data = dict()
         bm_data.update(self._bench._bm_static)
-        bm_data['function_name'] = self._name or '<record>'
+        bm_data.setdefault('call', {})['name'] = self._name or '<record>'
         bm_data['_args'] = ()
         bm_data['_kwargs'] = {}
         self._bm_data = bm_data
@@ -832,7 +845,7 @@ class _TimingSection:
         duration = self._bench._duration_counter() - self._start
         entry = {'name': self._name, 'duration': duration}
         if self._bm_data is not None:
-            self._bm_data.setdefault('mb_timings', []).append(entry)
+            self._bm_data.setdefault('call', {}).setdefault('timings', []).append(entry)
         elif hasattr(self._bench, '_record_on_exit_timings'):
             self._bench._record_on_exit_timings.append(entry)
         return False  # never suppress exceptions

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -151,7 +151,7 @@ def _build_parser(mixin_map):
             'By default captures host-info, slurm-info, and loaded-modules. '
             'Specifying --mixin replaces the defaults; use --show-mixins to '
             'list all available mixins. '
-            'Metadata capture failures are recorded in mb_capture_errors '
+            'Metadata capture failures are recorded in call.capture_errors '
             'rather than aborting the run.'
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -346,14 +346,16 @@ def main(argv=None):
             self._subprocess_timed_phase = True
 
         def capturepost_subprocess_result(self, bm_data):
-            bm_data['command'] = self._subprocess_command
-            bm_data['returncode'] = self._subprocess_returncodes
+            call = bm_data.setdefault('call', {})
+            call['invocation'] = 'CLI'
+            call['command'] = self._subprocess_command
+            call['returncode'] = self._subprocess_returncodes
             if self._subprocess_stdout:
-                bm_data['stdout'] = self._subprocess_stdout
+                call['stdout'] = self._subprocess_stdout
             if self._subprocess_stderr:
-                bm_data['stderr'] = self._subprocess_stderr
+                call['stderr'] = self._subprocess_stderr
             if any(self._subprocess_monitor):
-                bm_data['subprocess_monitor'] = self._subprocess_monitor
+                call['monitor'] = self._subprocess_monitor
 
     BenchClass = type(
         'CLIBench',

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -115,26 +115,27 @@ class MBFunctionCall:
     """Capture function arguments and keyword arguments"""
 
     def capture_function_args_and_kwargs(self, bm_data):
+        call = bm_data.setdefault('call', {})
         # Check all args are encodeable as JSON, then store the raw value
-        bm_data['args'] = []
+        call['args'] = []
         for i, v in enumerate(bm_data['_args']):
             try:
                 self.to_json(v)
-                bm_data['args'].append(v)
+                call['args'].append(v)
             except TypeError:
                 warnings.warn(
                     f'Function argument {i} is not JSON encodable (type: {type(v)}). '
                     'Extend JSONEncoder class to fix (see README).',
                     JSONEncodeWarning,
                 )
-                bm_data['args'].append(_UNENCODABLE_PLACEHOLDER_VALUE)
+                call['args'].append(_UNENCODABLE_PLACEHOLDER_VALUE)
 
         # Check all kwargs are encodeable as JSON, then store the raw value
-        bm_data['kwargs'] = {}
+        call['kwargs'] = {}
         for k, v in bm_data['_kwargs'].items():
             try:
                 self.to_json(v)
-                bm_data['kwargs'][k] = v
+                call['kwargs'][k] = v
             except TypeError:
                 warnings.warn(
                     f'Function keyword argument "{k}" is not JSON encodable'
@@ -142,7 +143,7 @@ class MBFunctionCall:
                     ' (see README).',
                     JSONEncodeWarning,
                 )
-                bm_data['kwargs'][k] = _UNENCODABLE_PLACEHOLDER_VALUE
+                call['kwargs'][k] = _UNENCODABLE_PLACEHOLDER_VALUE
 
 
 class MBReturnValue:
@@ -184,23 +185,25 @@ class MBPythonInfo:
     cli_compatible = True
 
     def capture_python_info(self, bm_data):
-        bm_data['python'] = {
-            'version': platform.python_version(),
-            'prefix': sys.prefix,
-            'executable': sys.executable,
-        }
+        python = bm_data.setdefault('python', {})
+        python['version'] = platform.python_version()
+        python['prefix'] = sys.prefix
+        python['executable'] = sys.executable
 
 
 class MBHostInfo:
-    """Capture the hostname and operating system."""
+    """Capture the hostname and operating system.
+
+    Results are stored in the ``host`` dict with keys ``hostname`` and ``os``.
+    """
 
     cli_compatible = True
 
     def capture_hostname(self, bm_data):
-        bm_data['hostname'] = socket.gethostname()
+        bm_data.setdefault('host', {})['hostname'] = socket.gethostname()
 
     def capture_os(self, bm_data):
-        bm_data['operating_system'] = sys.platform
+        bm_data.setdefault('host', {})['os'] = sys.platform
 
 
 _microbench_dir = os.path.dirname(os.path.abspath(__file__))
@@ -280,12 +283,16 @@ class MBLoadedModules:
 
 
 class MBWorkingDir:
-    """Capture the working directory at benchmark time."""
+    """Capture the working directory at benchmark time.
+
+    Records the current working directory as ``call.working_dir``. This is
+    per-call data since the working directory can change between calls.
+    """
 
     cli_compatible = True
 
     def capture_working_dir(self, bm_data):
-        bm_data['working_dir'] = os.getcwd()
+        bm_data.setdefault('call', {})['working_dir'] = os.getcwd()
 
 
 def _read_cgroup_v2():
@@ -318,7 +325,11 @@ def _read_cgroup_v2():
         if content != 'max':
             memory_bytes = int(content)
 
-    return {'cpu_cores': cpu_cores, 'memory_bytes': memory_bytes, 'cgroup_version': 2}
+    return {
+        'cpu_cores_limit': cpu_cores,
+        'memory_bytes_limit': memory_bytes,
+        'version': 2,
+    }
 
 
 def _read_cgroup_v1():
@@ -359,37 +370,41 @@ def _read_cgroup_v1():
             if limit < 2**62:
                 memory_bytes = limit
 
-    return {'cpu_cores': cpu_cores, 'memory_bytes': memory_bytes, 'cgroup_version': 1}
+    return {
+        'cpu_cores_limit': cpu_cores,
+        'memory_bytes_limit': memory_bytes,
+        'version': 1,
+    }
 
 
 class MBCgroupLimits:
     """Capture CPU quota and memory limit from Linux cgroups.
 
     Works for SLURM jobs and Kubernetes pods (cgroup v1 and v2). Results
-    are stored in the ``cgroup_limits`` field as a dict containing:
+    are stored in the ``cgroups`` field as a dict containing:
 
-    - ``cpu_cores``: effective CPU parallelism as a float (quota ÷ period),
-      or ``None`` if unlimited or unavailable.
-    - ``memory_bytes``: memory limit in bytes as an int, or ``None`` if
-      unlimited or unavailable.
-    - ``cgroup_version``: ``1`` or ``2``.
+    - ``cpu_cores_limit``: effective CPU parallelism as a float (quota ÷
+      period), or ``None`` if unlimited or unavailable.
+    - ``memory_bytes_limit``: memory limit in bytes as an int, or ``None``
+      if unlimited or unavailable.
+    - ``version``: ``1`` or ``2``.
 
     On non-Linux systems or when the cgroup filesystem is unavailable,
-    ``cgroup_limits`` is an empty dict.
+    ``cgroups`` is an empty dict.
 
     Note:
-        ``cpu_cores`` is derived from the cgroup CPU quota and period, so it
-        represents effective CPU parallelism, not a physical core count. A
-        SLURM job launched with ``--cpus-per-task=4`` will typically report
-        ``cpu_cores: 4.0``.
+        ``cpu_cores_limit`` is derived from the cgroup CPU quota and period,
+        so it represents effective CPU parallelism, not a physical core count.
+        A SLURM job launched with ``--cpus-per-task=4`` will typically report
+        ``cpu_cores_limit: 4.0``.
 
     Example output::
 
         {
-            "cgroup_limits": {
-                "cpu_cores": 4.0,
-                "memory_bytes": 17179869184,
-                "cgroup_version": 2
+            "cgroups": {
+                "cpu_cores_limit": 4.0,
+                "memory_bytes_limit": 17179869184,
+                "version": 2
             }
         }
     """
@@ -398,15 +413,15 @@ class MBCgroupLimits:
 
     def capture_cgroup_limits(self, bm_data):
         if sys.platform != 'linux':
-            bm_data['cgroup_limits'] = {}
+            bm_data['cgroups'] = {}
             return
         try:
             if os.path.exists('/sys/fs/cgroup/cgroup.controllers'):
-                bm_data['cgroup_limits'] = _read_cgroup_v2()
+                bm_data['cgroups'] = _read_cgroup_v2()
             else:
-                bm_data['cgroup_limits'] = _read_cgroup_v1()
+                bm_data['cgroups'] = _read_cgroup_v1()
         except (OSError, ValueError, ZeroDivisionError):
-            bm_data['cgroup_limits'] = {}
+            bm_data['cgroups'] = {}
 
 
 class MBGitInfo:
@@ -415,7 +430,7 @@ class MBGitInfo:
     Requires ``git`` ≥ 2.11 to be available on ``PATH``. Records the
     current repo directory, commit hash, branch name, and whether the
     working tree has uncommitted changes. Results are stored in the
-    ``git_info`` field.
+    ``git`` field.
 
     By default inspects the repository containing the running script
     (``sys.argv[0]``), falling back to the shell's working directory
@@ -437,7 +452,7 @@ class MBGitInfo:
     Example output::
 
         {
-            "git_info": {
+            "git": {
                 "repo": "/home/user/project",
                 "commit": "a1b2c3d4e5f6...",
                 "branch": "main",
@@ -496,7 +511,7 @@ class MBGitInfo:
             elif not line.startswith('#'):
                 dirty = True
 
-        bm_data['git_info'] = {
+        bm_data['git'] = {
             'repo': repo,
             'commit': commit,
             'branch': branch,
@@ -587,7 +602,11 @@ class MBFileHash:
 
 
 class MBGlobalPackages:
-    """Capture Python packages imported in global environment"""
+    """Capture Python packages imported in global environment.
+
+    Results are stored in ``python.loaded_packages`` as a dict mapping
+    package name to version string.
+    """
 
     def capture_functions(self, bm_data):
         # Walk up the call stack to the first frame outside the microbench
@@ -676,9 +695,14 @@ class MBInstalledPackages:
     Records the name and version of every distribution available in the
     current Python environment via ``importlib.metadata``.
 
+    Results are stored in ``python.installed_packages`` as a dict mapping
+    package name to version string. When ``capture_paths=True``,
+    installation paths are stored in ``python.installed_package_paths``.
+
     Attributes:
         capture_paths (bool): Also record the installation path of each
-            package under ``package_paths``. Defaults to ``False``.
+            package under ``python.installed_package_paths``. Defaults to
+            ``False``.
     """
 
     cli_compatible = True
@@ -687,14 +711,15 @@ class MBInstalledPackages:
     def capture_packages(self, bm_data):
         import importlib.metadata
 
-        bm_data['package_versions'] = {}
+        python = bm_data.setdefault('python', {})
+        python['installed_packages'] = {}
         if self.capture_paths:
-            bm_data['package_paths'] = {}
+            python['installed_package_paths'] = {}
 
         for pkg in importlib.metadata.distributions():
-            bm_data['package_versions'][pkg.name] = pkg.version
+            python['installed_packages'][pkg.name] = pkg.version
             if self.capture_paths:
-                bm_data['package_paths'][pkg.name] = os.path.dirname(
+                python['installed_package_paths'][pkg.name] = os.path.dirname(
                     pkg.locate_file(pkg.files[0])
                 )
 
@@ -707,10 +732,13 @@ class MBLineProfiler:
     times the execution of each line of Python code in your function. This will
     slightly slow down the execution of your function, so it's not recommended
     in production.
+
+    Results are stored in ``call.line_profiler`` as a base64-encoded pickled
+    ``LineStats`` object.
     """
 
     def capturepost_line_profile(self, bm_data):
-        bm_data['line_profiler'] = base64.b64encode(
+        bm_data.setdefault('call', {})['line_profiler'] = base64.b64encode(
             pickle.dumps(self._line_profiler.get_stats())
         ).decode('utf8')
 
@@ -739,24 +767,32 @@ class _NeedsPsUtil:
 
 
 class MBHostCpuCores(_NeedsPsUtil):
-    """Capture the number of logical CPU cores."""
+    """Capture the number of logical and physical CPU cores.
+
+    Results are stored in the ``host`` dict under ``cpu_cores_logical``
+    and ``cpu_cores_physical``.
+    """
 
     cli_compatible = True
 
     def capture_cpu_cores(self, bm_data):
         self._check_psutil()
-        bm_data['cpu_cores_logical'] = psutil.cpu_count(logical=True)
-        bm_data['cpu_cores_physical'] = psutil.cpu_count(logical=False)
+        host = bm_data.setdefault('host', {})
+        host['cpu_cores_logical'] = psutil.cpu_count(logical=True)
+        host['cpu_cores_physical'] = psutil.cpu_count(logical=False)
 
 
 class MBHostRamTotal(_NeedsPsUtil):
-    """Capture the total host RAM in bytes."""
+    """Capture the total host RAM in bytes.
+
+    Result is stored in ``host.ram_total``.
+    """
 
     cli_compatible = True
 
     def capture_total_ram(self, bm_data):
         self._check_psutil()
-        bm_data['ram_total'] = psutil.virtual_memory().total
+        bm_data.setdefault('host', {})['ram_total'] = psutil.virtual_memory().total
 
 
 class MBPeakMemory:
@@ -764,7 +800,7 @@ class MBPeakMemory:
 
     Uses :mod:`tracemalloc` from the Python standard library (no extra
     dependencies). Records the peak memory allocated in bytes across all
-    iterations as ``peak_memory_bytes``.
+    iterations as ``call.peak_memory_bytes``.
 
     Note:
         ``tracemalloc`` tracks memory that goes through Python's allocator,
@@ -786,7 +822,7 @@ class MBPeakMemory:
         import tracemalloc
 
         _, peak = tracemalloc.get_traced_memory()
-        bm_data['peak_memory_bytes'] = peak
+        bm_data.setdefault('call', {})['peak_memory_bytes'] = peak
         if not self._tracemalloc_was_tracing:
             tracemalloc.stop()
 
@@ -797,9 +833,22 @@ class MBNvidiaSmi:
     Requires the ``nvidia-smi`` utility to be available on ``PATH``
     (bundled with NVIDIA drivers).
 
-    Results are stored as ``nvidia_<attr>`` fields, each a dict keyed by
-    GPU UUID. Run ``nvidia-smi --help-query-gpu`` for all available
-    attribute names. Run ``nvidia-smi -L`` to list GPU UUIDs.
+    Results are stored as ``nvidia``, a list of per-GPU dicts. Each dict
+    contains ``uuid`` plus one key per queried attribute. Run
+    ``nvidia-smi --help-query-gpu`` for all available attribute names.
+    Run ``nvidia-smi -L`` to list GPU UUIDs.
+
+    Example output::
+
+        {
+            "nvidia": [
+                {
+                    "uuid": "GPU-abc123",
+                    "gpu_name": "Tesla T4",
+                    "memory.total": "16160 MiB"
+                }
+            ]
+        }
 
     Attributes:
         nvidia_attributes (tuple[str]): Attributes to query. Defaults to
@@ -846,16 +895,18 @@ class MBNvidiaSmi:
         # Execute the command
         res = subprocess.check_output(cmd).decode('utf8')
 
-        # Process results
+        # Process results into a list of per-GPU dicts
+        nvidia_list = []
         for gpu_line in res.split('\n'):
             if not gpu_line:
                 continue
             gpu_res = gpu_line.split(', ')
+            gpu_uuid = gpu_res[0]
+            gpu_dict = {'uuid': gpu_uuid}
             for attr_idx, attr in enumerate(nvidia_attributes):
-                gpu_uuid = gpu_res[0]
-                bm_data.setdefault(f'nvidia_{attr}', {})[gpu_uuid] = gpu_res[
-                    attr_idx + 1
-                ]
+                gpu_dict[attr] = gpu_res[attr_idx + 1]
+            nvidia_list.append(gpu_dict)
+        bm_data['nvidia'] = nvidia_list
 
 
 class _MonitorThread(threading.Thread):

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -40,12 +40,12 @@ def test_cli_records_command_and_timing():
     code, record, _ = _run_main(['--', 'sleep', '1'])
 
     assert code == 0
-    assert record['command'] == ['sleep', '1']
-    assert record['returncode'] == [0]
-    assert 'start_time' in record
-    assert 'finish_time' in record
-    assert 'run_durations' in record
-    assert record['function_name'] == 'sleep'
+    assert record['call']['command'] == ['sleep', '1']
+    assert record['call']['returncode'] == [0]
+    assert 'start_time' in record['call']
+    assert 'finish_time' in record['call']
+    assert 'durations' in record['call']
+    assert record['call']['name'] == 'sleep'
 
 
 def test_cli_nonzero_returncode():
@@ -53,7 +53,7 @@ def test_cli_nonzero_returncode():
     code, record, _ = _run_main(['--', 'false'], mock_returncode=1)
 
     assert code == 1
-    assert record['returncode'] == [1]
+    assert record['call']['returncode'] == [1]
 
 
 def test_cli_custom_field():
@@ -77,8 +77,8 @@ def test_cli_default_mixins_include_host_info():
     """Default configuration includes MBHostInfo fields."""
     _, record, _ = _run_main(['--', 'true'])
 
-    assert 'hostname' in record
-    assert 'operating_system' in record
+    assert 'hostname' in record['host']
+    assert 'os' in record['host']
 
 
 def test_cli_default_mixins_include_slurm():
@@ -99,8 +99,8 @@ def test_cli_default_mixins_include_working_dir():
     """Default configuration includes MBWorkingDir (working_dir field)."""
     _, record, _ = _run_main(['--', 'true'])
 
-    assert 'working_dir' in record
-    assert record['working_dir'] == os.getcwd()
+    assert 'working_dir' in record['call']
+    assert record['call']['working_dir'] == os.getcwd()
 
 
 def test_cli_default_mixins_include_python_info():
@@ -119,7 +119,7 @@ def test_cli_explicit_mixin_replaces_defaults():
 
     assert 'python' in record
     # Default mixins should not be present
-    assert 'hostname' not in record
+    assert 'host' not in record
     assert 'slurm' not in record
 
 
@@ -136,8 +136,8 @@ def test_cli_outfile(tmp_path):
             main(['--outfile', str(outfile), '--', 'true'])
 
     record = json.loads(outfile.read_text())
-    assert record['command'] == ['true']
-    assert record['returncode'] == [0]
+    assert record['call']['command'] == ['true']
+    assert record['call']['returncode'] == [0]
 
 
 def test_cli_no_command_exits_with_error():
@@ -162,7 +162,7 @@ def test_cli_show_mixins():
 
 
 def test_cli_capture_optional_on_by_default():
-    """Capture failures are recorded in mb_capture_errors, not raised."""
+    """Capture failures are recorded in call.capture_errors, not raised."""
 
     def bad_capture(self, bm_data):
         raise RuntimeError('simulated capture failure')
@@ -172,8 +172,10 @@ def test_cli_capture_optional_on_by_default():
     with patch.object(MBHostInfo, 'capture_hostname', bad_capture):
         _, record, _ = _run_main(['--mixin', 'MBHostInfo', '--', 'true'])
 
-    assert 'mb_capture_errors' in record
-    assert any('capture_hostname' in e['method'] for e in record['mb_capture_errors'])
+    assert 'capture_errors' in record['call']
+    assert any(
+        'capture_hostname' in e['method'] for e in record['call']['capture_errors']
+    )
 
 
 def test_cli_all_flag_includes_all_mixins():
@@ -192,12 +194,12 @@ def test_cli_all_flag_includes_all_mixins():
 
     # At minimum the record should be written (even with capture_optional errors)
     record = json.loads(buf.getvalue())
-    assert 'command' in record
+    assert 'command' in record['call']
     assert len(all_names) > 2  # sanity: more than just defaults
 
 
 def test_cli_includes_mb_run_id_and_version():
-    """CLI records mb_run_id and mb_version in every record."""
+    """CLI records mb.run_id and mb.version in every record."""
     import re
 
     import microbench
@@ -207,8 +209,8 @@ def test_cli_includes_mb_run_id_and_version():
     uuid_re = re.compile(
         r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
     )
-    assert uuid_re.match(record['mb_run_id'])
-    assert record['mb_version'] == microbench.__version__
+    assert uuid_re.match(record['mb']['run_id'])
+    assert record['mb']['version'] == microbench.__version__
 
 
 def test_cli_double_dash_separator():
@@ -221,12 +223,12 @@ def test_cli_double_dash_separator():
 
 
 def test_cli_iterations():
-    """--iterations N runs the command N times and produces N run_durations entries."""
+    """--iterations N runs the command N times and produces N durations entries."""
     _, record, mock_run = _run_main(['--iterations', '3', '--', 'true'])
 
     assert mock_run.call_count == 3
-    assert len(record['run_durations']) == 3
-    assert len(record['returncode']) == 3
+    assert len(record['call']['durations']) == 3
+    assert len(record['call']['returncode']) == 3
 
 
 def test_cli_warmup():
@@ -235,8 +237,8 @@ def test_cli_warmup():
 
     # 2 warmup calls + 1 timed call
     assert mock_run.call_count == 3
-    assert len(record['run_durations']) == 1
-    assert len(record['returncode']) == 1
+    assert len(record['call']['durations']) == 1
+    assert len(record['call']['returncode']) == 1
 
 
 def test_cli_iterations_and_warmup():
@@ -246,8 +248,8 @@ def test_cli_iterations_and_warmup():
     )
 
     assert mock_run.call_count == 6
-    assert len(record['run_durations']) == 4
-    assert len(record['returncode']) == 4
+    assert len(record['call']['durations']) == 4
+    assert len(record['call']['returncode']) == 4
 
 
 def test_cli_returncode_is_max_across_iterations():
@@ -264,14 +266,14 @@ def test_cli_returncode_is_max_across_iterations():
                 main(['--iterations', '3', '--', 'true'])
 
     assert exc.value.code == 2
-    assert json.loads(buf.getvalue())['returncode'] == [0, 2, 1]
+    assert json.loads(buf.getvalue())['call']['returncode'] == [0, 2, 1]
 
 
 def test_cli_multiple_mixins():
     """Multiple space-separated mixins all take effect."""
     _, record, _ = _run_main(['--mixin', 'MBHostInfo', 'MBPythonVersion', '--', 'true'])
 
-    assert 'hostname' in record
+    assert 'hostname' in record['host']
     assert 'python_version' in record
 
 
@@ -320,8 +322,8 @@ def test_cli_no_stdout_capture_by_default():
     """stdout and stderr fields are absent unless --stdout/--stderr are given."""
     _, record, _ = _run_main(['--', 'echo', 'hello'])
 
-    assert 'stdout' not in record
-    assert 'stderr' not in record
+    assert 'stdout' not in record.get('call', {})
+    assert 'stderr' not in record.get('call', {})
 
 
 def test_cli_capture_stdout_records_output():
@@ -337,8 +339,8 @@ def test_cli_capture_stdout_records_output():
                     main(['--stdout', '--', 'echo', 'hello'])
 
     record = json.loads(buf.getvalue())
-    assert record['stdout'] == ['hello\n']
-    assert 'stderr' not in record
+    assert record['call']['stdout'] == ['hello\n']
+    assert 'stderr' not in record.get('call', {})
     assert terminal.getvalue() == 'hello\n'
     assert mock_popen.call_args[1].get('stdout') == subprocess.PIPE
 
@@ -356,7 +358,7 @@ def test_cli_capture_stdout_suppress():
                     main(['--stdout=suppress', '--', 'echo', 'hello'])
 
     record = json.loads(buf.getvalue())
-    assert record['stdout'] == ['hello\n']
+    assert record['call']['stdout'] == ['hello\n']
     assert terminal.getvalue() == ''  # nothing re-printed
 
 
@@ -373,8 +375,8 @@ def test_cli_capture_stderr_records_output():
                     main(['--stderr', '--', 'cmd'])
 
     record = json.loads(buf.getvalue())
-    assert record['stderr'] == ['warning\n']
-    assert 'stdout' not in record
+    assert record['call']['stderr'] == ['warning\n']
+    assert 'stdout' not in record.get('call', {})
     assert terminal_err.getvalue() == 'warning\n'
 
 
@@ -391,7 +393,7 @@ def test_cli_capture_stderr_suppress():
                     main(['--stderr=suppress', '--', 'cmd'])
 
     record = json.loads(buf.getvalue())
-    assert record['stderr'] == ['warning\n']
+    assert record['call']['stderr'] == ['warning\n']
     assert terminal_err.getvalue() == ''
 
 
@@ -414,8 +416,8 @@ def test_cli_capture_stdout_multiple_iterations():
                     )
 
     record = json.loads(buf.getvalue())
-    assert record['stdout'] == ['run1\n', 'run2\n', 'run3\n']
-    assert len(record['stdout']) == len(record['run_durations'])
+    assert record['call']['stdout'] == ['run1\n', 'run2\n', 'run3\n']
+    assert len(record['call']['stdout']) == len(record['call']['durations'])
 
 
 def test_cli_capture_stdout_and_stderr():
@@ -433,8 +435,8 @@ def test_cli_capture_stdout_and_stderr():
                         main(['--stdout', '--stderr', '--', 'cmd'])
 
     record = json.loads(buf.getvalue())
-    assert record['stdout'] == ['out\n']
-    assert record['stderr'] == ['err\n']
+    assert record['call']['stdout'] == ['out\n']
+    assert record['call']['stderr'] == ['err\n']
 
 
 def test_cli_capture_invalid_value():
@@ -469,20 +471,20 @@ def test_cli_no_mixin_omits_all_metadata():
     """--no-mixin produces a record with no mixin fields."""
     _, record, _ = _run_main(['--no-mixin', '--', 'true'])
 
-    assert 'hostname' not in record
+    assert 'host' not in record
     assert 'slurm' not in record
     assert 'python_version' not in record
     # Core fields still present
-    assert 'command' in record
-    assert 'returncode' in record
-    assert 'run_durations' in record
+    assert 'command' in record['call']
+    assert 'returncode' in record['call']
+    assert 'durations' in record['call']
 
 
 def test_cli_no_mixin_overrides_mixin():
     """--no-mixin takes precedence over --mixin."""
     _, record, _ = _run_main(['--no-mixin', '--mixin', 'MBHostInfo', '--', 'true'])
 
-    assert 'hostname' not in record
+    assert 'host' not in record
 
 
 def test_cli_all_and_no_mixin_are_mutually_exclusive():
@@ -536,22 +538,22 @@ def _run_main_with_monitor(argv, mock_pid=12345, mock_returncode=0, fake_samples
 
 
 def test_cli_monitor_interval_absent_by_default():
-    """subprocess_monitor is absent when --monitor-interval is not given."""
+    """call.monitor is absent when --monitor-interval is not given."""
     _, record, _ = _run_main(['--no-mixin', '--', 'true'])
 
-    assert 'subprocess_monitor' not in record
+    assert 'monitor' not in record.get('call', {})
 
 
 def test_cli_monitor_interval_creates_field():
-    """--monitor-interval produces a subprocess_monitor field with samples."""
+    """--monitor-interval produces a call.monitor field with samples."""
     record, MockThread, mock_thread = _run_main_with_monitor(
         ['--no-mixin', '--monitor-interval', '5', '--', 'sleep', '10']
     )
 
-    assert 'subprocess_monitor' in record
-    assert len(record['subprocess_monitor']) == 1  # one iteration
-    assert record['subprocess_monitor'][0][0]['cpu_percent'] == 12.5
-    assert record['subprocess_monitor'][0][0]['rss_bytes'] == 1048576
+    assert 'monitor' in record['call']
+    assert len(record['call']['monitor']) == 1  # one iteration
+    assert record['call']['monitor'][0][0]['cpu_percent'] == 12.5
+    assert record['call']['monitor'][0][0]['rss_bytes'] == 1048576
 
 
 def test_cli_monitor_interval_thread_constructed_correctly():
@@ -576,7 +578,7 @@ def test_cli_monitor_interval_thread_lifecycle():
 
 
 def test_cli_monitor_interval_empty_samples():
-    """subprocess_monitor field is absent when no samples were collected."""
+    """call.monitor field is absent when no samples were collected."""
     # A very fast process may exit before the first sample interval fires.
     record, _, _ = _run_main_with_monitor(
         ['--no-mixin', '--monitor-interval', '60', '--', 'true'],
@@ -585,11 +587,11 @@ def test_cli_monitor_interval_empty_samples():
 
     # Empty per-iteration lists → outer list is [[]], which is falsy per-element
     # but the field should still be absent (no data to report).
-    assert 'subprocess_monitor' not in record
+    assert 'monitor' not in record.get('call', {})
 
 
 def test_cli_monitor_interval_multiple_iterations():
-    """With --iterations N, subprocess_monitor has N inner lists."""
+    """With --iterations N, call.monitor has N inner lists."""
     mock_proc = _make_mock_popen_for_monitor(pid=42)
 
     samples_per_iter = [
@@ -624,14 +626,14 @@ def test_cli_monitor_interval_multiple_iterations():
                     )
 
     record = json.loads(buf.getvalue())
-    assert len(record['subprocess_monitor']) == 3
-    assert record['subprocess_monitor'][0][0]['cpu_percent'] == 10.0
-    assert record['subprocess_monitor'][1][0]['cpu_percent'] == 20.0
-    assert record['subprocess_monitor'][2][0]['cpu_percent'] == 30.0
+    assert len(record['call']['monitor']) == 3
+    assert record['call']['monitor'][0][0]['cpu_percent'] == 10.0
+    assert record['call']['monitor'][1][0]['cpu_percent'] == 20.0
+    assert record['call']['monitor'][2][0]['cpu_percent'] == 30.0
 
 
 def test_cli_monitor_interval_warmup_excluded():
-    """Warmup iterations not monitored; subprocess_monitor length == --iterations."""
+    """Warmup iterations not monitored; call.monitor length == --iterations."""
     mock_proc = _make_mock_popen_for_monitor(pid=7)
     call_count = {'n': 0}
     # 2 warmup + 2 timed = 4 Popen calls; but only 2 monitor threads should start.
@@ -663,7 +665,7 @@ def test_cli_monitor_interval_warmup_excluded():
                     )
 
     record = json.loads(buf.getvalue())
-    assert len(record['subprocess_monitor']) == 2
+    assert len(record['call']['monitor']) == 2
     assert call_count['n'] == 2  # only timed iterations got a monitor thread
 
 
@@ -717,8 +719,8 @@ def test_cli_monitor_interval_with_stdout_capture():
                         )
 
     record = json.loads(buf.getvalue())
-    assert record['stdout'] == ['hello\n']
-    assert record['subprocess_monitor'][0][0]['cpu_percent'] == 8.0
+    assert record['call']['stdout'] == ['hello\n']
+    assert record['call']['monitor'][0][0]['cpu_percent'] == 8.0
 
 
 # ---------------------------------------------------------------------------
@@ -785,7 +787,7 @@ def test_cli_git_repo_explicit(tmp_path):
         _, record, _ = _run_main(
             ['--mixin', 'git-info', '--git-repo', str(tmp_path), '--', 'true']
         )
-    assert record.get('git_info', {}).get('repo') == str(tmp_path)
+    assert record.get('git', {}).get('repo') == str(tmp_path)
     for call in mock_co.call_args_list:
         assert call.kwargs.get('cwd') == str(tmp_path)
 
@@ -794,7 +796,7 @@ def test_cli_git_repo_default_cwd():
     """git-info defaults to the current working directory when --git-repo is omitted."""
     with patch('subprocess.check_output', side_effect=_fake_git_output):
         _, record, _ = _run_main(['--mixin', 'git-info', '--', 'true'])
-    assert record.get('git_info', {}).get('repo') == os.getcwd()
+    assert record.get('git', {}).get('repo') == os.getcwd()
 
 
 def test_cli_hash_file_explicit(tmp_path):
@@ -828,7 +830,7 @@ def test_cli_hash_file_default_unresolvable_cmd():
     """file-hash records empty file_hashes without error when cmd cannot be resolved."""
     with patch('shutil.which', return_value=None):
         _, record, _ = _run_main(['--mixin', 'file-hash', '--', 'ghost_cmd'])
-    assert 'mb_capture_errors' not in record
+    assert 'capture_errors' not in record.get('call', {})
     assert record.get('file_hashes') == {}
 
 

--- a/microbench/tests/test_core.py
+++ b/microbench/tests/test_core.py
@@ -24,7 +24,7 @@ from microbench import (
 
 
 def test_mb_run_id_and_version():
-    """Every record contains mb_run_id (UUID) and mb_version."""
+    """Every record contains mb.run_id (UUID) and mb.version."""
     import re
 
     import microbench
@@ -38,17 +38,18 @@ def test_mb_run_id_and_version():
     noop()
     noop()
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
 
-    # mb_run_id is a valid UUID and consistent across calls
+    # mb.run_id is a valid UUID and consistent across calls
     uuid_re = re.compile(
         r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
     )
-    assert results['mb_run_id'].nunique() == 1
-    assert uuid_re.match(results['mb_run_id'][0])
+    run_ids = {r['mb']['run_id'] for r in results}
+    assert len(run_ids) == 1
+    assert uuid_re.match(list(run_ids)[0])
 
-    # mb_version matches the installed package version
-    assert (results['mb_version'] == microbench.__version__).all()
+    # mb.version matches the installed package version
+    assert all(r['mb']['version'] == microbench.__version__ for r in results)
 
 
 def test_microbench_includes_python_info_by_default():
@@ -77,7 +78,7 @@ def test_microbench_includes_python_info_by_default():
 
 
 def test_mb_run_id_shared_across_instances():
-    """All MicroBench instances in the same process share the same mb_run_id."""
+    """All MicroBench instances in the same process share the same mb.run_id."""
     bench_a = MicroBench()
     bench_b = MicroBench()
 
@@ -92,8 +93,8 @@ def test_mb_run_id_shared_across_instances():
     func_a()
     func_b()
 
-    run_id_a = bench_a.get_results(format='df')['mb_run_id'][0]
-    run_id_b = bench_b.get_results(format='df')['mb_run_id'][0]
+    run_id_a = bench_a.get_results()[0]['mb']['run_id']
+    run_id_b = bench_b.get_results()[0]['mb']['run_id']
     assert run_id_a == run_id_b
 
 
@@ -116,14 +117,12 @@ def test_function():
     for _ in range(3):
         assert my_function() == 499999500000
 
-    results = benchmark.get_results(format='df')
-    assert (results['function_name'] == 'my_function').all()
-    assert results['package_versions'][0]['pandas'] == pandas.__version__
-    runtimes = results['finish_time'] - results['start_time']
-    assert (runtimes > datetime.timedelta(0)).all()
-
-    assert results['timestamp_tz'][0] == 'UTC'
-    assert results['duration_counter'][0] == 'perf_counter'
+    results = benchmark.get_results()
+    assert all(r['call']['name'] == 'my_function' for r in results)
+    assert results[0]['python']['loaded_packages']['pandas'] == pandas.__version__
+    assert all(r['call']['durations'][0] >= 0 for r in results)
+    assert results[0]['mb']['timezone'] == 'UTC'
+    assert results[0]['mb']['duration_counter'] == 'perf_counter'
 
 
 def test_multi_iterations():
@@ -141,21 +140,26 @@ def test_multi_iterations():
     # call the function
     my_function()
 
-    results = benchmark.get_results(format='df')
-    assert (results['function_name'] == 'my_function').all()
-    runtimes = results['finish_time'] - results['start_time']
-    assert (runtimes >= datetime.timedelta(0)).all()
-    assert results['timestamp_tz'][0] == str(tz)
-    # Verify the timezone is actually applied to the timestamps, not just recorded
-    assert results['start_time'][0].utcoffset() == datetime.timedelta(hours=10)
-    assert results['finish_time'][0].utcoffset() == datetime.timedelta(hours=10)
+    results = benchmark.get_results()
+    result = results[0]
+    assert result['call']['name'] == 'my_function'
+    assert result['mb']['timezone'] == str(tz)
 
-    assert len(results['run_durations'][0]) == iterations
-    assert all(dur >= 0 for dur in results['run_durations'][0])
+    # Parse datetime strings to verify timezone offset
+    from datetime import datetime as dt
+
+    start = dt.fromisoformat(result['call']['start_time'])
+    finish = dt.fromisoformat(result['call']['finish_time'])
+    assert finish >= start
+    assert start.utcoffset() == datetime.timedelta(hours=10)
+    assert finish.utcoffset() == datetime.timedelta(hours=10)
+
+    assert len(result['call']['durations']) == iterations
+    assert all(dur >= 0 for dur in result['call']['durations'])
 
 
 def test_capture_optional_records_errors():
-    """capture_optional=True catches failing captures, records in mb_capture_errors."""
+    """capture_optional=True catches failures; records in call.capture_errors."""
 
     class BrokenCapture(MicroBench):
         capture_optional = True
@@ -171,8 +175,8 @@ def test_capture_optional_records_errors():
 
     noop()
 
-    results = bench.get_results(format='df')
-    errors = results['mb_capture_errors'][0]
+    results = bench.get_results()
+    errors = results[0]['call']['capture_errors']
     assert len(errors) == 1
     assert errors[0]['method'] == 'capture_will_fail'
     assert 'RuntimeError' in errors[0]['error']
@@ -180,7 +184,7 @@ def test_capture_optional_records_errors():
 
 
 def test_capture_optional_no_errors_no_field():
-    """When no captures fail, mb_capture_errors is absent from the record."""
+    """When no captures fail, call.capture_errors is absent from the record."""
 
     class Bench(MicroBench):
         capture_optional = True
@@ -193,8 +197,8 @@ def test_capture_optional_no_errors_no_field():
 
     noop()
 
-    results = bench.get_results(format='df')
-    assert 'mb_capture_errors' not in results.columns
+    results = bench.get_results()
+    assert 'capture_errors' not in results[0].get('call', {})
 
 
 def test_capture_optional_false_raises():
@@ -231,8 +235,8 @@ def test_capture_optional_capturepost():
 
     noop()
 
-    results = bench.get_results(format='df')
-    errors = results['mb_capture_errors'][0]
+    results = bench.get_results()
+    errors = results[0]['call']['capture_errors']
     assert any(e['method'] == 'capturepost_will_fail' for e in errors)
 
 
@@ -251,10 +255,10 @@ def test_warmup():
     # 3 warmup + 2 recorded iterations = 5 total calls
     assert call_count == 5
 
-    results = bench.get_results(format='df')
-    # Only one record (one decorated call), with 2 run_durations
+    results = bench.get_results()
+    # Only one record (one decorated call), with 2 call.durations
     assert len(results) == 1
-    assert len(results['run_durations'][0]) == 2
+    assert len(results[0]['call']['durations']) == 2
 
 
 def test_local_timezone():
@@ -279,11 +283,16 @@ def test_local_timezone():
 
     noop()
 
-    results = benchmark.get_results(format='df')
+    from datetime import datetime as dt
+
+    results = benchmark.get_results()
+    result = results[0]
+    start = dt.fromisoformat(result['call']['start_time'])
+    finish = dt.fromisoformat(result['call']['finish_time'])
     expected_offset = datetime.datetime.now().astimezone().utcoffset()
-    assert results['start_time'][0].utcoffset() == expected_offset
-    assert results['finish_time'][0].utcoffset() == expected_offset
-    assert results['timestamp_tz'][0] == str(local_tz)
+    assert start.utcoffset() == expected_offset
+    assert finish.utcoffset() == expected_offset
+    assert result['mb']['timezone'] == str(local_tz)
 
 
 def test_monitor():
@@ -304,8 +313,8 @@ def test_monitor():
     assert not monitor_bench._monitor_thread.is_alive()
 
     # Check some monitor data was captured
-    results = monitor_bench.get_results(format='df')
-    assert len(results['monitor']) > 0
+    results = monitor_bench.get_results()
+    assert len(results[0]['call']['monitor']) > 0
 
 
 def test_monitor_from_non_main_thread():
@@ -366,8 +375,10 @@ def test_monitor_multiple_samples():
 
     slow_function()
 
-    results = monitor_bench.get_results(format='df')
-    assert len(results['monitor'][0]) >= 2, 'Expected at least 2 monitor samples'
+    results = monitor_bench.get_results()
+    assert len(results[0]['call']['monitor']) >= 2, (
+        'Expected at least 2 monitor samples'
+    )
 
 
 def test_functioncall_args_not_double_encoded():
@@ -388,9 +399,9 @@ def test_functioncall_args_not_double_encoded():
 
     dummy(42, {'key': 'value'}, kw_str='hello')
 
-    results = bench.get_results(format='df')
-    args = results['args'][0]
-    kwargs = results['kwargs'][0]
+    results = bench.get_results()
+    args = results[0]['call']['args']
+    kwargs = results[0]['call']['kwargs']
 
     # Values must be their native Python types, not JSON-encoded strings
     assert args[0] == 42, f'Expected int 42, got {args[0]!r}'
@@ -410,26 +421,26 @@ def test_record_standard_fields():
     with bench.record('my_block'):
         pass
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    row = results.iloc[0]
-    assert row['function_name'] == 'my_block'
-    assert 'start_time' in results.columns
-    assert 'finish_time' in results.columns
-    assert len(row['run_durations']) == 1
-    assert 'mb_run_id' in results.columns
-    assert 'mb_version' in results.columns
+    result = results[0]
+    assert result['call']['name'] == 'my_block'
+    assert 'start_time' in result['call']
+    assert 'finish_time' in result['call']
+    assert len(result['call']['durations']) == 1
+    assert 'run_id' in result['mb']
+    assert 'version' in result['mb']
 
 
 def test_record_no_name_defaults():
-    """bench.record() with no name sets function_name to '<record>'."""
+    """bench.record() with no name sets call.name to '<record>'."""
     bench = MicroBench()
 
     with bench.record():
         pass
 
-    results = bench.get_results(format='df')
-    assert results.iloc[0]['function_name'] == '<record>'
+    results = bench.get_results()
+    assert results[0]['call']['name'] == '<record>'
 
 
 def test_record_static_fields():
@@ -439,9 +450,9 @@ def test_record_static_fields():
     with bench.record('block'):
         pass
 
-    results = bench.get_results(format='df')
-    assert results.iloc[0]['experiment'] == 'run-1'
-    assert results.iloc[0]['trial'] == 3
+    results = bench.get_results()
+    assert results[0]['experiment'] == 'run-1'
+    assert results[0]['trial'] == 3
 
 
 def test_record_mixin_fields():
@@ -455,9 +466,10 @@ def test_record_mixin_fields():
     with bench.record('block'):
         pass
 
-    results = bench.get_results(format='df')
-    assert 'hostname' in results.columns
-    assert 'operating_system' in results.columns
+    results = bench.get_results()
+    assert 'host' in results[0]
+    assert 'hostname' in results[0]['host']
+    assert 'os' in results[0]['host']
 
 
 def test_record_multiple_records():
@@ -469,9 +481,9 @@ def test_record_multiple_records():
     with bench.record('second'):
         pass
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 2
-    assert list(results['function_name']) == ['first', 'second']
+    assert [r['call']['name'] for r in results] == ['first', 'second']
 
 
 def test_record_exception_captured_and_reraised():
@@ -482,9 +494,9 @@ def test_record_exception_captured_and_reraised():
         with bench.record('block'):
             raise ValueError('oops')
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    exc = results.iloc[0]['exception']
+    exc = results[0]['exception']
     assert exc['type'] == 'ValueError'
     assert exc['message'] == 'oops'
 
@@ -496,8 +508,8 @@ def test_record_no_exception_field_on_success():
     with bench.record('block'):
         pass
 
-    results = bench.get_results(format='df')
-    assert 'exception' not in results.columns
+    results = bench.get_results()
+    assert 'exception' not in results[0]
 
 
 def test_record_coexists_with_decorator():
@@ -513,9 +525,9 @@ def test_record_coexists_with_decorator():
 
     decorated()
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 2
-    assert set(results['function_name']) == {'ctx', 'decorated'}
+    assert {r['call']['name'] for r in results} == {'ctx', 'decorated'}
 
 
 # ---------------------------------------------------------------------------
@@ -534,9 +546,9 @@ def test_decorator_exception_captured_and_reraised():
     with pytest.raises(RuntimeError, match='boom'):
         failing()
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    exc = results.iloc[0]['exception']
+    exc = results[0]['exception']
     assert exc['type'] == 'RuntimeError'
     assert exc['message'] == 'boom'
 
@@ -551,8 +563,8 @@ def test_decorator_no_exception_field_on_success():
 
     ok()
 
-    results = bench.get_results(format='df')
-    assert 'exception' not in results.columns
+    results = bench.get_results()
+    assert 'exception' not in results[0]
 
 
 def test_decorator_exception_stops_iterations():
@@ -571,9 +583,9 @@ def test_decorator_exception_stops_iterations():
     with pytest.raises(ValueError):
         sometimes_fails()
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert call_count == 2
-    assert len(results.iloc[0]['run_durations']) == 2
+    assert len(results[0]['call']['durations']) == 2
 
 
 def test_decorator_return_value_mixin_skipped_on_exception():
@@ -591,8 +603,8 @@ def test_decorator_return_value_mixin_skipped_on_exception():
     with pytest.raises(TypeError):
         failing()
 
-    results = bench.get_results(format='df')
-    assert 'return_value' not in results.columns
+    results = bench.get_results()
+    assert 'return_value' not in results[0].get('call', {})
 
 
 # ---------------------------------------------------------------------------
@@ -611,9 +623,9 @@ def test_record_mbfunctioncall_produces_empty_args():
     with bench.record('block'):
         pass
 
-    results = bench.get_results(format='df')
-    assert results.iloc[0]['args'] == []
-    assert results.iloc[0]['kwargs'] == {}
+    results = bench.get_results()
+    assert results[0]['call']['args'] == []
+    assert results[0]['call']['kwargs'] == {}
 
 
 def test_record_mbreturnvalue_ignored():
@@ -627,8 +639,8 @@ def test_record_mbreturnvalue_ignored():
     with bench.record('block'):
         pass
 
-    results = bench.get_results(format='df')
-    assert 'return_value' not in results.columns
+    results = bench.get_results()
+    assert 'return_value' not in results[0].get('call', {})
 
 
 # ---------------------------------------------------------------------------
@@ -639,7 +651,7 @@ def test_record_mbreturnvalue_ignored():
 def _invoke_record_on_exit(bench):
     """Directly call the registered exit handler and return its results."""
     bench._record_on_exit_handler()
-    return bench.get_results(format='df')
+    return bench.get_results()
 
 
 def test_record_on_exit_standard_fields():
@@ -654,18 +666,18 @@ def test_record_on_exit_standard_fields():
         _atexit.unregister(bench._record_on_exit_handler)
 
     assert len(results) == 1
-    row = results.iloc[0]
-    assert row['function_name'] == 'simulation'
-    assert len(row['run_durations']) == 1
-    assert row['run_durations'][0] >= 0
-    assert 'start_time' in results.columns
-    assert 'finish_time' in results.columns
-    assert 'mb_run_id' in results.columns
-    assert 'mb_version' in results.columns
+    result = results[0]
+    assert result['call']['name'] == 'simulation'
+    assert len(result['call']['durations']) == 1
+    assert result['call']['durations'][0] >= 0
+    assert 'start_time' in result['call']
+    assert 'finish_time' in result['call']
+    assert 'run_id' in result['mb']
+    assert 'version' in result['mb']
 
 
 def test_record_on_exit_default_name():
-    """record_on_exit() with no name sets function_name to '<process>'."""
+    """record_on_exit() with no name sets call.name to '<process>'."""
     bench = MicroBench()
     orig_excepthook = sys.excepthook
     try:
@@ -675,7 +687,7 @@ def test_record_on_exit_default_name():
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
-    assert results.iloc[0]['function_name'] == '<process>'
+    assert results[0]['call']['name'] == '<process>'
 
 
 def test_record_on_exit_static_fields():
@@ -689,8 +701,8 @@ def test_record_on_exit_static_fields():
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
-    assert results.iloc[0]['experiment'] == 'run-1'
-    assert results.iloc[0]['trial'] == 7
+    assert results[0]['experiment'] == 'run-1'
+    assert results[0]['trial'] == 7
 
 
 def test_record_on_exit_mixin_fields():
@@ -708,8 +720,9 @@ def test_record_on_exit_mixin_fields():
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
-    assert 'hostname' in results.columns
-    assert 'operating_system' in results.columns
+    assert 'host' in results[0]
+    assert 'hostname' in results[0]['host']
+    assert 'os' in results[0]['host']
 
 
 def test_record_on_exit_exception_capture():
@@ -727,7 +740,7 @@ def test_record_on_exit_exception_capture():
         _atexit.unregister(bench._record_on_exit_handler)
 
     assert len(results) == 1
-    exc_field = results.iloc[0]['exception']
+    exc_field = results[0]['exception']
     assert exc_field['type'] == 'RuntimeError'
     assert exc_field['message'] == 'something broke'
 
@@ -743,7 +756,7 @@ def test_record_on_exit_no_exception_field_on_clean_exit():
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
-    assert 'exception' not in results.columns
+    assert 'exception' not in results[0]
 
 
 def test_record_on_exit_sigterm_writes_record():
@@ -758,14 +771,14 @@ def test_record_on_exit_sigterm_writes_record():
         # Invoke the handler but prevent it from re-killing the process.
         with patch('os.kill'), patch('signal.signal'):
             handler(_signal.SIGTERM, None)
-        results = bench.get_results(format='df')
+        results = bench.get_results()
     finally:
         sys.excepthook = orig_excepthook
         _signal.signal(_signal.SIGTERM, orig_sigterm)
         _atexit.unregister(bench._record_on_exit_handler)
 
     assert len(results) == 1
-    assert results.iloc[0]['exit_signal'] == 'SIGTERM'
+    assert results[0]['exit_signal'] == 'SIGTERM'
 
 
 def test_record_on_exit_handle_sigterm_false():
@@ -789,7 +802,7 @@ def test_record_on_exit_double_fire_prevention():
         bench.record_on_exit('sim')
         bench._record_on_exit_handler()
         bench._record_on_exit_handler()
-        results = bench.get_results(format='df')
+        results = bench.get_results()
     finally:
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
@@ -813,13 +826,13 @@ def test_record_on_exit_re_registration_replaces_first():
         assert first_handler is not second_handler
 
         second_handler()
-        results = bench.get_results(format='df')
+        results = bench.get_results()
     finally:
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
     assert len(results) == 1
-    assert results.iloc[0]['function_name'] == 'second'
+    assert results[0]['call']['name'] == 'second'
 
 
 def test_record_on_exit_non_main_thread_warns():
@@ -866,7 +879,7 @@ def test_record_on_exit_output_fallback_to_stderr(capsys):
     import json as _json
 
     record = _json.loads(captured.err.strip())
-    assert record['function_name'] == 'sim'
+    assert record['call']['name'] == 'sim'
 
 
 # ---------------------------------------------------------------------------
@@ -885,18 +898,19 @@ async def test_async_decorator_standard_fields():
 
     await async_noop()
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    assert results.iloc[0]['function_name'] == 'async_noop'
-    assert 'start_time' in results.columns
-    assert 'finish_time' in results.columns
-    assert len(results.iloc[0]['run_durations']) == 1
-    assert results.iloc[0]['run_durations'][0] >= 0
+    result = results[0]
+    assert result['call']['name'] == 'async_noop'
+    assert 'start_time' in result['call']
+    assert 'finish_time' in result['call']
+    assert len(result['call']['durations']) == 1
+    assert result['call']['durations'][0] >= 0
 
 
 @pytest.mark.asyncio
 async def test_async_decorator_iterations():
-    """iterations=N on an async function produces N run_durations."""
+    """iterations=N on an async function produces N call.durations entries."""
     bench = MicroBench(iterations=3)
 
     @bench
@@ -905,8 +919,8 @@ async def test_async_decorator_iterations():
 
     await async_noop()
 
-    results = bench.get_results(format='df')
-    assert len(results.iloc[0]['run_durations']) == 3
+    results = bench.get_results()
+    assert len(results[0]['call']['durations']) == 3
 
 
 @pytest.mark.asyncio
@@ -925,8 +939,8 @@ async def test_async_decorator_warmup():
 
     # 2 warmup + 3 recorded = 5 total
     assert call_count == 5
-    results = bench.get_results(format='df')
-    assert len(results.iloc[0]['run_durations']) == 3
+    results = bench.get_results()
+    assert len(results[0]['call']['durations']) == 3
 
 
 @pytest.mark.asyncio
@@ -941,9 +955,9 @@ async def test_async_decorator_exception():
     with pytest.raises(ValueError, match='async boom'):
         await async_fail()
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    exc = results.iloc[0]['exception']
+    exc = results[0]['exception']
     assert exc['type'] == 'ValueError'
     assert exc['message'] == 'async boom'
 
@@ -964,8 +978,8 @@ async def test_async_decorator_return_value():
     result = await async_compute()
 
     assert result == 42
-    results = bench.get_results(format='df')
-    assert results.iloc[0]['return_value'] == 42
+    results = bench.get_results()
+    assert results[0]['call']['return_value'] == 42
 
 
 @pytest.mark.asyncio
@@ -983,9 +997,9 @@ async def test_async_decorator_functioncall():
 
     await async_fn(1, y=2)
 
-    results = bench.get_results(format='df')
-    assert results.iloc[0]['args'] == [1]
-    assert results.iloc[0]['kwargs'] == {'y': 2}
+    results = bench.get_results()
+    assert results[0]['call']['args'] == [1]
+    assert results[0]['call']['kwargs'] == {'y': 2}
 
 
 @pytest.mark.asyncio
@@ -996,25 +1010,25 @@ async def test_async_arecord_standard_fields():
     async with bench.arecord('my_block'):
         await asyncio.sleep(0)
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    row = results.iloc[0]
-    assert row['function_name'] == 'my_block'
-    assert 'start_time' in results.columns
-    assert 'finish_time' in results.columns
-    assert len(row['run_durations']) == 1
+    result = results[0]
+    assert result['call']['name'] == 'my_block'
+    assert 'start_time' in result['call']
+    assert 'finish_time' in result['call']
+    assert len(result['call']['durations']) == 1
 
 
 @pytest.mark.asyncio
 async def test_async_arecord_no_name_defaults():
-    """bench.arecord() with no name sets function_name to '<record>'."""
+    """bench.arecord() with no name sets call.name to '<record>'."""
     bench = MicroBench()
 
     async with bench.arecord():
         pass
 
-    results = bench.get_results(format='df')
-    assert results.iloc[0]['function_name'] == '<record>'
+    results = bench.get_results()
+    assert results[0]['call']['name'] == '<record>'
 
 
 @pytest.mark.asyncio
@@ -1026,9 +1040,9 @@ async def test_async_arecord_exception():
         async with bench.arecord('block'):
             raise RuntimeError('async oops')
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    exc = results.iloc[0]['exception']
+    exc = results[0]['exception']
     assert exc['type'] == 'RuntimeError'
     assert exc['message'] == 'async oops'
 
@@ -1066,8 +1080,8 @@ async def test_async_monitor_thread():
     await async_noop()
 
     assert not monitor_bench._monitor_thread.is_alive()
-    results = monitor_bench.get_results(format='df')
-    assert len(results['monitor'][0]) > 0
+    results = monitor_bench.get_results()
+    assert len(results[0]['call']['monitor']) > 0
 
 
 @pytest.mark.asyncio
@@ -1085,9 +1099,9 @@ async def test_monitor_with_arecord():
         await asyncio.sleep(0)
 
     assert not bench._monitor_thread.is_alive()
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 1
-    assert len(results.iloc[0]['monitor']) > 0
+    assert len(results[0]['call']['monitor']) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -1122,7 +1136,7 @@ def test_monitor_record_on_exit_samples_span_lifetime():
         _atexit.unregister(bench._record_on_exit_handler)
 
     assert len(results) == 1
-    monitor_data = results.iloc[0]['monitor']
+    monitor_data = results[0]['call']['monitor']
     assert len(monitor_data) >= 2, (
         f'Expected >=2 monitor samples across process lifetime, got {len(monitor_data)}'
     )
@@ -1155,7 +1169,7 @@ def test_monitor_record_on_exit_re_registration_terminates_old_thread():
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
-    assert results.iloc[0]['function_name'] == 'second'
+    assert results[0]['call']['name'] == 'second'
 
 
 # ---------------------------------------------------------------------------
@@ -1164,7 +1178,7 @@ def test_monitor_record_on_exit_re_registration_terminates_old_thread():
 
 
 def test_time_with_record():
-    """bench.time() inside bench.record() appends entries to mb_timings."""
+    """bench.time() inside bench.record() appends entries to call.timings."""
     bench = MicroBench()
 
     with bench.record('pipeline'):
@@ -1173,8 +1187,8 @@ def test_time_with_record():
         with bench.time('transform'):
             pass
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'parse'
     assert timings[1]['name'] == 'transform'
@@ -1195,8 +1209,8 @@ def test_time_with_decorator():
 
     pipeline()
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'step_a'
     assert timings[1]['name'] == 'step_b'
@@ -1216,8 +1230,8 @@ async def test_time_with_async_decorator():
 
     await async_pipeline()
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'fetch'
     assert timings[1]['name'] == 'process'
@@ -1234,15 +1248,15 @@ async def test_time_with_arecord():
         with bench.time('save'):
             pass
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'load'
     assert timings[1]['name'] == 'save'
 
 
 def test_time_with_record_on_exit():
-    """bench.time() after bench.record_on_exit() accumulates in mb_timings."""
+    """bench.time() after bench.record_on_exit() accumulates in call.timings."""
     bench = MicroBench()
     orig_excepthook = sys.excepthook
     try:
@@ -1256,7 +1270,7 @@ def test_time_with_record_on_exit():
         sys.excepthook = orig_excepthook
         _atexit.unregister(bench._record_on_exit_handler)
 
-    timings = results.iloc[0]['mb_timings']
+    timings = results[0]['call']['timings']
     assert len(timings) == 2
     assert timings[0]['name'] == 'setup'
     assert timings[1]['name'] == 'run'
@@ -1273,19 +1287,19 @@ def test_time_noop_outside_benchmark():
         pass
 
     # Nothing written
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 0
 
 
 def test_time_absent_when_not_used():
-    """mb_timings is absent from the record when bench.time() is never called."""
+    """call.timings is absent from the record when bench.time() is never called."""
     bench = MicroBench()
 
     with bench.record('block'):
         pass
 
-    results = bench.get_results(format='df')
-    assert 'mb_timings' not in results.columns
+    results = bench.get_results()
+    assert 'timings' not in results[0].get('call', {})
 
 
 def test_time_multiple_iterations():
@@ -1299,8 +1313,8 @@ def test_time_multiple_iterations():
 
     pipeline()
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 3
     assert all(t['name'] == 'step' for t in timings)
 
@@ -1314,15 +1328,15 @@ def test_time_exception_closes_segment():
             with bench.time('risky'):
                 raise ValueError('fail')
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 1
     assert timings[0]['name'] == 'risky'
     assert timings[0]['duration'] >= 0
 
 
 def test_time_ordering_preserved():
-    """mb_timings entries appear in call order."""
+    """call.timings entries appear in call order."""
     bench = MicroBench()
 
     names = ['alpha', 'beta', 'gamma', 'delta']
@@ -1331,8 +1345,8 @@ def test_time_ordering_preserved():
             with bench.time(n):
                 pass
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert [t['name'] for t in timings] == names
 
 
@@ -1345,15 +1359,15 @@ def test_time_same_name_multiple_times():
             with bench.time('repeat'):
                 pass
 
-    results = bench.get_results(format='df')
-    timings = results.iloc[0]['mb_timings']
+    results = bench.get_results()
+    timings = results[0]['call']['timings']
     assert len(timings) == 3
     assert all(t['name'] == 'repeat' for t in timings)
 
 
 @pytest.mark.asyncio
 async def test_time_concurrent_arecord():
-    """Two concurrent arecord() calls get independent mb_timings."""
+    """Two concurrent arecord() calls get independent call.timings."""
     bench = MicroBench()
 
     async def task_a():
@@ -1368,15 +1382,15 @@ async def test_time_concurrent_arecord():
 
     await asyncio.gather(task_a(), task_b())
 
-    results = bench.get_results(format='df')
+    results = bench.get_results()
     assert len(results) == 2
-    by_name = {row['function_name']: row for _, row in results.iterrows()}
+    by_name = {r['call']['name']: r for r in results}
 
-    assert by_name['a']['mb_timings'] == [
-        {'name': 'a_step', 'duration': by_name['a']['mb_timings'][0]['duration']}
+    assert by_name['a']['call']['timings'] == [
+        {'name': 'a_step', 'duration': by_name['a']['call']['timings'][0]['duration']}
     ]
-    assert by_name['b']['mb_timings'] == [
-        {'name': 'b_step', 'duration': by_name['b']['mb_timings'][0]['duration']}
+    assert by_name['b']['call']['timings'] == [
+        {'name': 'b_step', 'duration': by_name['b']['call']['timings'][0]['duration']}
     ]
-    assert by_name['a']['mb_timings'][0]['name'] == 'a_step'
-    assert by_name['b']['mb_timings'][0]['name'] == 'b_step'
+    assert by_name['a']['call']['timings'][0]['name'] == 'a_step'
+    assert by_name['b']['call']['timings'][0]['name'] == 'b_step'

--- a/microbench/tests/test_line_profiler.py
+++ b/microbench/tests/test_line_profiler.py
@@ -41,8 +41,8 @@ def test_line_profiler():
     for _ in range(3):
         assert my_function() == 499999500000
 
-    results = lpbench.get_results(format='df')
-    lp = MBLineProfiler.decode_line_profile(results['line_profiler'][0])
+    results = lpbench.get_results()
+    lp = MBLineProfiler.decode_line_profile(results[0]['call']['line_profiler'])
     assert lp.__class__.__name__ == 'LineStats'
-    MBLineProfiler.print_line_profile(results['line_profiler'][0])
+    MBLineProfiler.print_line_profile(results[0]['call']['line_profiler'])
     assert not all(len(v) == 0 for v in lp.timings.values()), 'No timings present'

--- a/microbench/tests/test_mixins.py
+++ b/microbench/tests/test_mixins.py
@@ -42,8 +42,7 @@ def test_mb_slurm_info():
     with patch.dict(os.environ, slurm_env, clear=False):
         noop()
 
-    results = bench.get_results(format='df')
-    slurm = results['slurm'][0]
+    slurm = bench.get_results()[0]['slurm']
     assert slurm['job_id'] == '12345'
     assert slurm['array_task_id'] == '3'
     assert slurm['nodelist'] == 'gpu-node-01'
@@ -67,8 +66,7 @@ def test_mb_slurm_info_empty():
     with patch.dict(os.environ, clean_env, clear=True):
         noop()
 
-    results = bench.get_results(format='df')
-    assert results['slurm'][0] == {}
+    assert bench.get_results()[0]['slurm'] == {}
 
 
 def test_mb_loaded_modules():
@@ -90,7 +88,7 @@ def test_mb_loaded_modules():
     ):
         noop()
 
-    modules = bench.get_results(format='df')['loaded_modules'][0]
+    modules = bench.get_results()[0]['loaded_modules']
     assert modules['gcc'] == '12.2.0'
     assert modules['openmpi'] == '4.1.5'
     assert modules['python'] == '3.10.4'
@@ -112,7 +110,7 @@ def test_mb_loaded_modules_empty():
     with patch.dict(os.environ, clean_env, clear=True):
         noop()
 
-    assert bench.get_results(format='df')['loaded_modules'][0] == {}
+    assert bench.get_results()[0]['loaded_modules'] == {}
 
 
 def test_mb_loaded_modules_no_version():
@@ -130,7 +128,7 @@ def test_mb_loaded_modules_no_version():
     with patch.dict(os.environ, {'LOADEDMODULES': 'null:gcc/12.2.0'}, clear=False):
         noop()
 
-    modules = bench.get_results(format='df')['loaded_modules'][0]
+    modules = bench.get_results()[0]['loaded_modules']
     assert modules['null'] == ''
     assert modules['gcc'] == '12.2.0'
 
@@ -155,7 +153,7 @@ def test_mb_loaded_modules_version_with_slash():
     ):
         noop()
 
-    modules = bench.get_results(format='df')['loaded_modules'][0]
+    modules = bench.get_results()[0]['loaded_modules']
     assert modules['GCC'] == '12.2.0-GCCcore-12.2.0'
 
 
@@ -174,7 +172,7 @@ def test_mb_working_dir():
     noop()
 
     result = bench.get_results()[0]
-    assert result['working_dir'] == os.getcwd()
+    assert result['call']['working_dir'] == os.getcwd()
 
 
 def test_capture_global_packages():
@@ -184,12 +182,14 @@ def test_capture_global_packages():
 
     noop()
 
-    results = globals_bench.get_results(format='df')
+    results = globals_bench.get_results()
 
     # We should've captured microbench and pandas versions from top level
     # imports in this file
-    assert results['package_versions'][0]['microbench'] == str(microbench_version)
-    assert results['package_versions'][0]['pandas'] == pandas.__version__
+    assert results[0]['python']['loaded_packages']['microbench'] == str(
+        microbench_version
+    )
+    assert results[0]['python']['loaded_packages']['pandas'] == pandas.__version__
 
 
 def test_capture_packages_importlib():
@@ -204,8 +204,8 @@ def test_capture_packages_importlib():
 
     noop()
 
-    results = pkg_bench.get_results(format='df')
-    assert pandas.__version__ == results['package_versions'][0]['pandas']
+    results = pkg_bench.get_results()
+    assert pandas.__version__ == results[0]['python']['installed_packages']['pandas']
 
 
 def test_capture_packages_self_imports_metadata():
@@ -229,9 +229,9 @@ def test_capture_packages_self_imports_metadata():
 
         noop()
 
-        results = bench.get_results(format='df')
-        assert isinstance(results['package_versions'][0], dict)
-        assert len(results['package_versions'][0]) > 0
+        results = bench.get_results()
+        assert isinstance(results[0]['python']['installed_packages'], dict)
+        assert len(results[0]['python']['installed_packages']) > 0
     finally:
         if saved is not None:
             sys.modules['importlib.metadata'] = saved
@@ -249,8 +249,8 @@ def test_mb_peak_memory():
 
     allocate()
 
-    results = bench.get_results(format='df')
-    assert results['peak_memory_bytes'][0] > 0
+    results = bench.get_results()
+    assert results[0]['call']['peak_memory_bytes'] > 0
 
 
 def test_mb_peak_memory_stops_tracemalloc():
@@ -292,8 +292,8 @@ def test_mb_peak_memory_preserves_existing_trace():
         noop()
 
         assert tracemalloc.is_tracing()
-        results = bench.get_results(format='df')
-        assert 'peak_memory_bytes' in results.columns
+        results = bench.get_results()
+        assert 'peak_memory_bytes' in results[0]['call']
     finally:
         tracemalloc.stop()
 
@@ -338,11 +338,11 @@ def test_mb_git_info():
     with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_CLEAN)):
         noop()
 
-    git_info = bench.get_results(format='df')['git_info'][0]
-    assert git_info['repo'] == '/home/user/project'
-    assert git_info['commit'] == 'abc123def456abc123def456abc123def456abc1'
-    assert git_info['branch'] == 'main'
-    assert git_info['dirty'] is False
+    git = bench.get_results()[0]['git']
+    assert git['repo'] == '/home/user/project'
+    assert git['commit'] == 'abc123def456abc123def456abc123def456abc1'
+    assert git['branch'] == 'main'
+    assert git['dirty'] is False
 
 
 def test_mb_git_info_dirty():
@@ -360,7 +360,7 @@ def test_mb_git_info_dirty():
     with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_DIRTY)):
         noop()
 
-    assert bench.get_results(format='df')['git_info'][0]['dirty'] is True
+    assert bench.get_results()[0]['git']['dirty'] is True
 
 
 def test_mb_git_info_detached_head():
@@ -378,7 +378,7 @@ def test_mb_git_info_detached_head():
     with patch('subprocess.check_output', side_effect=_git_mock(_GIT_STATUS_DETACHED)):
         noop()
 
-    assert bench.get_results(format='df')['git_info'][0]['branch'] == ''
+    assert bench.get_results()[0]['git']['branch'] == ''
 
 
 def test_mb_git_info_no_git_raises():
@@ -661,7 +661,7 @@ def test_cgroup_limits_non_linux():
     with patch('sys.platform', 'win32'):
         noop()
 
-    assert bench.get_results(format='df')['cgroup_limits'][0] == {}
+    assert bench.get_results()[0].get('cgroups', {}) == {}
 
 
 def test_cgroup_limits_v2_limited():
@@ -695,10 +695,10 @@ def test_cgroup_limits_v2_limited():
     ):
         noop()
 
-    result = bench.get_results(format='df')['cgroup_limits'][0]
-    assert result['cpu_cores'] == 4.0
-    assert result['memory_bytes'] == 17179869184
-    assert result['cgroup_version'] == 2
+    result = bench.get_results()[0]['cgroups']
+    assert result['cpu_cores_limit'] == 4.0
+    assert result['memory_bytes_limit'] == 17179869184
+    assert result['version'] == 2
 
 
 def test_cgroup_limits_v2_unlimited():
@@ -732,10 +732,10 @@ def test_cgroup_limits_v2_unlimited():
     ):
         noop()
 
-    result = bench.get_results(format='df')['cgroup_limits'][0]
-    assert result['cpu_cores'] is None
-    assert result['memory_bytes'] is None
-    assert result['cgroup_version'] == 2
+    result = bench.get_results()[0]['cgroups']
+    assert result['cpu_cores_limit'] is None
+    assert result['memory_bytes_limit'] is None
+    assert result['version'] == 2
 
 
 def test_cgroup_limits_v1_limited():
@@ -771,14 +771,14 @@ def test_cgroup_limits_v1_limited():
     ):
         noop()
 
-    result = bench.get_results(format='df')['cgroup_limits'][0]
-    assert result['cpu_cores'] == 2.0
-    assert result['memory_bytes'] == 8589934592
-    assert result['cgroup_version'] == 1
+    result = bench.get_results()[0]['cgroups']
+    assert result['cpu_cores_limit'] == 2.0
+    assert result['memory_bytes_limit'] == 8589934592
+    assert result['version'] == 1
 
 
 def test_cgroup_limits_v1_unlimited_cpu():
-    """cgroup v1: quota -1 means unlimited CPU; cpu_cores is None."""
+    """cgroup v1: quota -1 means unlimited CPU; cpu_cores_limit is None."""
 
     class Bench(MicroBench, MBCgroupLimits):
         pass
@@ -810,10 +810,10 @@ def test_cgroup_limits_v1_unlimited_cpu():
     ):
         noop()
 
-    result = bench.get_results(format='df')['cgroup_limits'][0]
-    assert result['cpu_cores'] is None
-    assert result['memory_bytes'] == 4294967296
-    assert result['cgroup_version'] == 1
+    result = bench.get_results()[0]['cgroups']
+    assert result['cpu_cores_limit'] is None
+    assert result['memory_bytes_limit'] == 4294967296
+    assert result['version'] == 1
 
 
 def test_cgroup_limits_unavailable():
@@ -835,4 +835,4 @@ def test_cgroup_limits_unavailable():
     ):
         noop()
 
-    assert bench.get_results(format='df')['cgroup_limits'][0] == {}
+    assert bench.get_results()[0].get('cgroups', {}) == {}

--- a/microbench/tests/test_nvidia.py
+++ b/microbench/tests/test_nvidia.py
@@ -29,9 +29,11 @@ def test_nvidia():
 
     test()
 
-    results = bench.get_results(format='df')
-    assert 'nvidia_gpu_name' in results.columns
-    assert 'nvidia_memory.total' in results.columns
+    results = bench.get_results()
+    assert 'nvidia' in results[0]
+    assert len(results[0]['nvidia']) > 0
+    assert 'gpu_name' in results[0]['nvidia'][0]
+    assert 'memory.total' in results[0]['nvidia'][0]
 
 
 def test_nvidia_custom_attributes():
@@ -49,8 +51,9 @@ def test_nvidia_custom_attributes():
     with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_SMI_OUTPUT):
         noop()
 
-    results = bench.get_results(format='df')
-    assert 'nvidia_gpu_name' in results.columns
+    results = bench.get_results()
+    assert 'nvidia' in results[0]
+    assert results[0]['nvidia'][0]['gpu_name'] == 'Tesla T4'
 
 
 def test_nvidia_gpus_empty_raises():

--- a/microbench/tests/test_output.py
+++ b/microbench/tests/test_output.py
@@ -5,7 +5,6 @@ import warnings
 from unittest.mock import MagicMock, patch
 
 import numpy
-import pandas
 import pytest
 
 from microbench import (
@@ -87,8 +86,8 @@ def test_outfile_string_path():
         noop()
 
         assert os.path.getsize(tmppath) > 0
-        results = pandas.read_json(tmppath, lines=True)
-        assert results['function_name'][0] == 'noop'
+        results = bench.get_results()
+        assert results[0]['call']['name'] == 'noop'
     finally:
         os.unlink(tmppath)
 
@@ -109,7 +108,7 @@ def test_get_results_without_pandas():
         # Default format='dict' works without pandas
         results = bench.get_results()
         assert isinstance(results, list)
-        assert results[0]['function_name'] == 'noop'
+        assert results[0]['call']['name'] == 'noop'
 
         # format='df' raises ImportError
         with pytest.raises(ImportError, match='pandas'):
@@ -139,9 +138,9 @@ def test_multi_sink_output():
     noop()
 
     assert len(sink_a.records) == 2
-    results = sink_b.get_results(format='df')
+    results = sink_b.get_results()
     assert len(results) == 2
-    assert (results['function_name'] == 'noop').all()
+    assert all(r['call']['name'] == 'noop' for r in results)
 
 
 def test_output_base_get_results_raises():
@@ -195,10 +194,10 @@ def test_redis_output_get_results():
 
         noop()
 
-        results = bench.get_results(format='df')
-        assert results['function_name'][0] == 'noop'
-        assert 'start_time' in results.columns
-        assert 'finish_time' in results.columns
+        results = bench.get_results()
+        assert results[0]['call']['name'] == 'noop'
+        assert 'start_time' in results[0]['call']
+        assert 'finish_time' in results[0]['call']
 
         mock_redis_client.rpush.assert_called_once()
         assert mock_redis_client.rpush.call_args[0][0] == 'test:bench'
@@ -238,9 +237,9 @@ def test_redis_output_multiple_results():
         func_a()
         func_b()
 
-        results = bench.get_results(format='df')
+        results = bench.get_results()
         assert len(results) == 2
-        assert list(results['function_name']) == ['func_a', 'func_b']
+        assert [r['call']['name'] for r in results] == ['func_a', 'func_b']
 
 
 def test_unjsonencodable_arg_kwarg_retval():
@@ -262,10 +261,10 @@ def test_unjsonencodable_arg_kwarg_retval():
         assert len(w) == 3
         assert all(issubclass(w_.category, JSONEncodeWarning) for w_ in w)
 
-    results = bench.get_results(format='df')
-    assert results['args'][0] == [_UNENCODABLE_PLACEHOLDER_VALUE]
-    assert results['kwargs'][0] == {'arg2': _UNENCODABLE_PLACEHOLDER_VALUE}
-    assert results['return_value'][0] == _UNENCODABLE_PLACEHOLDER_VALUE
+    results = bench.get_results()
+    assert results[0]['call']['args'] == [_UNENCODABLE_PLACEHOLDER_VALUE]
+    assert results[0]['call']['kwargs'] == {'arg2': _UNENCODABLE_PLACEHOLDER_VALUE}
+    assert results[0]['call']['return_value'] == _UNENCODABLE_PLACEHOLDER_VALUE
 
 
 def test_custom_jsonencoder():
@@ -300,8 +299,8 @@ def test_custom_jsonencoder():
 
     dummy()
 
-    results = bench.get_results(format='df')
-    assert results['return_value'][0] == str(obj)
+    results = bench.get_results()
+    assert results[0]['call']['return_value'] == str(obj)
 
 
 def test_jsonencoder_numpy_types():
@@ -341,7 +340,7 @@ def test_get_results_default_returns_list_of_dicts():
     assert isinstance(results, list)
     assert len(results) == 2
     assert all(isinstance(r, dict) for r in results)
-    assert results[0]['function_name'] == 'noop'
+    assert results[0]['call']['name'] == 'noop'
 
 
 def test_get_results_format_df_returns_dataframe():
@@ -356,7 +355,7 @@ def test_get_results_format_df_returns_dataframe():
 
     results = bench.get_results(format='df')
     assert hasattr(results, 'columns')  # DataFrame duck-type check
-    assert results['function_name'][0] == 'noop'
+    assert results['call'][0]['name'] == 'noop'
 
 
 def test_get_results_invalid_format_raises():
@@ -442,7 +441,7 @@ def test_get_results_flat_df():
 
 
 def test_summary_function_prints(capsys):
-    """summary() prints min/mean/median/max/stdev of run_durations."""
+    """summary() prints min/mean/median/max/stdev of call.durations."""
     bench = MicroBench()
 
     @bench
@@ -463,15 +462,15 @@ def test_summary_function_prints(capsys):
 
 
 def test_summary_function_no_results(capsys):
-    """summary() prints a message when there are no run_durations."""
-    summary([{'function_name': 'noop'}])
+    """summary() prints a message when there are no call.durations."""
+    summary([{'call': {'name': 'noop'}}])
     out = capsys.readouterr().out
-    assert 'No run_durations' in out
+    assert 'No' in out
 
 
 def test_summary_single_result_no_stdev(capsys):
     """summary() prints nan for stdev when there is only one duration."""
-    summary([{'run_durations': [0.5]}])
+    summary([{'call': {'durations': [0.5]}}])
     out = capsys.readouterr().out
     assert 'n=1' in out
     assert 'stdev=nan' in out

--- a/microbench/tests/test_psutil.py
+++ b/microbench/tests/test_psutil.py
@@ -17,15 +17,16 @@ def test_psutil():
 
     test_func()
 
-    results = mybench.get_results(format='df')
+    results = mybench.get_results()
+    host = results[0]['host']
     # psutil.cpu_count(logical=True) can return None on some platforms
     # (e.g. macOS with psutil 7.x), so check that at least one is set
-    logical = results['cpu_cores_logical'][0]
-    physical = results['cpu_cores_physical'][0]
+    logical = host['cpu_cores_logical']
+    physical = host['cpu_cores_physical']
     assert (logical is not None and logical >= 1) or (
         physical is not None and physical >= 1
     ), f'Expected at least one core count, got logical={logical}, physical={physical}'
-    assert results['ram_total'][0] > 0
+    assert host['ram_total'] > 0
 
 
 def test_psutil_missing_raises():


### PR DESCRIPTION
## Summary

- Introduces a consistent namespace structure for all benchmark record fields as a 2.0.0 breaking change
- `mb.*` for static config (run_id, version, timezone, duration_counter); `call.*` for all per-call data; `host.*`, `python.*`, `git`, `cgroups`, `nvidia` (list), `env.*` for mixin data
- Updates all source files, tests, and docs to use the new field names; see CHANGELOG for the complete rename table

## Breaking changes

See [CHANGELOG.md](CHANGELOG.md) for the full field rename table. Key changes:

| Old | New |
|---|---|
| `mb_run_id`, `mb_version` | `mb.run_id`, `mb.version` |
| `start_time`, `finish_time` | `call.start_time`, `call.finish_time` |
| `run_durations` | `call.durations` |
| `function_name` | `call.name` |
| `hostname`, `operating_system` | `host.hostname`, `host.os` |
| `cpu_cores_logical/physical` | `host.cpu_cores_logical/physical` |
| `package_versions` | `python.loaded_packages` / `python.installed_packages` |
| `git_info` | `git` |
| `cgroup_limits` | `cgroups` (inner keys renamed too) |
| `nvidia_<attr>` flat keys | `nvidia` list of per-GPU dicts |
| `env_<NAME>` | `env.<NAME>` |
| `mb_capture_errors` | `call.capture_errors` |
| `mb_timings` | `call.timings` |
| CLI `command`, `returncode` | `call.command`, `call.returncode` |