### PR TITLE
feat: add HttpOutput and --http-output CLI flag

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,9 @@ microbench [options] -- COMMAND [ARGS...]
 | Option | Description |
 |---|---|
 | `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
+| `--http-output URL` | POST each record as JSON to URL. Can be combined with `--outfile`. |
+| `--http-output-header KEY:VALUE` | Extra HTTP header for `--http-output` (repeatable). Use for authentication. Requires `--http-output`. |
+| `--http-output-method METHOD` | HTTP method for `--http-output`. Defaults to `POST`. Requires `--http-output`. |
 | `--mixin MIXIN [MIXIN ...]` / `-m MIXIN [MIXIN ...]` | One or more mixins to include. Replaces defaults when specified. |
 | `--show-mixins` | List all available mixins with descriptions and exit. |
 | `--all` / `-a` | Include all available mixins. |
@@ -253,6 +256,49 @@ df['any_timed_out'] = df['call.timed_out'].notna()
 ```
 
 The `call.returncode` for a SIGTERM-killed process will be `-15`; for SIGKILL, `-9`.
+
+## HTTP output
+
+Use `--http-output` to POST each record as JSON to an HTTP endpoint. The record
+body is identical to what `--outfile` would write. This is useful for real-time
+notifications and custom REST endpoints.
+
+```bash
+microbench --http-output https://api.example.com/benchmarks -- ./run.sh
+```
+
+For authenticated endpoints, pass headers with `--http-output-header`. The value
+is split on the first `:`, so bearer tokens and other header values work naturally:
+
+```bash
+microbench \
+    --http-output https://api.example.com/benchmarks \
+    --http-output-header "Authorization:Bearer $MY_TOKEN" \
+    -- ./run.sh
+```
+
+Multiple headers can be supplied by repeating the flag:
+
+```bash
+microbench \
+    --http-output https://api.example.com/benchmarks \
+    --http-output-header "Authorization:Bearer $TOKEN" \
+    --http-output-header "X-Tenant:my-org" \
+    -- ./run.sh
+```
+
+`--outfile` and `--http-output` can be combined to write to both destinations simultaneously:
+
+```bash
+microbench \
+    --outfile /scratch/$USER/results.jsonl \
+    --http-output https://hooks.example.com/events \
+    -- ./run.sh
+```
+
+To send results to a service that requires a shaped payload (e.g. Slack's
+`{"text": "..."}` envelope), use the Python API with a `HttpOutput` subclass
+that overrides `format_payload`. The CLI always sends the raw record JSON.
 
 ## Dry run
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -51,7 +51,7 @@ from ._mixins import (
     MBWorkingDir,
     _MonitorThread,
 )
-from ._output import FileOutput, Output, RedisOutput
+from ._output import FileOutput, HttpOutput, Output, RedisOutput
 
 # Generated once at import time; shared by all MicroBench instances in this
 # process, allowing records from independent bench suites to be correlated.
