### PR TITLE
feat: add --nvidia-attributes and --nvidia-gpus CLI flags

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,6 +128,23 @@ so the CLI defaults to the working directory instead.
 `sys.argv[0]` issue applies here, so the CLI defaults to hashing the
 command being benchmarked instead.
 
+### `nvidia-smi` options
+
+| Option | Description |
+|---|---|
+| `--nvidia-attributes ATTR [ATTR ...]` | GPU attributes to query. Run `nvidia-smi --help-query-gpu` for all names. Default: `gpu_name memory.total`. |
+| `--nvidia-gpus GPU [GPU ...]` | GPU IDs to query: zero-based indexes, UUIDs, or PCI bus IDs. Run `nvidia-smi -L` to list UUIDs. Default: all GPUs. |
+
+Example — record power draw and temperature for GPUs 0 and 1:
+
+```bash
+microbench \
+    --mixin nvidia-smi \
+    --nvidia-attributes gpu_name power.draw temperature.gpu \
+    --nvidia-gpus 0 1 \
+    -- ./run_simulation.sh
+```
+
 ## Capture failures
 
 Metadata capture failures (e.g. `nvidia-smi` not installed on this node,

--- a/microbench/mixins.py
+++ b/microbench/mixins.py
@@ -69,6 +69,19 @@ def _existing_dir(value):
     return value
 
 
+_NVIDIA_GPU_REGEX = re.compile(r'^[0-9A-Za-z\-:]+$')
+
+
+def _nvidia_gpu_id(value):
+    """argparse type: accept a GPU index, UUID, or PCI bus ID."""
+    if not _NVIDIA_GPU_REGEX.match(value):
+        raise argparse.ArgumentTypeError(
+            f'{value!r} is not a valid GPU ID. '
+            'Use a zero-based index, UUID, or PCI bus ID.'
+        )
+    return value
+
+
 class CLIArg:
     """Declares a CLI argument that sets a mixin attribute.
 
@@ -826,7 +839,32 @@ class MBNvidiaSmi:
 
     cli_compatible = True
     _nvidia_default_attributes = ('gpu_name', 'memory.total')
-    _nvidia_gpu_regex = re.compile(r'^[0-9A-Za-z\-:]+$')
+    _nvidia_gpu_regex = _NVIDIA_GPU_REGEX
+    cli_args = [
+        CLIArg(
+            flags=['--nvidia-attributes'],
+            dest='nvidia_attributes',
+            metavar='ATTR',
+            nargs='+',
+            help=(
+                'GPU attributes to query with nvidia-smi. '
+                'Run nvidia-smi --help-query-gpu for all names. '
+                'Default: gpu_name memory.total'
+            ),
+        ),
+        CLIArg(
+            flags=['--nvidia-gpus'],
+            dest='nvidia_gpus',
+            metavar='GPU',
+            nargs='+',
+            type=_nvidia_gpu_id,
+            help=(
+                'GPU IDs to query: zero-based indexes, UUIDs, or PCI bus IDs. '
+                'Run nvidia-smi -L to list UUIDs. '
+                'Default: all GPUs.'
+            ),
+        ),
+    ]
 
     def capture_nvidia(self, bm_data):
         nvidia_attributes = getattr(

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -933,3 +933,107 @@ def test_cli_version(capsys):
         main(['--version'])
     assert exc.value.code == 0
     assert __version__ in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Mixin CLI args: MBNvidiaSmi
+# ---------------------------------------------------------------------------
+
+_FAKE_NVIDIA_DEFAULT = b'GPU-abc123, Tesla T4, 16160 MiB\n'
+_FAKE_NVIDIA_SINGLE_ATTR = b'GPU-abc123, Tesla T4\n'
+_FAKE_NVIDIA_TWO_ATTR = b'GPU-abc123, Tesla T4, 300.00 W\n'
+
+
+def test_cli_nvidia_attributes_default():
+    """nvidia-smi uses default attributes when --nvidia-attributes is absent."""
+    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_DEFAULT) as mock_co:
+        _, record, _ = _run_main(['--mixin', 'nvidia-smi', '--', 'true'])
+    cmd = mock_co.call_args[0][0]
+    assert '--query-gpu=uuid,gpu_name,memory.total' in cmd
+
+
+def test_cli_nvidia_attributes_custom():
+    """--nvidia-attributes changes the attributes queried from nvidia-smi."""
+    with patch(
+        'subprocess.check_output', return_value=_FAKE_NVIDIA_SINGLE_ATTR
+    ) as mock_co:
+        _, record, _ = _run_main(
+            ['--mixin', 'nvidia-smi', '--nvidia-attributes', 'gpu_name', '--', 'true']
+        )
+    cmd = mock_co.call_args[0][0]
+    assert '--query-gpu=uuid,gpu_name' in cmd
+    assert not any('memory.total' in arg for arg in cmd)
+
+
+def test_cli_nvidia_attributes_multiple():
+    """--nvidia-attributes accepts multiple space-separated attribute names."""
+    with patch(
+        'subprocess.check_output', return_value=_FAKE_NVIDIA_TWO_ATTR
+    ) as mock_co:
+        _, record, _ = _run_main(
+            [
+                '--mixin',
+                'nvidia-smi',
+                '--nvidia-attributes',
+                'gpu_name',
+                'power.draw',
+                '--',
+                'true',
+            ]
+        )
+    cmd = mock_co.call_args[0][0]
+    assert '--query-gpu=uuid,gpu_name,power.draw' in cmd
+
+
+def test_cli_nvidia_gpus_filters_devices():
+    """--nvidia-gpus passes the -i flag to nvidia-smi."""
+    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_DEFAULT) as mock_co:
+        _, record, _ = _run_main(
+            ['--mixin', 'nvidia-smi', '--nvidia-gpus', '0', '--', 'true']
+        )
+    cmd = mock_co.call_args[0][0]
+    assert '-i' in cmd
+    assert cmd[cmd.index('-i') + 1] == '0'
+
+
+def test_cli_nvidia_gpus_multiple_devices():
+    """--nvidia-gpus with multiple IDs joins them with commas."""
+    with patch('subprocess.check_output', return_value=_FAKE_NVIDIA_DEFAULT) as mock_co:
+        _, record, _ = _run_main(
+            ['--mixin', 'nvidia-smi', '--nvidia-gpus', '0', '1', '--', 'true']
+        )
+    cmd = mock_co.call_args[0][0]
+    assert '-i' in cmd
+    assert cmd[cmd.index('-i') + 1] == '0,1'
+
+
+def test_cli_nvidia_gpus_invalid_rejected():
+    """--nvidia-gpus rejects an ID containing whitespace."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'nvidia-smi', '--nvidia-gpus', 'invalid id', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_nvidia_attributes_without_mixin_errors():
+    """--nvidia-attributes without the nvidia-smi mixin is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'host-info', '--nvidia-attributes', 'gpu_name', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_nvidia_gpus_without_mixin_errors():
+    """--nvidia-gpus without the nvidia-smi mixin is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--mixin', 'host-info', '--nvidia-gpus', '0', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_show_mixins_includes_nvidia_flags():
+    """--show-mixins lists --nvidia-attributes and --nvidia-gpus under nvidia-smi."""
+    buf = io.StringIO()
+    with patch('sys.stdout', buf):
+        with pytest.raises(SystemExit):
+            main(['--show-mixins'])
+    output = buf.getvalue()
+    assert '--nvidia-attributes' in output
+    assert '--nvidia-gpus' in output


### PR DESCRIPTION
## Summary

- Adds `--nvidia-attributes ATTR [ATTR ...]` CLI flag to configure which nvidia-smi attributes are queried (default: `gpu_name memory.total`)
- Adds `--nvidia-gpus GPU [GPU ...]` CLI flag to filter which GPUs are polled by index, UUID, or PCI bus ID (default: all GPUs)
- Both flags follow the existing `CLIArg` autodiscovery pattern used by `git-info` and `file-hash`; mixin-specific validation (invalid GPU ID format, flag used without mixin) is handled consistently with those
- Adds a `_NVIDIA_GPU_REGEX` module-level constant and `_nvidia_gpu_id` argparse type validator to `mixins.py`
- Documents the new flags under a new `### nvidia-smi options` subsection in `docs/cli.md`
- 9 new CLI tests covering default behaviour, custom attributes, multiple attributes, GPU filtering, invalid GPU ID rejection, and missing-mixin errors