### PR TITLE
feat: add --dry-run flag to CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ microbench [options] -- COMMAND [ARGS...]
 | `--no-mixin` | Disable all mixins including defaults. Records only timing and command fields. |
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
+| `--dry-run` | Print the resolved configuration and exit without running the command. |
 | `--stdout[=suppress]` | Capture stdout into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--stderr[=suppress]` | Capture stderr into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--timeout SECONDS` | Send SIGTERM to the command after SECONDS seconds per iteration. If the process has not exited after an additional grace period (default 5 s, see `--timeout-grace-period`), send SIGKILL. Timed-out iterations are recorded with `call.timed_out = true`. |
@@ -252,6 +253,36 @@ df['any_timed_out'] = df['call.timed_out'].notna()
 ```
 
 The `call.returncode` for a SIGTERM-killed process will be `-15`; for SIGKILL, `-9`.
+
+## Dry run
+
+Use `--dry-run` to verify your configuration without actually running the command:
+
+```bash
+microbench \
+    --dry-run \
+    --outfile /scratch/$USER/results.jsonl \
+    --mixin host-info slurm-info nvidia-smi \
+    --nvidia-attributes gpu_name power.draw \
+    --iterations 10 \
+    -- ./run_simulation.sh --steps 1000
+```
+
+Example output:
+
+```
+Dry run — command will not be executed.
+
+  Command:    ./run_simulation.sh --steps 1000
+  Output:     /scratch/user/results.jsonl
+  Mixins:     host-info, nvidia-smi, slurm-info
+    --nvidia-attributes gpu_name power.draw
+  Iterations: 10
+```
+
+All argument validation still runs, so `--dry-run` will catch errors like a
+missing `--timeout` when `--timeout-grace-period` is given, or a `--hash-file`
+path that does not exist.
 
 ## Extra metadata
 

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -66,6 +66,48 @@ def _make_mixin_type(mixin_map):
     return _parse
 
 
+def _show_dry_run(args, cmd, mixin_names, mixin_map):
+    """Print a summary of the resolved configuration and exit."""
+    lines = ['Dry run — command will not be executed.\n']
+    lines.append(f'  Command:    {" ".join(cmd)}')
+    lines.append(f'  Output:     {args.outfile or "stdout"}')
+    lines.append(f'  Mixins:     {", ".join(mixin_names) if mixin_names else "none"}')
+
+    # Mixin-specific settings that were explicitly supplied on the command line.
+    for name in mixin_names:
+        for arg in getattr(mixin_map[name], 'cli_args', []):
+            val = getattr(args, arg.dest, None)
+            if val is not None:
+                flag = arg.flags[0]
+                val_str = (
+                    ' '.join(str(v) for v in val) if isinstance(val, list) else val
+                )
+                lines.append(f'    {flag} {val_str}')
+
+    iters = str(args.iterations)
+    if args.warmup:
+        iters += f' (+{args.warmup} warmup)'
+    lines.append(f'  Iterations: {iters}')
+
+    capture = [
+        f for f, v in (('--stdout', args.stdout), ('--stderr', args.stderr)) if v
+    ]
+    if capture:
+        lines.append(f'  Capture:    {" ".join(capture)}')
+
+    if args.timeout is not None:
+        grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
+        lines.append(f'  Timeout:    {args.timeout}s (grace period: {grace}s)')
+
+    if args.monitor_interval is not None:
+        lines.append(f'  Monitor:    every {args.monitor_interval}s')
+
+    if args.fields:
+        lines.append(f'  Fields:     {", ".join(args.fields)}')
+
+    print('\n'.join(lines))
+
+
 def _show_mixins(mixin_map):
     """Print a table of available CLI-compatible mixins and their descriptions."""
     default_set = set(_DEFAULT_MIXINS)
@@ -200,6 +242,14 @@ def _build_parser(mixin_map):
         '--show-mixins',
         action='store_true',
         help='List available mixins with descriptions and exit.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help=(
+            'Print the resolved configuration (command, mixins, settings) '
+            'and exit without running the command.'
+        ),
     )
     mixin_scope = parser.add_mutually_exclusive_group()
     mixin_scope.add_argument(
@@ -379,6 +429,10 @@ def main(argv=None):
             import psutil  # noqa: F401
         except ImportError:
             parser.error('--monitor-interval requires the "psutil" package.')
+
+    if args.dry_run:
+        _show_dry_run(args, cmd, mixin_names, mixin_map)
+        sys.exit(0)
 
     from microbench import FileOutput, MicroBench
 

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -936,6 +936,123 @@ def test_cli_version(capsys):
 
 
 # ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_exits_zero(capsys):
+    """--dry-run exits 0 and does not write a JSONL record."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--dry-run', '--', 'sleep', '1'])
+    assert exc.value.code == 0
+
+
+def test_cli_dry_run_no_subprocess(capsys):
+    """--dry-run does not execute the command."""
+    with patch('subprocess.run') as mock_run:
+        with patch('subprocess.Popen') as mock_popen:
+            with pytest.raises(SystemExit):
+                main(['--dry-run', '--', 'sleep', '1'])
+    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
+
+
+def test_cli_dry_run_shows_command(capsys):
+    """--dry-run output includes the command."""
+    with pytest.raises(SystemExit):
+        main(['--dry-run', '--', 'sleep', '1'])
+    assert 'sleep 1' in capsys.readouterr().out
+
+
+def test_cli_dry_run_shows_mixins(capsys):
+    """--dry-run output lists the active mixins."""
+    with pytest.raises(SystemExit):
+        main(['--dry-run', '--mixin', 'host-info', 'python-info', '--', 'true'])
+    out = capsys.readouterr().out
+    assert 'host-info' in out
+    assert 'python-info' in out
+
+
+def test_cli_dry_run_no_mixin(capsys):
+    """--dry-run with --no-mixin shows 'none' for mixins."""
+    with pytest.raises(SystemExit):
+        main(['--dry-run', '--no-mixin', '--', 'true'])
+    assert 'none' in capsys.readouterr().out
+
+
+def test_cli_dry_run_shows_iterations(capsys):
+    """--dry-run output includes iteration and warmup counts."""
+    with pytest.raises(SystemExit):
+        main(['--dry-run', '--iterations', '5', '--warmup', '2', '--', 'true'])
+    out = capsys.readouterr().out
+    assert '5' in out
+    assert '2' in out
+
+
+def test_cli_dry_run_shows_output_file(capsys, tmp_path):
+    """--dry-run output includes the output file path."""
+    outfile = str(tmp_path / 'results.jsonl')
+    with pytest.raises(SystemExit):
+        main(['--dry-run', '--outfile', outfile, '--', 'true'])
+    assert outfile in capsys.readouterr().out
+
+
+def test_cli_dry_run_shows_timeout(capsys):
+    """--dry-run output includes timeout settings."""
+    with pytest.raises(SystemExit):
+        main(
+            [
+                '--dry-run',
+                '--timeout',
+                '60',
+                '--timeout-grace-period',
+                '10',
+                '--',
+                'true',
+            ]
+        )
+    out = capsys.readouterr().out
+    assert '60' in out
+    assert '10' in out
+
+
+def test_cli_dry_run_shows_mixin_specific_args(capsys):
+    """--dry-run shows mixin-specific flags that were explicitly set."""
+    with patch('subprocess.check_output'):
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    '--dry-run',
+                    '--mixin',
+                    'nvidia-smi',
+                    '--nvidia-attributes',
+                    'gpu_name',
+                    'power.draw',
+                    '--',
+                    'true',
+                ]
+            )
+    out = capsys.readouterr().out
+    assert '--nvidia-attributes' in out
+    assert 'gpu_name' in out
+    assert 'power.draw' in out
+
+
+def test_cli_dry_run_validates_args(capsys):
+    """--dry-run validates arguments; --timeout-grace-period requires --timeout."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--dry-run', '--timeout-grace-period', '10', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_dry_run_shows_fields(capsys):
+    """--dry-run output includes --field values."""
+    with pytest.raises(SystemExit):
+        main(['--dry-run', '--field', 'experiment=run-1', '--', 'true'])
+    assert 'experiment=run-1' in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # Mixin CLI args: MBNvidiaSmi
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag: prints the resolved configuration and exits 0 without running the command or writing any JSONL output
- Output shows command, output destination, active mixins, any mixin-specific flags that were explicitly set, iterations/warmup, capture mode, timeout, monitor interval, and extra fields
- All argument validation still runs (argparse type checks, `--timeout-grace-period` requires `--timeout`, mixin-specific arg requires mixin loaded, etc.), so `--dry-run` catches misconfiguration the same way a real run would
- 11 new tests covering exit code, no subprocess execution, output content, and validation behaviour