### PR TITLE
feat: merge MBHostCpuCores and MBHostRamTotal into MBHostInfo

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -143,14 +143,16 @@ A typical SLURM job script:
 
 microbench \
     --outfile /scratch/$USER/results.jsonl \
-    --mixin host-info slurm-info host-cpu-cores \
+    --mixin host-info slurm-info \
     --field experiment=baseline \
     -- ./run_simulation.sh --steps 10000
 ```
 
 Each node that runs this job appends one JSONL record to `results.jsonl`,
-capturing hostname, CPU count, and all SLURM variables (job ID, array task
-ID, node list, etc.) alongside the wall-clock time of the simulation.
+capturing hostname, OS, CPU count, RAM, and all SLURM variables (job ID, array
+task ID, node list, etc.) alongside the wall-clock time of the simulation.
+CPU and RAM fields are included automatically by `host-info` when psutil is
+installed.
 
 Read the results with pandas:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Some mixins have optional requirements:
 
 | Mixin / feature | Requires |
 |---|---|
-| `MBHostCpuCores`, `MBHostRamTotal`, periodic monitoring | [psutil](https://pypi.org/project/psutil/) |
+| `MBHostInfo` (cpu/ram fields), periodic monitoring | [psutil](https://pypi.org/project/psutil/) |
 | `MBLineProfiler` | [line_profiler](https://github.com/rkern/line_profiler) |
 | `MBNvidiaSmi` | `nvidia-smi` on `PATH` (ships with NVIDIA drivers) |
 | `MBCondaPackages` | `conda` on `PATH` |

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -4,9 +4,9 @@ Mixins are classes that add metadata capture to a benchmark suite via
 multiple inheritance. Combine any number of mixins with `MicroBench`:
 
 ```python
-from microbench import MicroBench, MBHostInfo, MBHostCpuCores
+from microbench import MicroBench, MBHostInfo
 
-class MyBench(MicroBench, MBHostInfo, MBHostCpuCores):
+class MyBench(MicroBench, MBHostInfo):
     pass
 ```
 
@@ -30,9 +30,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBReturnValue` | `call.return_value` | — |
 | `MBPythonInfo` | `python.version`, `python.prefix`, `python.executable` — **included in `MicroBench` by default** | — |
 | `MBPythonVersion` | `python_version`, `python_executable` — *deprecated, use `MBPythonInfo`* | — |
-| `MBHostInfo` | `host.hostname`, `host.os` | — |
-| `MBHostCpuCores` | `host.cpu_cores_logical`, `host.cpu_cores_physical` | psutil |
-| `MBHostRamTotal` | `host.ram_total` (bytes) | psutil |
+| `MBHostInfo` | `host.hostname`, `host.os`; also `host.cpu_cores_logical`, `host.cpu_cores_physical`, `host.ram_total` (bytes) when psutil is installed (silently omitted otherwise) | psutil (optional) |
 | `MBPeakMemory` | `call.peak_memory_bytes` | — |
 | `MBSlurmInfo` | `slurm` dict of all `SLURM_*` env vars (empty dict if not in a SLURM job) | — |
 | `MBLoadedModules` | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
@@ -96,19 +94,27 @@ custom types.
 
 ## Host resources
 
-### `MBHostCpuCores` and `MBHostRamTotal`
+### `MBHostInfo`
 