@@ -73,6 +73,7 @@ __all__ = [
     # Output sinks
     'Output',
     'FileOutput',
+    'HttpOutput',
     'RedisOutput',
     # Mixin authoring
     'CLIArg',

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -226,6 +226,32 @@ def _build_parser(mixin_map):
         help='Append results to FILE (JSONL format). Defaults to stdout.',
     )
     parser.add_argument(
+        '--http-output',
+        metavar='URL',
+        help=(
+            'POST each record as JSON to URL. '
+            'Can be combined with --outfile to write to both destinations.'
+        ),
+    )
+    parser.add_argument(
+        '--http-output-header',
+        metavar='KEY:VALUE',
+        action='append',
+        dest='http_output_headers',
+        help=(
+            'Extra HTTP header for --http-output (repeatable). '
+            'Use for authentication, e.g. '
+            '"Authorization:Bearer $TOKEN". '
+            'Requires --http-output.'
+        ),
+    )
+    parser.add_argument(
+        '--http-output-method',
+        metavar='METHOD',
+        default='POST',
+        help='HTTP method for --http-output. Defaults to POST. Requires --http-output.',
+    )
+    parser.add_argument(
         '--mixin',
         '-m',
         nargs='+',
@@ -424,6 +450,11 @@ def main(argv=None):
     if args.timeout_grace_period is not None and args.timeout is None:
         parser.error('--timeout-grace-period requires --timeout.')
 
+    if args.http_output_headers is not None and args.http_output is None:
+        parser.error('--http-output-header requires --http-output.')
+    if args.http_output_method != 'POST' and args.http_output is None:
+        parser.error('--http-output-method requires --http-output.')
+
     if args.monitor_interval is not None:
         try:
             import psutil  # noqa: F401
@@ -434,7 +465,7 @@ def main(argv=None):
         _show_dry_run(args, cmd, mixin_names, mixin_map)
         sys.exit(0)
 
-    from microbench import FileOutput, MicroBench
+    from microbench import FileOutput, HttpOutput, MicroBench
 
     class _MBSubprocessResult:
         def capture_subprocess_reset(self, bm_data):
@@ -484,9 +515,28 @@ def main(argv=None):
                     else arg.cli_default,
                 )
 
