### PR TITLE
feat: add --timeout and --timeout-grace-period to CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ microbench [options] -- COMMAND [ARGS...]
 | `--stdout[=suppress]` | Capture stdout into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--stderr[=suppress]` | Capture stderr into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--timeout SECONDS` | Send SIGTERM to the command after SECONDS seconds per iteration. If the process has not exited after an additional grace period (default 5 s, see `--timeout-grace-period`), send SIGKILL. Timed-out iterations are recorded with `call.timed_out = true`. |
-| `--timeout-grace-period SECONDS` | Seconds to wait after SIGTERM before sending SIGKILL. Only relevant when `--timeout` is set. Default: 5. |
+| `--timeout-grace-period SECONDS` | Seconds to wait after SIGTERM before sending SIGKILL. Requires `--timeout`. Default: 5. |
 | `--monitor-interval SECONDS` | Sample the child process CPU usage and RSS memory every SECONDS seconds. Requires `psutil`. See [Subprocess monitoring](#subprocess-monitoring) below. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,8 @@ microbench [options] -- COMMAND [ARGS...]
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
 | `--stdout[=suppress]` | Capture stdout into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--stderr[=suppress]` | Capture stderr into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
+| `--timeout SECONDS` | Send SIGTERM to the command after SECONDS seconds per iteration. If the process has not exited after an additional grace period (default 5 s, see `--timeout-grace-period`), send SIGKILL. Timed-out iterations are recorded with `call.timed_out = true`. |
+| `--timeout-grace-period SECONDS` | Seconds to wait after SIGTERM before sending SIGKILL. Only relevant when `--timeout` is set. Default: 5. |
 | `--monitor-interval SECONDS` | Sample the child process CPU usage and RSS memory every SECONDS seconds. Requires `psutil`. See [Subprocess monitoring](#subprocess-monitoring) below. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 
@@ -45,6 +47,7 @@ Every record contains the standard `mb.*` and `call.*` fields plus:
 | `call.name` | Basename of the executable, e.g. `"run_sim.sh"`. |
 | `call.command` | Full command as a list, e.g. `["./run_sim.sh", "--steps", "1000"]`. |
 | `call.returncode` | List of exit codes, one per timed iteration (warmup excluded). The process exits with the highest value. |
+| `call.timed_out` | *(present only when `--timeout` fires)* `true` when at least one timed iteration was killed due to the timeout. Absent on normal completion. |
 | `call.monitor` | *(present only with `--monitor-interval`)* List of per-iteration sample lists. See [Subprocess monitoring](#subprocess-monitoring). |
 
 ## Default mixins
@@ -205,6 +208,33 @@ To detect failed iterations when analysing results with pandas (using `flat=True
 ```python
 df['any_failed'] = df['call.returncode'].apply(lambda rc: max(rc) != 0)
 ```
+
+## Timeout
+
+Use `--timeout SECONDS` to limit how long each iteration is allowed to run:
+
+```bash
+microbench --timeout 120 -- ./run_simulation.sh
+```
+
+After `SECONDS` seconds, microbench sends **SIGTERM** to the process. If the
+process has not exited after an additional grace period (default 5 s), **SIGKILL**
+is sent. The SIGTERM window gives well-behaved processes a chance to flush output
+and write partial results before being force-killed. Use `--timeout-grace-period`
+to adjust the gap between SIGTERM and SIGKILL:
+
+```bash
+microbench --timeout 120 --timeout-grace-period 30 -- ./run_simulation.sh
+```
+
+The record is always written, even for timed-out iterations. Detect timeouts in
+analysis with:
+
+```python
+df['any_timed_out'] = df['call.timed_out'].notna()
+```
+
+The `call.returncode` for a SIGTERM-killed process will be `-15`; for SIGKILL, `-9`.
 
 ## Extra metadata
 

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -47,6 +47,9 @@ _DEFAULT_MIXINS = (
 
 _CAPTURE_CHOICES = ('capture', 'suppress')
 
+# Seconds to wait after SIGTERM before sending SIGKILL on timeout.
+_SIGTERM_GRACE_PERIOD = 5
+
 
 def _make_mixin_type(mixin_map):
     """Return an argparse type function that normalises and validates mixin names."""
@@ -126,6 +129,17 @@ class _SubprocessMonitorThread(threading.Thread):
                     break
         except psutil.NoSuchProcess:
             pass
+
+
+def _positive_float(value):
+    """Return an argparse type function that accepts positive floats."""
+    try:
+        fvalue = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f'{value!r} is not a number')
+    if fvalue <= 0:
+        raise argparse.ArgumentTypeError(f'must be > 0, got {fvalue}')
+    return fvalue
 
 
 def _int_at_least(minimum):
@@ -253,6 +267,29 @@ def _build_parser(mixin_map):
         ),
     )
     parser.add_argument(
+        '--timeout',
+        type=_positive_float,
+        default=None,
+        metavar='SECONDS',
+        help=(
+            'Send SIGTERM to the command after SECONDS seconds per iteration. '
+            'If the process has not exited after an additional grace period '
+            f'(default {_SIGTERM_GRACE_PERIOD}s, see --timeout-grace-period), '
+            'sends SIGKILL. '
+            'Timed-out iterations are recorded with call.timed_out = true.'
+        ),
+    )
+    parser.add_argument(
+        '--timeout-grace-period',
+        type=_positive_float,
+        default=_SIGTERM_GRACE_PERIOD,
+        metavar='SECONDS',
+        help=(
+            f'Seconds to wait after SIGTERM before sending SIGKILL. '
+            f'Only relevant when --timeout is used. Default: {_SIGTERM_GRACE_PERIOD}.'
+        ),
+    )
+    parser.add_argument(
         '--field',
         '-f',
         action='append',
@@ -350,6 +387,7 @@ def main(argv=None):
             self._subprocess_stdout = []
             self._subprocess_stderr = []
             self._subprocess_monitor = []
+            self._subprocess_timed_out = False
             self._subprocess_timed_phase = True
 
         def capturepost_subprocess_result(self, bm_data):
@@ -357,6 +395,8 @@ def main(argv=None):
             call['invocation'] = 'CLI'
             call['command'] = self._subprocess_command
             call['returncode'] = self._subprocess_returncodes
+            if self._subprocess_timed_out:
+                call['timed_out'] = True
             if self._subprocess_stdout:
                 call['stdout'] = self._subprocess_stdout
             if self._subprocess_stderr:
@@ -399,6 +439,7 @@ def main(argv=None):
     bench._subprocess_stdout = []
     bench._subprocess_stderr = []
     bench._subprocess_monitor = []
+    bench._subprocess_timed_out = False
     bench._subprocess_timed_phase = False  # becomes True after warmup
 
     # Hold references to the real streams before any patching in tests.
@@ -409,8 +450,14 @@ def main(argv=None):
         capture_stdout = args.stdout in _CAPTURE_CHOICES
         capture_stderr = args.stderr in _CAPTURE_CHOICES
         monitor_interval = args.monitor_interval
+        timeout = args.timeout
 
-        if not capture_stdout and not capture_stderr and monitor_interval is None:
+        if (
+            not capture_stdout
+            and not capture_stderr
+            and monitor_interval is None
+            and timeout is None
+        ):
             result = subprocess.run(cmd)
             bench._subprocess_returncodes.append(result.returncode)
             return
@@ -468,7 +515,17 @@ def main(argv=None):
                 monitor_thread = _SubprocessMonitorThread(proc.pid, monitor_interval)
                 monitor_thread.start()
 
-            proc.wait()
+            timed_out = False
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                proc.terminate()
+                try:
+                    proc.wait(timeout=args.timeout_grace_period)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
 
             if monitor_thread is not None:
                 monitor_thread.stop()
@@ -478,6 +535,8 @@ def main(argv=None):
             for t in threads:
                 t.join()
 
+        if timed_out and bench._subprocess_timed_phase:
+            bench._subprocess_timed_out = True
         bench._subprocess_returncodes.append(proc.returncode)
         if capture_stdout:
             bench._subprocess_stdout.append(''.join(stdout_chunks))

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -282,11 +282,11 @@ def _build_parser(mixin_map):
     parser.add_argument(
         '--timeout-grace-period',
         type=_positive_float,
-        default=_SIGTERM_GRACE_PERIOD,
+        default=None,
         metavar='SECONDS',
         help=(
             f'Seconds to wait after SIGTERM before sending SIGKILL. '
-            f'Only relevant when --timeout is used. Default: {_SIGTERM_GRACE_PERIOD}.'
+            f'Requires --timeout. Default: {_SIGTERM_GRACE_PERIOD}.'
         ),
     )
     parser.add_argument(
@@ -370,6 +370,9 @@ def main(argv=None):
             parser.error(f'Invalid --field: {field!r}. Use KEY=VALUE.')
         k, v = field.split('=', 1)
         extra_fields[k] = v
+
+    if args.timeout_grace_period is not None and args.timeout is None:
+        parser.error('--timeout-grace-period requires --timeout.')
 
     if args.monitor_interval is not None:
         try:
@@ -522,7 +525,8 @@ def main(argv=None):
                 timed_out = True
                 proc.terminate()
                 try:
-                    proc.wait(timeout=args.timeout_grace_period)
+                    grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
+                    proc.wait(timeout=grace)
                 except subprocess.TimeoutExpired:
                     proc.kill()
                     proc.wait()

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -861,6 +861,13 @@ def test_cli_hash_algorithm(tmp_path):
     assert sha256_hex != md5_hex
 
 
+def test_cli_timeout_grace_period_requires_timeout():
+    """--timeout-grace-period without --timeout is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--timeout-grace-period', '10', '--', 'sleep', '1'])
+    assert exc.value.code != 0
+
+
 def test_cli_timeout_not_exceeded():
     """--timeout that does not fire produces a normal record with no timed_out field."""
     mock_proc = _make_mock_popen()

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -861,6 +861,65 @@ def test_cli_hash_algorithm(tmp_path):
     assert sha256_hex != md5_hex
 
 
+def test_cli_timeout_not_exceeded():
+    """--timeout that does not fire produces a normal record with no timed_out field."""
+    mock_proc = _make_mock_popen()
+    mock_proc.returncode = 0
+
+    buf = io.StringIO()
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit) as exc:
+                main(['--no-mixin', '--timeout', '30', '--', 'sleep', '1'])
+    assert exc.value.code == 0
+    record = json.loads(buf.getvalue())
+    assert 'timed_out' not in record['call']
+    assert record['call']['returncode'] == [0]
+
+
+def test_cli_timeout_sigterm_sufficient():
+    """--timeout: process exits after SIGTERM; SIGKILL is not sent."""
+    mock_proc = _make_mock_popen()
+    mock_proc.returncode = -15  # killed by SIGTERM
+    mock_proc.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # main timeout
+        None,  # exits cleanly after SIGTERM (within grace period)
+        None,  # called again by Popen.__exit__
+    ]
+
+    buf = io.StringIO()
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit):
+                main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
+    record = json.loads(buf.getvalue())
+    assert record['call']['timed_out'] is True
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_not_called()
+
+
+def test_cli_timeout_sigkill_required():
+    """--timeout: SIGKILL sent when process ignores SIGTERM past the grace period."""
+    mock_proc = _make_mock_popen()
+    mock_proc.returncode = -9  # killed by SIGKILL
+    mock_proc.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # main timeout
+        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # grace period
+        None,  # exits after SIGKILL
+        None,  # called again by Popen.__exit__
+    ]
+
+    buf = io.StringIO()
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit):
+                main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
+    record = json.loads(buf.getvalue())
+    assert record['call']['timed_out'] is True
+    mock_proc.terminate.assert_called_once()
+    mock_proc.kill.assert_called_once()
+
+
 def test_cli_version(capsys):
     """--version prints the package version and exits 0."""
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary

- `--timeout SECONDS` sends SIGTERM to the child process after the specified number of seconds per iteration; if the process has not exited after a further grace period, sends SIGKILL
- `--timeout-grace-period SECONDS` configures the SIGTERM→SIGKILL gap (default: 5 s)
- Timed-out iterations are recorded with `call.timed_out = true`; absent on normal completion
- Three tests cover: timeout not reached, SIGTERM sufficient, SIGKILL required