### PR TITLE
feat: add --redis-output CLI flag; group --help by category

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,24 +19,41 @@ select a specific Python interpreter explicitly.
 microbench [options] -- COMMAND [ARGS...]
 ```
 
+**Output**
+
 | Option | Description |
 |---|---|
 | `--outfile FILE` / `-o FILE` | Append results to FILE in JSONL format. Defaults to stdout. |
 | `--http-output URL` | POST each record as JSON to URL. Can be combined with `--outfile`. |
 | `--http-output-header KEY:VALUE` | Extra HTTP header for `--http-output` (repeatable). Use for authentication. Requires `--http-output`. |
 | `--http-output-method METHOD` | HTTP method for `--http-output`. Defaults to `POST`. Requires `--http-output`. |
+| `--redis-output KEY` | RPUSH each record as JSON to a Redis list at KEY. Can be combined with `--outfile` or `--http-output`. Requires the `redis` package. |
+| `--redis-host HOST` | Redis server hostname for `--redis-output` (default: `localhost`). |
+| `--redis-port PORT` | Redis server port for `--redis-output` (default: `6379`). Requires `--redis-output`. |
+| `--redis-db DB` | Redis database index for `--redis-output` (default: `0`). Requires `--redis-output`. |
+| `--redis-password PASSWORD` | Redis AUTH password for `--redis-output`. Requires `--redis-output`. |
+
+**Mixins**
+
+| Option | Description |
+|---|---|
 | `--mixin MIXIN [MIXIN ...]` / `-m MIXIN [MIXIN ...]` | One or more mixins to include. Replaces defaults when specified. |
 | `--show-mixins` | List all available mixins with descriptions and exit. |
 | `--all` / `-a` | Include all available mixins. |
 | `--no-mixin` | Disable all mixins including defaults. Records only timing and command fields. |
+
+**Execution**
+
+| Option | Description |
+|---|---|
 | `--iterations N` / `-n N` | Run the command N times, recording each duration. Defaults to 1. |
 | `--warmup N` / `-w N` | Run the command N times before timing begins (unrecorded). Defaults to 0. |
-| `--dry-run` | Print the resolved configuration and exit without running the command. |
 | `--stdout[=suppress]` | Capture stdout into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--stderr[=suppress]` | Capture stderr into the record and stream it to the terminal in real time. Use `=suppress` to capture without printing. |
 | `--timeout SECONDS` | Send SIGTERM to the command after SECONDS seconds per iteration. If the process has not exited after an additional grace period (default 5 s, see `--timeout-grace-period`), send SIGKILL. Timed-out iterations are recorded with `call.timed_out = true`. |
 | `--timeout-grace-period SECONDS` | Seconds to wait after SIGTERM before sending SIGKILL. Requires `--timeout`. Default: 5. |
 | `--monitor-interval SECONDS` | Sample the child process CPU usage and RSS memory every SECONDS seconds. Requires `psutil`. See [Subprocess monitoring](#subprocess-monitoring) below. |
+| `--dry-run` | Print the resolved configuration and exit without running the command. |
 | `--field KEY=VALUE` / `-f KEY=VALUE` | Extra metadata field. Can be repeated. |
 
 Use `--` to separate microbench options from the command being benchmarked.
@@ -299,6 +316,67 @@ microbench \
 To send results to a service that requires a shaped payload (e.g. Slack's
 `{"text": "..."}` envelope), use the Python API with a `HttpOutput` subclass
 that overrides `format_payload`. The CLI always sends the raw record JSON.
+
+## Redis output
+
+Use `--redis-output KEY` to RPUSH each record as JSON to a Redis list. This is
+the natural output sink for SLURM array jobs where many nodes write concurrently
+and a shared filesystem is impractical. Requires the
+[redis-py](https://github.com/andymccurdy/redis-py) package (`pip install redis`).
+
+```bash
+microbench \
+    --redis-output bench:results \
+    --redis-host redis.example.com \
+    -- ./run_simulation.sh
+```
+
+Use `--redis-port` and `--redis-db` to connect to a non-default port or database:
+
+```bash
+microbench \
+    --redis-output bench:results \
+    --redis-host redis.example.com \
+    --redis-port 6380 \
+    --redis-db 1 \
+    -- ./run_simulation.sh
+```
+
+For password-protected Redis instances, pass `--redis-password`. Read it from an
+environment variable to avoid it appearing in shell history:
+
+```bash
+microbench \
+    --redis-output bench:results \
+    --redis-host redis.example.com \
+    --redis-password "$REDIS_PASSWORD" \
+    -- ./run_simulation.sh
+```
+
+`--redis-output` can be combined with `--outfile` or `--http-output` to write to
+multiple destinations simultaneously:
+
+```bash
+microbench \
+    --outfile /scratch/$USER/results.jsonl \
+    --redis-output bench:results \
+    -- ./run_simulation.sh
+```
+
+Read results back from Redis with Python:
+
+```python
+import redis, json
+client = redis.StrictRedis(host='redis.example.com')
+records = [json.loads(r) for r in client.lrange('bench:results', 0, -1)]
+```
+
+Or via microbench's `RedisOutput.get_results()`:
+
+```python
+from microbench import RedisOutput
+results = RedisOutput('bench:results', host='redis.example.com').get_results()
+```
 
 ## Dry run
 

--- a/docs/user-guide/output.md
+++ b/docs/user-guide/output.md
@@ -119,6 +119,8 @@ results = bench.get_results(format='df')  # pandas DataFrame
 Results are appended to a Redis list using `RPUSH` and read back with
 `LRANGE`.
 
+The CLI exposes the same sink via `--redis-output KEY` (see the [CLI reference](../cli.md#redis-output)).
+
 ## Custom output sinks
 
 Subclass `Output` and implement `write` to send results anywhere:

--- a/microbench/__main__.py
+++ b/microbench/__main__.py
@@ -70,7 +70,14 @@ def _show_dry_run(args, cmd, mixin_names, mixin_map):
     """Print a summary of the resolved configuration and exit."""
     lines = ['Dry run — command will not be executed.\n']
     lines.append(f'  Command:    {" ".join(cmd)}')
-    lines.append(f'  Output:     {args.outfile or "stdout"}')
+    output_parts = []
+    if args.outfile:
+        output_parts.append(args.outfile)
+    if args.http_output:
+        output_parts.append(args.http_output)
+    if args.redis_output:
+        output_parts.append(f'redis:{args.redis_output}')
+    lines.append(f'  Output:     {", ".join(output_parts) or "stdout"}')
     lines.append(f'  Mixins:     {", ".join(mixin_names) if mixin_names else "none"}')
 
     # Mixin-specific settings that were explicitly supplied on the command line.
@@ -219,13 +226,15 @@ def _build_parser(mixin_map):
         action='version',
         version=f'microbench {__version__}',
     )
-    parser.add_argument(
+
+    output_group = parser.add_argument_group('output')
+    output_group.add_argument(
         '--outfile',
         '-o',
         metavar='FILE',
         help='Append results to FILE (JSONL format). Defaults to stdout.',
     )
-    parser.add_argument(
+    output_group.add_argument(
         '--http-output',
         metavar='URL',
         help=(
@@ -233,7 +242,7 @@ def _build_parser(mixin_map):
             'Can be combined with --outfile to write to both destinations.'
         ),
     )
-    parser.add_argument(
+    output_group.add_argument(
         '--http-output-header',
         metavar='KEY:VALUE',
         action='append',
@@ -245,13 +254,56 @@ def _build_parser(mixin_map):
             'Requires --http-output.'
         ),
     )
-    parser.add_argument(
+    output_group.add_argument(
         '--http-output-method',
         metavar='METHOD',
         default='POST',
         help='HTTP method for --http-output. Defaults to POST. Requires --http-output.',
     )
-    parser.add_argument(
+    output_group.add_argument(
+        '--redis-output',
+        metavar='KEY',
+        help=(
+            'RPUSH each record as JSON to a Redis list at KEY. '
+            'Can be combined with --outfile or --http-output. '
+            'Requires the "redis" package (pip install redis).'
+        ),
+    )
+    output_group.add_argument(
+        '--redis-host',
+        metavar='HOST',
+        default='localhost',
+        help='Redis server hostname for --redis-output (default: localhost).',
+    )
+    output_group.add_argument(
+        '--redis-port',
+        metavar='PORT',
+        type=int,
+        default=6379,
+        help=(
+            'Redis server port for --redis-output (default: 6379). '
+            'Requires --redis-output.'
+        ),
+    )
+    output_group.add_argument(
+        '--redis-db',
+        metavar='DB',
+        type=int,
+        default=0,
+        help=(
+            'Redis database index for --redis-output (default: 0). '
+            'Requires --redis-output.'
+        ),
+    )
+    output_group.add_argument(
+        '--redis-password',
+        metavar='PASSWORD',
+        default=None,
+        help='Redis AUTH password for --redis-output. Requires --redis-output.',
+    )
+
+    mixin_group = parser.add_argument_group('mixins')
+    mixin_group.add_argument(
         '--mixin',
         '-m',
         nargs='+',
@@ -264,20 +316,12 @@ def _build_parser(mixin_map):
             'MB-prefixed names (e.g. MBHostInfo) are also accepted.'
         ),
     )
-    parser.add_argument(
+    mixin_group.add_argument(
         '--show-mixins',
         action='store_true',
         help='List available mixins with descriptions and exit.',
     )
-    parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help=(
-            'Print the resolved configuration (command, mixins, settings) '
-            'and exit without running the command.'
-        ),
-    )
-    mixin_scope = parser.add_mutually_exclusive_group()
+    mixin_scope = mixin_group.add_mutually_exclusive_group()
     mixin_scope.add_argument(
         '--all',
         '-a',
@@ -291,7 +335,9 @@ def _build_parser(mixin_map):
         dest='no_mixins',
         help='Disable all mixins including defaults. Overrides --mixin.',
     )
-    parser.add_argument(
+
+    exec_group = parser.add_argument_group('execution')
+    exec_group.add_argument(
         '--iterations',
         '-n',
         type=_int_at_least(1),
@@ -299,7 +345,7 @@ def _build_parser(mixin_map):
         metavar='N',
         help='Run the command N times, recording each duration. Defaults to 1.',
     )
-    parser.add_argument(
+    exec_group.add_argument(
         '--warmup',
         '-w',
         type=_int_at_least(0),
@@ -307,7 +353,7 @@ def _build_parser(mixin_map):
         metavar='N',
         help='Run N unrecorded warm-up calls before timing begins. Defaults to 0.',
     )
-    parser.add_argument(
+    exec_group.add_argument(
         '--stdout',
         nargs='?',
         const='capture',
@@ -319,7 +365,7 @@ def _build_parser(mixin_map):
             'use --stdout=suppress to hide it.'
         ),
     )
-    parser.add_argument(
+    exec_group.add_argument(
         '--stderr',
         nargs='?',
         const='capture',
@@ -331,18 +377,7 @@ def _build_parser(mixin_map):
             'use --stderr=suppress to hide it.'
         ),
     )
-    parser.add_argument(
-        '--monitor-interval',
-        type=_int_at_least(1),
-        default=None,
-        metavar='SECONDS',
-        help=(
-            'Sample child process CPU usage and RSS every SECONDS seconds, '
-            'recording results in subprocess_monitor. Requires psutil. '
-            'Monitoring is disabled when this flag is omitted.'
-        ),
-    )
-    parser.add_argument(
+    exec_group.add_argument(
         '--timeout',
         type=_positive_float,
         default=None,
@@ -355,7 +390,7 @@ def _build_parser(mixin_map):
             'Timed-out iterations are recorded with call.timed_out = true.'
         ),
     )
-    parser.add_argument(
+    exec_group.add_argument(
         '--timeout-grace-period',
         type=_positive_float,
         default=None,
@@ -365,7 +400,26 @@ def _build_parser(mixin_map):
             f'Requires --timeout. Default: {_SIGTERM_GRACE_PERIOD}.'
         ),
     )
-    parser.add_argument(
+    exec_group.add_argument(
+        '--monitor-interval',
+        type=_int_at_least(1),
+        default=None,
+        metavar='SECONDS',
+        help=(
+            'Sample child process CPU usage and RSS every SECONDS seconds, '
+            'recording results in subprocess_monitor. Requires psutil. '
+            'Monitoring is disabled when this flag is omitted.'
+        ),
+    )
+    exec_group.add_argument(
+        '--dry-run',
+        action='store_true',
+        help=(
+            'Print the resolved configuration (command, mixins, settings) '
+            'and exit without running the command.'
+        ),
+    )
+    exec_group.add_argument(
         '--field',
         '-f',
         action='append',
@@ -373,12 +427,15 @@ def _build_parser(mixin_map):
         metavar='KEY=VALUE',
         help='Extra metadata field added to every record. Can be repeated.',
     )
+
     parser.add_argument(
         'command',
         nargs=argparse.REMAINDER,
         help='Command to benchmark (use -- to separate from microbench options).',
     )
+
     # Mixin-specific arguments, auto-discovered from cli_args on each mixin class.
+    mixin_opts_group = parser.add_argument_group('mixin options')
     for cli_name, cls in sorted(mixin_map.items()):
         for arg in getattr(cls, 'cli_args', []):
             kwargs = {
@@ -392,7 +449,7 @@ def _build_parser(mixin_map):
                 kwargs['nargs'] = arg.nargs
             if arg.type is not str:
                 kwargs['type'] = arg.type
-            parser.add_argument(*arg.flags, **kwargs)
+            mixin_opts_group.add_argument(*arg.flags, **kwargs)
     return parser
 
 
@@ -454,6 +511,21 @@ def main(argv=None):
         parser.error('--http-output-header requires --http-output.')
     if args.http_output_method != 'POST' and args.http_output is None:
         parser.error('--http-output-method requires --http-output.')
+
+    if args.redis_port != 6379 and args.redis_output is None:
+        parser.error('--redis-port requires --redis-output.')
+    if args.redis_db != 0 and args.redis_output is None:
+        parser.error('--redis-db requires --redis-output.')
+    if args.redis_password is not None and args.redis_output is None:
+        parser.error('--redis-password requires --redis-output.')
+    if args.redis_output:
+        try:
+            import redis  # noqa: F401
+        except ImportError:
+            parser.error(
+                '--redis-output requires the "redis" package. '
+                'Install it with: pip install redis'
+            )
 
     if args.monitor_interval is not None:
         try:
@@ -532,6 +604,15 @@ def main(argv=None):
                 method=args.http_output_method,
             )
         )
+    if args.redis_output:
+        from microbench import RedisOutput
+
+        redis_kwargs = dict(
+            host=args.redis_host, port=args.redis_port, db=args.redis_db
+        )
+        if args.redis_password is not None:
+            redis_kwargs['password'] = args.redis_password
+        outputs.append(RedisOutput(args.redis_output, **redis_kwargs))
     if not outputs:
         outputs.append(FileOutput(sys.stdout))
 

--- a/microbench/tests/test_cli.py
+++ b/microbench/tests/test_cli.py
@@ -903,6 +903,156 @@ def test_cli_http_output_header_invalid_format_errors():
 
 
 # ---------------------------------------------------------------------------
+# Redis output
+# ---------------------------------------------------------------------------
+
+
+def _run_main_redis(argv):
+    redis_store = []
+    mock_client = MagicMock()
+    mock_client.rpush.side_effect = lambda key, val: redis_store.append(val)
+    mock_redis = MagicMock()
+    mock_redis.StrictRedis.return_value = mock_client
+    buf = io.StringIO()
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        with patch.dict('sys.modules', {'redis': mock_redis}):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(argv)
+    return exc.value.code, mock_redis, mock_client, redis_store
+
+
+def test_cli_redis_output_rpushes_record():
+    """--redis-output calls StrictRedis with defaults and rpushes a JSON record."""
+    code, mock_redis, mock_client, redis_store = _run_main_redis(
+        ['--no-mixin', '--redis-output', 'bench:results', '--', 'true']
+    )
+    assert code == 0
+    mock_redis.StrictRedis.assert_called_once_with(host='localhost', port=6379, db=0)
+    mock_client.rpush.assert_called_once()
+    key, val = mock_client.rpush.call_args[0]
+    assert key == 'bench:results'
+    record = json.loads(val)
+    assert record['call']['name'] == 'true'
+
+
+def test_cli_redis_output_no_stdout_record():
+    """--redis-output without --outfile produces no stdout JSONL."""
+    _, _, _, _ = _run_main_redis(
+        ['--no-mixin', '--redis-output', 'bench:results', '--', 'true']
+    )
+    # Implicitly verified: _run_main_redis uses a buf but doesn't return it;
+    # if stdout were written the rpush mock would still be called, so we
+    # test stdout directly here.
+    buf = io.StringIO()
+    mock_client = MagicMock()
+    mock_redis = MagicMock()
+    mock_redis.StrictRedis.return_value = mock_client
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        with patch.dict('sys.modules', {'redis': mock_redis}):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(
+                        ['--no-mixin', '--redis-output', 'bench:results', '--', 'true']
+                    )
+    assert buf.getvalue() == ''
+
+
+def test_cli_redis_output_and_outfile(tmp_path):
+    """--redis-output and --outfile together write to both destinations."""
+    outfile = tmp_path / 'results.jsonl'
+    mock_client = MagicMock()
+    mock_redis = MagicMock()
+    mock_redis.StrictRedis.return_value = mock_client
+    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+        with patch.dict('sys.modules', {'redis': mock_redis}):
+            with pytest.raises(SystemExit):
+                main(
+                    [
+                        '--no-mixin',
+                        '--outfile',
+                        str(outfile),
+                        '--redis-output',
+                        'bench:results',
+                        '--',
+                        'true',
+                    ]
+                )
+    assert outfile.exists()
+    assert json.loads(outfile.read_text())['call']['name'] == 'true'
+    mock_client.rpush.assert_called_once()
+
+
+def test_cli_redis_output_custom_host_port_db():
+    """--redis-host/port/db are forwarded to StrictRedis."""
+    _, mock_redis, _, _ = _run_main_redis(
+        [
+            '--no-mixin',
+            '--redis-output',
+            'bench:results',
+            '--redis-host',
+            'redis.example.com',
+            '--redis-port',
+            '6380',
+            '--redis-db',
+            '2',
+            '--',
+            'true',
+        ]
+    )
+    mock_redis.StrictRedis.assert_called_once_with(
+        host='redis.example.com', port=6380, db=2
+    )
+
+
+def test_cli_redis_output_password():
+    """--redis-password is forwarded as a password= kwarg to StrictRedis."""
+    _, mock_redis, _, _ = _run_main_redis(
+        [
+            '--no-mixin',
+            '--redis-output',
+            'bench:results',
+            '--redis-password',
+            'secret',
+            '--',
+            'true',
+        ]
+    )
+    mock_redis.StrictRedis.assert_called_once_with(
+        host='localhost', port=6379, db=0, password='secret'
+    )
+
+
+def test_cli_redis_port_without_redis_output_errors():
+    """--redis-port without --redis-output exits with a non-zero code."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--no-mixin', '--redis-port', '6380', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_redis_db_without_redis_output_errors():
+    """--redis-db without --redis-output exits with a non-zero code."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--no-mixin', '--redis-db', '1', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_redis_password_without_redis_output_errors():
+    """--redis-password without --redis-output exits with a non-zero code."""
+    with pytest.raises(SystemExit) as exc:
+        main(['--no-mixin', '--redis-password', 'secret', '--', 'true'])
+    assert exc.value.code != 0
+
+
+def test_cli_redis_output_missing_package_errors():
+    """--redis-output gives a helpful error when the redis package is not installed."""
+    with patch.dict('sys.modules', {'redis': None}):
+        with pytest.raises(SystemExit) as exc:
+            main(['--no-mixin', '--redis-output', 'bench:results', '--', 'true'])
+    assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
 # Mixin CLI args: MBGitInfo and MBFileHash
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `--redis-output KEY` (plus `--redis-host`, `--redis-port`, `--redis-db`, `--redis-password`) so the `RedisOutput` sink is usable from the CLI without writing Python. Companion flags require `--redis-output`; the `redis` package is validated at parse time with a helpful install hint.
- `--dry-run` now lists all active sinks, e.g. `Output: results.jsonl, redis:bench:key`.
- Restructure `_build_parser` into four named argument groups (`output`, `mixins`, `execution`, `mixin options`) so `--help` is scannable rather than a flat wall of 25+ flags. Flag order in `execution` is tightened: `--timeout`/`--timeout-grace-period` sit together, `--monitor-interval` follows, then `--dry-run` and `--field`.
- `docs/cli.md`: flags table split by group; `## Redis output` section added.
- `docs/user-guide/output.md`: one-line CLI cross-reference in the Redis section.