-    output = FileOutput(args.outfile) if args.outfile else FileOutput(sys.stdout)
+    outputs = []
+    if args.outfile:
+        outputs.append(FileOutput(args.outfile))
+    if args.http_output:
+        http_headers = {}
+        for h in args.http_output_headers or []:
+            if ':' not in h:
+                parser.error(f'--http-output-header: expected KEY:VALUE, got {h!r}')
+            k, v = h.split(':', 1)
+            http_headers[k.strip()] = v.strip()
+        outputs.append(
+            HttpOutput(
+                args.http_output,
+                headers=http_headers or None,
+                method=args.http_output_method,
+            )
+        )
+    if not outputs:
+        outputs.append(FileOutput(sys.stdout))
+
     bench = BenchClass(
-        outputs=[output],
+        outputs=outputs,
         iterations=args.iterations,
         warmup=args.warmup,
         **extra_fields,

--- a/microbench/_output.py
+++ b/microbench/_output.py
@@ -1,5 +1,7 @@
 import io
 import json
+import urllib.error
+import urllib.request
 
 try:
     import pandas
@@ -174,3 +176,112 @@ class RedisOutput(Output):
             return records
         else:  # format == 'df' and flat
             return pandas.DataFrame(records)
+
+
+class HttpOutput(Output):
+    """POST each benchmark result to an HTTP/HTTPS endpoint.
+
+    Designed for webhooks and real-time notifications (e.g. Slack, Teams,
+    custom event endpoints). Not intended for bulk storage — there is no
+    :meth:`get_results` support.
+
+    Uses only the Python standard library (``urllib``). Raises on non-2xx
+    responses or network failures — no silent dropping, no automatic retry.
+
+    By default the record dict is JSON-encoded and sent with
+    ``Content-Type: application/json``. Override :meth:`format_payload` in a
+    subclass to produce any body shape required by the target provider (e.g.
+    a Slack ``{"text": ...}`` envelope).
+
+    Args:
+        url (str): Endpoint URL. Must be ``http://`` or ``https://``.
+        headers (dict, optional): Extra HTTP headers merged with the defaults.
+            Caller-supplied keys win on collision (case-sensitive). Use this
+            for authentication (e.g. ``{'Authorization': 'Bearer <token>'}``).
+            Defaults to ``None``.
+        timeout (float, optional): Request timeout in seconds passed to
+            :func:`urllib.request.urlopen`. Defaults to ``30.0``.
+        method (str, optional): HTTP method. Defaults to ``'POST'``.
+
+    Raises:
+        urllib.error.HTTPError: If the server returns a non-2xx status code.
+        urllib.error.URLError: If a network-level error occurs (DNS failure,
+            connection refused, etc.).
+
+    Example — basic usage::
+
+        from microbench import MicroBench, HttpOutput
+
+        bench = MicroBench(outputs=[HttpOutput('https://example.com/events')])
+
+    Example — bearer token authentication::
+
+        from microbench import MicroBench, HttpOutput
+
+        bench = MicroBench(outputs=[HttpOutput(
+            'https://api.example.com/benchmarks',
+            headers={'Authorization': 'Bearer my-secret-token'},
+        )])
+
+    Example — Slack webhook via subclass::
+
+        import json
+        from microbench import MicroBench, HttpOutput
+
+        class SlackOutput(HttpOutput):
+            def format_payload(self, record):
+                name = record.get('call', {}).get('name', '?')
+                return json.dumps({'text': f'Benchmark `{name}` finished.'}).encode()
+
+        bench = MicroBench(outputs=[SlackOutput('https://hooks.slack.com/services/...')])
+    """
+
+    def __init__(self, url, *, headers=None, timeout=30.0, method='POST'):
+        self.url = url
+        self.headers = headers or {}
+        self.timeout = timeout
+        self.method = method.upper()
+
+    def format_payload(self, record):
+        """Encode *record* as the HTTP request body.
+
+        The default implementation JSON-encodes the record dict and returns
+        UTF-8 bytes. Subclasses may override this to produce any body shape
+        required by the target provider.
+
+        Args:
+            record (dict): Decoded benchmark result dict.
+
+        Returns:
+            bytes: Request body.
+        """
+        return json.dumps(record).encode('utf-8')
+
+    def _build_request(self, record):
+        body = self.format_payload(record)
+        if isinstance(body, str):
+            body = body.encode('utf-8')
+        default_headers = {'Content-Type': 'application/json'}
+        merged_headers = {**default_headers, **self.headers}
+        return urllib.request.Request(
+            self.url,
+            data=body,
+            headers=merged_headers,
+            method=self.method,
+        )
+
+    def write(self, bm_json_str):
+        """POST *bm_json_str* to the configured URL.
+
+        Args:
+            bm_json_str (str): JSON-encoded benchmark record, as produced by
+                :meth:`MicroBenchBase.to_json`.
+
+        Raises:
+            urllib.error.HTTPError: On a non-2xx HTTP response.
+            urllib.error.URLError: On a network-level error.
+        """
+        record = json.loads(bm_json_str)
+        request = self._build_request(record)
+        with urllib.request.urlopen(request, timeout=self.timeout):
+            pass

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -725,6 +725,184 @@ def test_cli_monitor_interval_with_stdout_capture():
 
 
 # ---------------------------------------------------------------------------
+# --http-output
+# ---------------------------------------------------------------------------
+
+
+def _run_main_http(argv, fake_status=200):
+    """Run main() with --http-output, mocking urlopen and subprocess."""
+    mock_response = MagicMock()
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    buf = io.StringIO()
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        with patch(
+            'urllib.request.urlopen', return_value=mock_response
+        ) as mock_urlopen:
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(argv)
+    return exc.value.code, mock_urlopen
+
+
+def test_cli_http_output_posts_record():
+    """--http-output POSTs a JSON record to the given URL."""
+    code, mock_urlopen = _run_main_http(
+        ['--no-mixin', '--http-output', 'https://example.com/hook', '--', 'true']
+    )
+    assert code == 0
+    mock_urlopen.assert_called_once()
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_full_url() == 'https://example.com/hook'
+    body = json.loads(req.data)
+    assert body['call']['name'] == 'true'
+
+
+def test_cli_http_output_no_stdout_record():
+    """--http-output without --outfile produces no stdout JSONL."""
+    buf = io.StringIO()
+    mock_response = MagicMock()
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        with patch('urllib.request.urlopen', return_value=mock_response):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(['--no-mixin', '--http-output', 'https://x.com', '--', 'true'])
+    assert buf.getvalue() == ''
+
+
+def test_cli_http_output_and_outfile(tmp_path):
+    """--http-output and --outfile together write to both destinations."""
+    outfile = tmp_path / 'results.jsonl'
+    mock_response = MagicMock()
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        with patch(
+            'urllib.request.urlopen', return_value=mock_response
+        ) as mock_urlopen:
+            with pytest.raises(SystemExit):
+                main(
+                    [
+                        '--no-mixin',
+                        '--outfile',
+                        str(outfile),
+                        '--http-output',
+                        'https://x.com',
+                        '--',
+                        'true',
+                    ]
+                )
+    assert outfile.exists()
+    assert json.loads(outfile.read_text())['call']['name'] == 'true'
+    mock_urlopen.assert_called_once()
+
+
+def test_cli_http_output_header_sets_authorization():
+    """--http-output-header KEY:VALUE is sent as an HTTP header."""
+    _, mock_urlopen = _run_main_http(
+        [
+            '--no-mixin',
+            '--http-output',
+            'https://example.com/hook',
+            '--http-output-header',
+            'Authorization:Bearer secret',
+            '--',
+            'true',
+        ]
+    )
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header('Authorization') == 'Bearer secret'
+
+
+def test_cli_http_output_header_strips_whitespace():
+    """Whitespace around KEY and VALUE in --http-output-header is stripped."""
+    _, mock_urlopen = _run_main_http(
+        [
+            '--no-mixin',
+            '--http-output',
+            'https://example.com/hook',
+            '--http-output-header',
+            'X-Custom: my value',
+            '--',
+            'true',
+        ]
+    )
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header('X-custom') == 'my value'
+
+
+def test_cli_http_output_multiple_headers():
+    """Multiple --http-output-header flags are all applied."""
+    _, mock_urlopen = _run_main_http(
+        [
+            '--no-mixin',
+            '--http-output',
+            'https://example.com/hook',
+            '--http-output-header',
+            'Authorization:Bearer tok',
+            '--http-output-header',
+            'X-Tenant:acme',
+            '--',
+            'true',
+        ]
+    )
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header('Authorization') == 'Bearer tok'
+    assert req.get_header('X-tenant') == 'acme'
+
+
+def test_cli_http_output_method():
+    """--http-output-method PUT sends a PUT request."""
+    _, mock_urlopen = _run_main_http(
+        [
+            '--no-mixin',
+            '--http-output',
+            'https://example.com/hook',
+            '--http-output-method',
+            'PUT',
+            '--',
+            'true',
+        ]
+    )
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_method() == 'PUT'
+
+
+def test_cli_http_output_header_without_http_output_errors():
+    """--http-output-header without --http-output is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--no-mixin', '--http-output-header', 'X-Key:val', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_http_output_method_without_http_output_errors():
+    """--http-output-method without --http-output is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--no-mixin', '--http-output-method', 'PUT', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_http_output_header_invalid_format_errors():
+    """--http-output-header without : separator is an error."""
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                '--no-mixin',
+                '--http-output',
+                'https://x.com',
+                '--http-output-header',
+                'NoColonHere',
+                '--',
+                'true',
+            ]
+        )
+    assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
 # Mixin CLI args: MBGitInfo and MBFileHash
 # ---------------------------------------------------------------------------
 