-Capture static host hardware information. Requires
-[psutil](https://pypi.org/project/psutil/).
+Captures hostname, operating system, and (when [psutil](https://pypi.org/project/psutil/)
+is installed) CPU core counts and total RAM.
 
 ```python
-from microbench import MicroBench, MBHostCpuCores, MBHostRamTotal
+from microbench import MicroBench, MBHostInfo
 
-class Bench(MicroBench, MBHostCpuCores, MBHostRamTotal):
+class Bench(MicroBench, MBHostInfo):
     pass
 ```
 
-Fields: `host.cpu_cores_logical`, `host.cpu_cores_physical`, `host.ram_total` (bytes).
+Always-present fields: `host.hostname`, `host.os`.
+
+Fields added when psutil is installed (silently omitted otherwise):
+`host.cpu_cores_logical`, `host.cpu_cores_physical`, `host.ram_total` (bytes).
+
+!!! note
+    `MBHostCpuCores` and `MBHostRamTotal` are deprecated. `MBHostInfo` now
+    covers all three mixins. The separate classes still work but emit a
+    `DeprecationWarning` at call time.
 
 ## Job resource utilisation
 
@@ -257,8 +263,7 @@ distinguished. Included in the CLI defaults.
 
 Captures the CPU quota and memory limit enforced by the Linux control groups
 (cgroups). Works for SLURM jobs and Kubernetes pods, on both cgroup v1 and
-cgroup v2 systems, with no external dependencies. Unlike `MBHostCpuCores` and
-`MBHostRamTotal` (which report the physical node's total resources),
+cgroup v2 systems, with no external dependencies. Unlike `MBHostInfo` (which reports the physical node's total resources),
 `MBCgroupLimits` reports what the scheduler actually allocated to this job or
 container — the number that determines your benchmark's resource budget.
 

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -192,9 +192,16 @@ class MBPythonInfo:
 
 
 class MBHostInfo:
-    """Capture the hostname and operating system.
+    """Capture hostname, operating system, and (optionally) CPU and RAM info.
 
-    Results are stored in the ``host`` dict with keys ``hostname`` and ``os``.
+    Always records ``host.hostname`` and ``host.os`` using only the standard
+    library. When `psutil <https://pypi.org/project/psutil/>`_ is installed,
+    also records ``host.cpu_cores_logical``, ``host.cpu_cores_physical``, and
+    ``host.ram_total`` (bytes). The psutil fields are silently omitted when
+    psutil is not available — no error or warning is raised.
+
+    This mixin supersedes the separate :class:`MBHostCpuCores` and
+    :class:`MBHostRamTotal` mixins, which are deprecated.
     """
 
     cli_compatible = True
@@ -204,6 +211,18 @@ class MBHostInfo:
 
     def capture_os(self, bm_data):
         bm_data.setdefault('host', {})['os'] = sys.platform
+
+    def capture_cpu_cores(self, bm_data):
+        if psutil is None:
+            return
+        host = bm_data.setdefault('host', {})
+        host['cpu_cores_logical'] = psutil.cpu_count(logical=True)
+        host['cpu_cores_physical'] = psutil.cpu_count(logical=False)
+
+    def capture_ram_total(self, bm_data):
+        if psutil is None:
+            return
+        bm_data.setdefault('host', {})['ram_total'] = psutil.virtual_memory().total
 
 
 _microbench_dir = os.path.dirname(os.path.abspath(__file__))
@@ -766,32 +785,55 @@ class _NeedsPsUtil:
             raise ImportError('psutil library needed')
 
 
-class MBHostCpuCores(_NeedsPsUtil):
+class MBHostCpuCores:
     """Capture the number of logical and physical CPU cores.
 
-    Results are stored in the ``host`` dict under ``cpu_cores_logical``
-    and ``cpu_cores_physical``.
+    .. deprecated::
+        Use :class:`MBHostInfo` instead. ``MBHostInfo`` now captures
+        ``host.cpu_cores_logical`` and ``host.cpu_cores_physical`` automatically
+        when psutil is available. ``MBHostCpuCores`` will be removed in a
+        future release.
     """
 
     cli_compatible = True
 
     def capture_cpu_cores(self, bm_data):
-        self._check_psutil()
+        warnings.warn(
+            'MBHostCpuCores is deprecated and will be removed in a future '
+            'release. Use MBHostInfo instead, which now captures '
+            'host.cpu_cores_logical and host.cpu_cores_physical when psutil '
+            'is available.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if psutil is None:
+            return
         host = bm_data.setdefault('host', {})
         host['cpu_cores_logical'] = psutil.cpu_count(logical=True)
         host['cpu_cores_physical'] = psutil.cpu_count(logical=False)
 
 
-class MBHostRamTotal(_NeedsPsUtil):
+class MBHostRamTotal:
     """Capture the total host RAM in bytes.
 
-    Result is stored in ``host.ram_total``.
+    .. deprecated::
+        Use :class:`MBHostInfo` instead. ``MBHostInfo`` now captures
+        ``host.ram_total`` automatically when psutil is available.
+        ``MBHostRamTotal`` will be removed in a future release.
     """
 
     cli_compatible = True
 
     def capture_total_ram(self, bm_data):
-        self._check_psutil()
+        warnings.warn(
+            'MBHostRamTotal is deprecated and will be removed in a future '
+            'release. Use MBHostInfo instead, which now captures '
+            'host.ram_total when psutil is available.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if psutil is None:
+            return
         bm_data.setdefault('host', {})['ram_total'] = psutil.virtual_memory().total
 
 

--- a/microbench/tests/test_psutil.py
+++ b/microbench/tests/test_psutil.py
@@ -1,12 +1,14 @@
+import warnings
 from unittest.mock import patch
 
-import pytest
+import microbench.mixins
+from microbench import MBHostCpuCores, MBHostInfo, MBHostRamTotal, MicroBench
 
-from microbench import MBHostCpuCores, MBHostRamTotal, MicroBench
 
+def test_mbhostinfo_with_psutil():
+    """MBHostInfo captures all five host fields when psutil is available."""
 
-def test_psutil():
-    class MyBench(MicroBench, MBHostCpuCores, MBHostRamTotal):
+    class MyBench(MicroBench, MBHostInfo):
         pass
 
     mybench = MyBench()
@@ -17,23 +19,79 @@ def test_psutil():
 
     test_func()
 
-    results = mybench.get_results()
-    host = results[0]['host']
-    # psutil.cpu_count(logical=True) can return None on some platforms
-    # (e.g. macOS with psutil 7.x), so check that at least one is set
+    host = mybench.get_results()[0]['host']
+    assert host['hostname']
+    assert host['os']
     logical = host['cpu_cores_logical']
     physical = host['cpu_cores_physical']
+    # psutil.cpu_count(logical=True) can return None on some platforms
+    # (e.g. macOS with psutil 7.x), so check at least one is non-None
     assert (logical is not None and logical >= 1) or (
         physical is not None and physical >= 1
     ), f'Expected at least one core count, got logical={logical}, physical={physical}'
     assert host['ram_total'] > 0
 
 
-def test_psutil_missing_raises():
-    """_NeedsPsUtil._check_psutil raises ImportError when psutil is unavailable."""
-    import microbench.mixins
-    from microbench.mixins import _NeedsPsUtil
+def test_mbhostinfo_without_psutil():
+    """MBHostInfo silently omits psutil fields when psutil is unavailable."""
+
+    class MyBench(MicroBench, MBHostInfo):
+        pass
+
+    mybench = MyBench()
+
+    @mybench
+    def test_func():
+        pass
 
     with patch.object(microbench.mixins, 'psutil', None):
-        with pytest.raises(ImportError, match='psutil'):
-            _NeedsPsUtil._check_psutil()
+        test_func()
+
+    host = mybench.get_results()[0]['host']
+    assert host['hostname']
+    assert host['os']
+    assert 'cpu_cores_logical' not in host
+    assert 'cpu_cores_physical' not in host
+    assert 'ram_total' not in host
+
+
+def test_mbhostcpucores_deprecated():
+    """MBHostCpuCores emits DeprecationWarning and still records the fields."""
+
+    class MyBench(MicroBench, MBHostCpuCores):
+        pass
+
+    mybench = MyBench()
+
+    @mybench
+    def test_func():
+        pass
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        test_func()
+
+    assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+    host = mybench.get_results()[0]['host']
+    assert 'cpu_cores_logical' in host
+    assert 'cpu_cores_physical' in host
+
+
+def test_mbhostramtotal_deprecated():
+    """MBHostRamTotal emits DeprecationWarning and still records ram_total."""
+
+    class MyBench(MicroBench, MBHostRamTotal):
+        pass
+
+    mybench = MyBench()
+
+    @mybench
+    def test_func():
+        pass
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        test_func()
+
+    assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+    assert mybench.get_results()[0]['host']['ram_total'] > 0


### PR DESCRIPTION
## Summary

- `MBHostInfo` now captures `host.cpu_cores_logical`, `host.cpu_cores_physical`, and `host.ram_total` when psutil is installed; silently omits them otherwise (no error, no `call.capture_errors` noise)
- `MBHostCpuCores` and `MBHostRamTotal` are deprecated — they still work and produce the same fields, but emit `DeprecationWarning` at call time
- CLI SLURM example simplified: `--mixin host-info slurm-info host-cpu-cores` → `--mixin host-info slurm-info`
- Requirements table in docs updated