--- a/microbench/tests/test_output.py
+++ b/microbench/tests/test_output.py
@@ -1,6 +1,11 @@
 import datetime
+import io
+import json
 import os
+import socket
 import tempfile
+import urllib.error
+import urllib.request
 import warnings
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +15,7 @@ import pytest
 from microbench import (
     _UNENCODABLE_PLACEHOLDER_VALUE,
     FileOutput,
+    HttpOutput,
     JSONEncoder,
     JSONEncodeWarning,
     MBFunctionCall,
@@ -489,3 +495,289 @@ def test_bench_summary_method(capsys):
     bench.summary()
     out = capsys.readouterr().out
     assert 'n=1' in out
+
+
+# ---------------------------------------------------------------------------
+# HttpOutput tests
+# ---------------------------------------------------------------------------
+
+_HTTP_URL = 'https://example.com/webhook'
+
+
+def _make_urlopen_mock(status=200):
+    """Return a mock for urllib.request.urlopen that returns *status*."""
+    mock_response = MagicMock()
+    mock_response.status = status
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+    return MagicMock(return_value=mock_response)
+
+
+def _make_http_error(code):
+    """Return a urllib.error.HTTPError with the given status code."""
+    return urllib.error.HTTPError(
+        url=_HTTP_URL,
+        code=code,
+        msg=f'HTTP {code}',
+        hdrs=None,
+        fp=io.BytesIO(b''),
+    )
+
+
+def test_http_output_posts_json():
+    """write() POSTs a valid JSON body with Content-Type application/json."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{"call": {"name": "noop"}}')
+
+    mock_urlopen.assert_called_once()
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_full_url() == _HTTP_URL
+    assert req.get_header('Content-type') == 'application/json'
+    body = json.loads(req.data)
+    assert body['call']['name'] == 'noop'
+
+
+def test_http_output_posts_to_correct_url():
+    """write() sends the request to exactly the URL given at construction."""
+    target = 'https://hooks.example.org/events'
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(target)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{"x": 1}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_full_url() == target
+
+
+def test_http_output_default_method_is_post():
+    """HttpOutput uses POST by default."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_method() == 'POST'
+
+
+def test_http_output_custom_method():
+    """method='PUT' is used when specified."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL, method='PUT')
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_method() == 'PUT'
+
+
+def test_http_output_custom_headers():
+    """Extra headers= dict is merged and sent."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(
+        _HTTP_URL,
+        headers={'Authorization': 'Bearer tok', 'X-Custom': 'value'},
+    )
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header('Authorization') == 'Bearer tok'
+    assert req.get_header('X-custom') == 'value'
+
+
+def test_http_output_custom_headers_override_default():
+    """A caller-supplied Content-Type wins over the default."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL, headers={'Content-type': 'text/plain'})
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header('Content-type') == 'text/plain'
+
+
+def test_http_output_custom_timeout():
+    """Custom timeout= float is forwarded to urlopen."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL, timeout=60.0)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    _, kwargs = mock_urlopen.call_args
+    assert kwargs.get('timeout') == 60.0
+
+
+def test_http_output_default_timeout():
+    """Default timeout is 30.0 seconds."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    _, kwargs = mock_urlopen.call_args
+    assert kwargs.get('timeout') == 30.0
+
+
+def test_http_output_bearer_token():
+    """Authorization header with bearer token is sent correctly."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL, headers={'Authorization': 'Bearer secret-token'})
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header('Authorization') == 'Bearer secret-token'
+
+
+def test_http_output_format_payload_str_encoded():
+    """format_payload returning a str is encoded to UTF-8 bytes before sending."""
+    mock_urlopen = _make_urlopen_mock()
+
+    class StrOutput(HttpOutput):
+        def format_payload(self, record):
+            return 'hello'
+
+    output = StrOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{}')
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.data == b'hello'
+
+
+def test_http_output_format_payload_override():
+    """Subclass overriding format_payload shapes the body correctly."""
+    mock_urlopen = _make_urlopen_mock()
+
+    class SlackOutput(HttpOutput):
+        def format_payload(self, record):
+            name = record.get('call', {}).get('name', '?')
+            return json.dumps({'text': f'Done: {name}'}).encode()
+
+    output = SlackOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{"call": {"name": "my_func"}}')
+
+    req = mock_urlopen.call_args[0][0]
+    body = json.loads(req.data)
+    assert body == {'text': 'Done: my_func'}
+
+
+@pytest.mark.parametrize('status_code', [400, 403, 404, 422])
+def test_http_output_raises_on_4xx(status_code):
+    """Non-2xx 4xx responses raise urllib.error.HTTPError."""
+    output = HttpOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', side_effect=_make_http_error(status_code)):
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            output.write('{}')
+    assert exc_info.value.code == status_code
+
+
+@pytest.mark.parametrize('status_code', [500, 502, 503])
+def test_http_output_raises_on_5xx(status_code):
+    """Server error 5xx responses raise urllib.error.HTTPError."""
+    output = HttpOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', side_effect=_make_http_error(status_code)):
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            output.write('{}')
+    assert exc_info.value.code == status_code
+
+
+def test_http_output_raises_on_network_error():
+    """URLError (DNS failure / connection refused) propagates to the caller."""
+    output = HttpOutput(_HTTP_URL)
+    url_error = urllib.error.URLError(reason='[Errno -2] Name or service not known')
+
+    with patch('urllib.request.urlopen', side_effect=url_error):
+        with pytest.raises(urllib.error.URLError):
+            output.write('{}')
+
+
+def test_http_output_raises_on_timeout():
+    """socket.timeout propagates to the caller."""
+    output = HttpOutput(_HTTP_URL)
+
+    with patch('urllib.request.urlopen', side_effect=TimeoutError('timed out')):
+        with pytest.raises(socket.timeout):
+            output.write('{}')
+
+
+def test_http_output_get_results_raises():
+    """get_results() raises NotImplementedError — HTTP is write-only."""
+    output = HttpOutput(_HTTP_URL)
+    with pytest.raises(NotImplementedError):
+        output.get_results()
+
+
+def test_http_output_slack_formatter_example():
+    """Slack envelope shape produced by format_payload subclass is correct."""
+    mock_urlopen = _make_urlopen_mock()
+
+    class SlackOutput(HttpOutput):
+        def format_payload(self, record):
+            name = record.get('call', {}).get('name', '?')
+            return json.dumps({'text': f'Benchmark `{name}` finished.'}).encode()
+
+    output = SlackOutput('https://hooks.slack.com/services/T00/B00/xxx')
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        output.write('{"call": {"name": "train_model"}}')
+
+    req = mock_urlopen.call_args[0][0]
+    body = json.loads(req.data)
+    assert body['text'] == 'Benchmark `train_model` finished.'
+
+
+def test_http_output_via_microbench():
+    """MicroBench routes records through HttpOutput.write()."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL)
+
+    bench = MicroBench(outputs=[output])
+
+    @bench
+    def noop():
+        pass
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        noop()
+
+    mock_urlopen.assert_called_once()
+    req = mock_urlopen.call_args[0][0]
+    body = json.loads(req.data)
+    assert body['call']['name'] == 'noop'
+
+
+def test_http_output_multiple_writes():
+    """Each benchmark call produces a separate HTTP request."""
+    mock_urlopen = _make_urlopen_mock()
+    output = HttpOutput(_HTTP_URL)
+
+    bench = MicroBench(outputs=[output])
+
+    @bench
+    def noop():
+        pass
+
+    with patch('urllib.request.urlopen', mock_urlopen):
+        noop()
+        noop()
+        noop()
+
+    assert mock_urlopen.call_count == 3


### PR DESCRIPTION
## Summary

- Fixes a bug in `HttpOutput` where `timeout=(10, 30)` tuple was passed to `urllib.request.urlopen`, which only accepts a float — runtime `TypeError` on every write
- Removes the over-engineered `formatter=` constructor parameter (duplicated the `format_payload()` subclass mechanism); `format_payload()` is now the single extension point
- Adds `--http-output URL`, `--http-output-header KEY:VALUE` (repeatable), and `--http-output-method METHOD` CLI flags so records can be POSTed to HTTP endpoints without writing Python code
- Shell variable expansion handles secrets: `--http-output-header "Authorization:Bearer $TOKEN"`
- `--outfile` and `--http-output` can be combined to write to both destinations simultaneously
- Documents the new flags and a `## HTTP output` section in `docs/cli.md`