### PR TITLE
fix: address all v2.0 review findings — code bugs, docs, config, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,8 +248,8 @@ All notable changes to microbench are documented here.
 - **`MBPythonInfo` mixin** replaces `MBPythonVersion`: records a `python` dict
   with `version`, `prefix` (`sys.prefix`), and `executable` (`sys.executable`),
   giving a complete picture of the running interpreter in one field. `MBPythonVersion`
-  is deprecated and will be removed in a future release. `MBPythonInfo` is included
-  in :class:`MicroBench` by default (Python API) and in the CLI default mixin set;
+  has been removed (see breaking changes above). `MBPythonInfo` is included
+  in `MicroBench` by default (Python API) and in the CLI default mixin set;
   `--no-mixin` suppresses it on the CLI as usual.
 
 - **`MicroBenchBase`**: the core benchmarking machinery is now exposed as
@@ -426,8 +426,8 @@ Also includes all changes from v1.1.0.
   v2 schema migration documented in the breaking changes section above.
 
 - **`python-dateutil` dependency removed from `LiveStream`**: timestamp
-  parsing now uses `datetime.fromisoformat()` from the standard library
-  (Python 3.7+). Remove `python-dateutil` from your environment if it was
+  parsing now uses `datetime.fromisoformat()` from the standard library.
+  Remove `python-dateutil` from your environment if it was
   only installed for microbench.
 
 ## [1.1.0] - 2026-03-13

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The fastest way to use microbench is from the command line. Wrap any command
 and capture host metadata alongside timing, with no Python code required:
 
 ```bash
-python -m microbench --outfile results.jsonl -- ./run_simulation.sh --steps 1000
+microbench --outfile results.jsonl -- ./run_simulation.sh --steps 1000
 ```
 
 This records one JSONL record per invocation with timing, hostname, Python
@@ -58,13 +58,13 @@ version, SLURM variables, and more. Use `--monitor-interval` to sample CPU
 and memory usage over time:
 
 ```bash
-python -m microbench --outfile results.jsonl --monitor-interval 30 -- ./train_model.py
+microbench --outfile results.jsonl --monitor-interval 30 -- ./train_model.py
 ```
 
 Add `--field` to tag runs with custom metadata:
 
 ```bash
-python -m microbench --outfile results.jsonl --field experiment=run-42 -- ./run.sh
+microbench --outfile results.jsonl --field experiment=run-42 -- ./run.sh
 ```
 
 See the [CLI documentation](https://alubbock.github.io/microbench/cli/) for the
@@ -112,7 +112,7 @@ like:
 | One-off timing with host metadata | CLI | Zero setup |
 | Python functions with sub-timings (`bench.time()`) | Python API | Sub-timings require the `@bench` decorator or `bench.record()` context manager |
 | Custom capture logic (subclassing mixins) | Python API | Mixins are Python classes |
-| Capturing loaded Python package versions | Python API | `capture_versions` inspects live Python module objects |
+| Capturing loaded Python package versions | Python API | `capture_versions` inspects live Python module versions, not just installed |
 | Async Python functions | Python API | Requires `@bench` async decorator or `bench.arecord()` |
 
 ## Extended example

--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ result, the metadata shows exactly what was running.
 - **JSONL output** — one JSON object per call; load into pandas with
   `read_json(..., lines=True)`; flexibility to add any extra fields you
   need
-- **Flexible output** — write to a local file, in-memory buffer, Redis, or
-  custom destinations; file writes are safe for simultaneous writes from
-  multiple processes
+- **Flexible output** — write to a local file, in-memory buffer, Redis, HTTP
+  endpoint, or custom destinations; file writes are safe for simultaneous
+  writes from multiple processes
 - **Sub-timings** — label named phases inside a single record with
   `bench.time(name)`; all phases share one metadata capture pass and results
   accumulate in `call.timings` in call order
+- **Context managers** — `bench.record(name)` and `bench.record_on_exit(name)`
+  for timing code blocks without decorators
+- **Async support** — native `async def` decorator support and `bench.arecord()`
+  async context manager
+- **Quick stats** — `bench.summary()` prints min/mean/median/max/stdev with no
+  extra dependencies
 
 ## Installation
 
@@ -38,11 +44,35 @@ result, the metadata shows exactly what was running.
 pip install microbench
 ```
 
-## Quick start
+## Quick start — CLI
 
-Microbench works by adding a Python decorator `@bench` to the function you want to
-benchmark. Assuming you have `my_function`, you create the benchmark suite `bench`,
-add the decorator to your function, and simply call it as normal:
+The fastest way to use microbench is from the command line. Wrap any command
+and capture host metadata alongside timing, with no Python code required:
+
+```bash
+python -m microbench --outfile results.jsonl -- ./run_simulation.sh --steps 1000
+```
+
+This records one JSONL record per invocation with timing, hostname, Python
+version, SLURM variables, and more. Use `--monitor-interval` to sample CPU
+and memory usage over time:
+
+```bash
+python -m microbench --outfile results.jsonl --monitor-interval 30 -- ./train_model.py
+```
+
+Add `--field` to tag runs with custom metadata:
+
+```bash
+python -m microbench --outfile results.jsonl --field experiment=run-42 -- ./run.sh
+```
+
+See the [CLI documentation](https://alubbock.github.io/microbench/cli/) for the
+full option reference.
+
+## Quick start — Python API
+
+For Python-specific use cases, decorate functions directly:
 
 ```python
 from microbench import MicroBench
@@ -73,16 +103,26 @@ like:
 0  3f2a1b4c-8d9e-4f2a-b1c3-d4e5f6a7b8c9  2.0.0      my_function  [0.049823]     baseline
 ```
 
+## CLI vs Python API
+
+| Use case | Recommended | Why |
+|---|---|---|
+| Benchmarking shell scripts, compiled executables, or non-Python programs | CLI | Works with any language; no code changes needed |
+| SLURM jobs or batch scripts | CLI | Drop-in wrapper; captures SLURM metadata automatically |
+| One-off timing with host metadata | CLI | Zero setup |
+| Python functions with sub-timings (`bench.time()`) | Python API | Sub-timings require the `@bench` decorator or `bench.record()` context manager |
+| Custom capture logic (subclassing mixins) | Python API | Mixins are Python classes |
+| Capturing loaded Python package versions | Python API | `capture_versions` inspects live Python module objects |
+| Async Python functions | Python API | Requires `@bench` async decorator or `bench.arecord()` |
+
 ## Extended example
 
-Here's an extended example to give you an idea of real-world usage.
-
 ```python
-from microbench import MicroBench, MBFunctionCall, MBPythonInfo, \
+from microbench import MicroBench, MBFunctionCall, \
   MBHostInfo, MBSlurmInfo
 import numpy, pandas, time
 
-class MyBench(MicroBench, MBFunctionCall, MBPythonInfo, MBHostInfo, MBSlurmInfo):
+class MyBench(MicroBench, MBFunctionCall, MBHostInfo, MBSlurmInfo):
     outfile = '/home/user/my-benchmarks.jsonl'
     capture_versions = (numpy, pandas)
     env_vars = ('CUDA_VISIBLE_DEVICES',)
@@ -99,7 +139,6 @@ myfunction(x, y)
 
 Mixins used:
 - `MBFunctionCall` records the supplied arguments `x` and `y`.
-- `MBPythonInfo` captures the Python version, prefix, and executable.
 - `MBHostInfo` captures `host.hostname` and `host.os`.
 - `MBSlurmInfo` captures all `SLURM_` environment variables
   (used by the [SLURM](https://slurm.schedmd.com/overview.html) cluster system).
@@ -114,21 +153,8 @@ Constructor arguments:
 - `duration_counter` overrides the timer function, if you need precise timing.
 - `experiment='run-1'` adds a custom `experiment` field to every record.
 
-## Command-line interface
-
-Microbench can also wrap any external command and record metadata alongside
-timing, without writing Python code:
-
-```bash
-python -m microbench --outfile results.jsonl -- ./run_simulation.sh --steps 1000
-```
-
-This is useful for SLURM jobs, shell scripts, and compiled executables. Host
-info and SLURM variables are captured by default. Use `--mixin`, `--field`,
-`--iterations`, and `--warmup` to customise the run.
-
-See the [CLI documentation](https://alubbock.github.io/microbench/cli/) for
-the full option reference.
+Note: `MBPythonInfo` is included in `MicroBench` by default, so it does not
+need to be listed explicitly.
 
 ## Documentation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,8 @@
 
 ## Core
 
+::: microbench.MicroBenchBase
+
 ::: microbench.MicroBench
 
 ::: microbench.summary
@@ -12,6 +14,8 @@
 
 ::: microbench.FileOutput
 
+::: microbench.HttpOutput
+
 ::: microbench.RedisOutput
 
 ## Mixins
@@ -20,9 +24,23 @@
 
 ::: microbench.MBReturnValue
 
+::: microbench.MBPythonInfo
+
 ::: microbench.MBHostInfo
 
+::: microbench.MBPeakMemory
+
 ::: microbench.MBSlurmInfo
+
+::: microbench.MBLoadedModules
+
+::: microbench.MBWorkingDir
+
+::: microbench.MBCgroupLimits
+
+::: microbench.MBGitInfo
+
+::: microbench.MBFileHash
 
 ::: microbench.MBGlobalPackages
 
@@ -33,6 +51,10 @@
 ::: microbench.MBNvidiaSmi
 
 ::: microbench.MBLineProfiler
+
+## CLI
+
+::: microbench.CLIArg
 
 ## JSON encoding
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,11 +53,11 @@ Every record contains these fields automatically (all nested under `mb` or `call
 Here's an extended example to give you an idea of real-world usage.
 
 ```python
-from microbench import MicroBench, MBFunctionCall, MBPythonInfo, \
+from microbench import MicroBench, MBFunctionCall, \
     MBHostInfo, MBSlurmInfo
 import numpy, pandas, time
 
-class MyBench(MicroBench, MBFunctionCall, MBPythonInfo, MBHostInfo, MBSlurmInfo):
+class MyBench(MicroBench, MBFunctionCall, MBHostInfo, MBSlurmInfo):
     outfile = '/home/user/my-benchmarks.jsonl'
     capture_versions = (numpy, pandas)
     env_vars = ('CUDA_VISIBLE_DEVICES',)
@@ -74,10 +74,12 @@ myfunction(x, y)
 
 Mixins used:
 - `MBFunctionCall` records the supplied arguments `x` and `y`.
-- `MBPythonInfo` captures the Python version, prefix, and executable.
 - `MBHostInfo` captures `host.hostname` and `host.os`.
 - `MBSlurmInfo` captures all `SLURM_` environment variables (used by the
   [SLURM](https://slurm.schedmd.com/overview.html) cluster system).
+
+Note: `MBPythonInfo` is already included in `MicroBench` by default — there is
+no need to list it explicitly in the class definition.
 
 Class variables:
 - `outfile` saves results to a file (one JSON object per line).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,11 @@ mixins.
 - **Cluster and HPC ready** — capture SLURM environment variables, psutil resource metrics, and run IDs for correlating results across nodes
 - **JSONL output** — one JSON object per call; load directly into pandas with `read_json(..., lines=True)`; no schema lock-in
 - **Automatic run correlation** — `mb.run_id` is a UUID generated once per process; all bench suites in the same run share it, enabling `groupby('mb.run_id')` across independent suites
-- **Flexible output** — write to a local file, an in-memory buffer, or Redis; concurrent writers safe via `O_APPEND`
+- **Flexible output** — write to a local file, an in-memory buffer, Redis, or an HTTP endpoint; concurrent writers safe via `O_APPEND`
+- **Sub-timings** — label named phases inside a single record with `bench.time(name)`
+- **Context managers** — `bench.record(name)` and `bench.record_on_exit(name)` for timing code blocks without decorators
+- **Async support** — native `async def` decorator support and `bench.arecord()` async context manager
+- **Quick stats** — `bench.summary()` prints min/mean/median/max/stdev with no extra dependencies
 
 ## Installation
 
@@ -37,6 +41,7 @@ Some mixins have optional requirements:
 | `MBNvidiaSmi` | `nvidia-smi` on `PATH` (ships with NVIDIA drivers) |
 | `MBCondaPackages` | `conda` on `PATH` |
 | `RedisOutput` | [redis-py](https://github.com/andymccurdy/redis-py) |
+| `HttpOutput` | no extra dependencies (uses stdlib `urllib`) |
 | `LiveStream` | no extra dependencies (uses stdlib `datetime`) |
 | `envdiff` | [IPython](https://ipython.org/) |
 

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -173,7 +173,7 @@ contains durations for all iterations up to and including the failing one.
 By default, an exception in any `capture_` or `capturepost_` method
 propagates and aborts the benchmark call. Set `capture_optional = True` as
 a class attribute to catch failures instead and record them in
-`mb_capture_errors`:
+`call.capture_errors`:
 
 ```python
 from microbench import MicroBench, MBNvidiaSmi, MBCondaPackages

--- a/docs/user-guide/async.md
+++ b/docs/user-guide/async.md
@@ -20,7 +20,7 @@ async def fetch_data(url):
     return {'rows': 42}
 
 asyncio.run(fetch_data('https://example.com/api'))
-print(bench.get_results(format='df')[['call.name', 'call.start_time', 'call.durations']])
+print(bench.get_results(format='df', flat=True)[['call.name', 'call.start_time', 'call.durations']])
 ```
 
 The wrapper is a true `async def`, so you can `await` it, pass it to

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -5,6 +5,7 @@
 | Parameter | Default | Description |
 |---|---|---|
 | `outfile` | `None` | File path or file-like object to write results to. |
+| `outputs` | `None` | List of `Output` instances for multi-sink output. Mutually exclusive with `outfile`. |
 | `json_encoder` | `JSONEncoder` | Custom JSON encoder class. |
 | `tz` | `timezone.utc` | Timezone for `start_time` / `finish_time`. |
 | `iterations` | `1` | Number of times to run the decorated function. |

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -38,16 +38,18 @@ def my_function():
     pass
 ```
 
-Samples are stored as a list in the `monitor` field of each result record,
+Samples are stored as a list in the `call.monitor` field of each result record,
 each entry including a `timestamp` and whatever your `monitor` method
 returns:
 
 ```json
 {
-  "monitor": [
-    {"timestamp": "2024-01-01T00:00:00+00:00", "rss": 104857600, "vms": 536870912},
-    {"timestamp": "2024-01-01T00:01:30+00:00", "rss": 209715200, "vms": 536870912}
-  ]
+  "call": {
+    "monitor": [
+      {"timestamp": "2024-01-01T00:00:00+00:00", "rss": 104857600, "vms": 536870912},
+      {"timestamp": "2024-01-01T00:01:30+00:00", "rss": 209715200, "vms": 536870912}
+    ]
+  }
 }
 ```
 

--- a/docs/user-guide/output.md
+++ b/docs/user-guide/output.md
@@ -121,6 +121,46 @@ Results are appended to a Redis list using `RPUSH` and read back with
 
 The CLI exposes the same sink via `--redis-output KEY` (see the [CLI reference](../cli.md#redis-output)).
 
+## HTTP output
+
+`HttpOutput` POSTs each benchmark record as JSON to an HTTP/HTTPS endpoint.
+Useful for webhooks and real-time notifications (Slack, Teams, custom event
+pipelines). Uses only the Python standard library (`urllib`).
+
+```python
+from microbench import MicroBench, HttpOutput
+
+bench = MicroBench(outputs=[HttpOutput('https://example.com/events')])
+```
+
+Add authentication headers:
+
+```python
+bench = MicroBench(outputs=[HttpOutput(
+    'https://api.example.com/benchmarks',
+    headers={'Authorization': 'Bearer my-secret-token'},
+)])
+```
+
+Override `format_payload()` to customize the body shape (e.g. for Slack):
+
+```python
+import json
+from microbench import HttpOutput
+
+class SlackOutput(HttpOutput):
+    def format_payload(self, record):
+        name = record.get('call', {}).get('name', '?')
+        return json.dumps({'text': f'Benchmark `{name}` finished.'}).encode()
+
+bench = MicroBench(outputs=[SlackOutput('https://hooks.slack.com/services/...')])
+```
+
+`HttpOutput` raises on non-2xx responses or network failures — no silent
+dropping, no automatic retry.
+
+The CLI exposes the same sink via `--http-output URL` (see the [CLI reference](../cli.md#http-output)).
+
 ## Custom output sinks
 
 Subclass `Output` and implement `write` to send results anywhere:

--- a/microbench/cli/parser.py
+++ b/microbench/cli/parser.py
@@ -62,7 +62,8 @@ def _build_parser(mixin_map):
         prog='python -m microbench',
         description=(
             'Run an external command and record benchmark metadata to JSONL.\n\n'
-            'By default captures host-info, slurm-info, and loaded-modules. '
+            'By default captures python-info, host-info, slurm-info, '
+            'loaded-modules, and working-dir. '
             'Specifying --mixin replaces the defaults; use --show-mixins to '
             'list all available mixins. '
             'Metadata capture failures are recorded in call.capture_errors '

--- a/microbench/core/bench.py
+++ b/microbench/core/bench.py
@@ -68,7 +68,7 @@ def summary(results):
 
     n = len(durations)
     if n == 0:
-        print('No run_durations found in results.')
+        print('No call.durations found in results.')
         return
 
     stdev = _statistics.stdev(durations) if n > 1 else float('nan')
@@ -270,7 +270,7 @@ class MicroBenchBase:
         ] = ver
 
     def to_json(self, bm_data):
-        bm_str = f'{json.dumps(bm_data, cls=self._json_encoder)}'
+        bm_str = json.dumps(bm_data, cls=self._json_encoder)
 
         return bm_str
 
@@ -395,6 +395,7 @@ class MicroBenchBase:
 
         from microbench.mixins.profiling import MBLineProfiler
 
+        @functools.wraps(func)
         def inner(*args, **kwargs):
             bm_data = dict()
             bm_data.update(self._bm_static)

--- a/microbench/core/contexts.py
+++ b/microbench/core/contexts.py
@@ -40,16 +40,18 @@ class _ContextManagerRun:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._bench.post_run_triggers(self._bm_data)
-        self._bench.post_finish_triggers(self._bm_data)
-        if exc_type is not None:
-            self._bm_data['exception'] = {
-                'type': exc_type.__name__,
-                'message': str(exc_val),
-            }
-        bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
-        self._bench.output_result(bm_data)
-        _active_bm_data.reset(self._ctx_token)
+        try:
+            self._bench.post_run_triggers(self._bm_data)
+            self._bench.post_finish_triggers(self._bm_data)
+            if exc_type is not None:
+                self._bm_data['exception'] = {
+                    'type': exc_type.__name__,
+                    'message': str(exc_val),
+                }
+            bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
+            self._bench.output_result(bm_data)
+        finally:
+            _active_bm_data.reset(self._ctx_token)
         return False  # never suppress exceptions
 
 
@@ -82,16 +84,18 @@ class _AsyncContextManagerRun:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self._bench.post_run_triggers(self._bm_data)
-        self._bench.post_finish_triggers(self._bm_data)
-        if exc_type is not None:
-            self._bm_data['exception'] = {
-                'type': exc_type.__name__,
-                'message': str(exc_val),
-            }
-        bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
-        self._bench.output_result(bm_data)
-        _active_bm_data.reset(self._ctx_token)
+        try:
+            self._bench.post_run_triggers(self._bm_data)
+            self._bench.post_finish_triggers(self._bm_data)
+            if exc_type is not None:
+                self._bm_data['exception'] = {
+                    'type': exc_type.__name__,
+                    'message': str(exc_val),
+                }
+            bm_data = {k: v for k, v in self._bm_data.items() if not k.startswith('_')}
+            self._bench.output_result(bm_data)
+        finally:
+            _active_bm_data.reset(self._ctx_token)
         return False  # never suppress exceptions
 
 

--- a/microbench/core/monitoring.py
+++ b/microbench/core/monitoring.py
@@ -18,10 +18,14 @@ except ImportError:
 class _MonitorThread(threading.Thread):
     def __init__(self, telem_fn, interval, slot, timezone, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not psutil:
+            raise ImportError('Monitoring requires the "psutil" package')
         self._terminate = threading.Event()
+        self._prev_sigint = None
+        self._prev_sigterm = None
         if threading.current_thread() is threading.main_thread():
-            signal.signal(signal.SIGINT, self.terminate)
-            signal.signal(signal.SIGTERM, self.terminate)
+            self._prev_sigint = signal.signal(signal.SIGINT, self.terminate)
+            self._prev_sigterm = signal.signal(signal.SIGTERM, self.terminate)
         else:
             warnings.warn(
                 '_MonitorThread: signal handlers not registered because '
@@ -34,12 +38,16 @@ class _MonitorThread(threading.Thread):
         self._monitor_data = slot
         self._monitor_fn = telem_fn
         self._tz = timezone
-        if not psutil:
-            raise ImportError('Monitoring requires the "psutil" package')
         self.process = psutil.Process()
 
     def terminate(self, signum=None, frame=None):
         self._terminate.set()
+        if self._prev_sigint is not None:
+            signal.signal(signal.SIGINT, self._prev_sigint)
+            self._prev_sigint = None
+        if self._prev_sigterm is not None:
+            signal.signal(signal.SIGTERM, self._prev_sigterm)
+            self._prev_sigterm = None
 
     def _get_sample(self):
         sample = {'timestamp': datetime.now(self._tz)}

--- a/microbench/mixins/python.py
+++ b/microbench/mixins/python.py
@@ -112,7 +112,7 @@ class MBInstalledPackages:
 
         for pkg in importlib.metadata.distributions():
             python['installed_packages'][pkg.name] = pkg.version
-            if self.capture_paths:
+            if self.capture_paths and pkg.files:
                 python['installed_package_paths'][pkg.name] = os.path.dirname(
                     pkg.locate_file(pkg.files[0])
                 )
@@ -153,8 +153,6 @@ class MBCondaPackages:
             'path': os.environ.get('CONDA_PREFIX'),
             'packages': {},
         }
-
-        conda_prefix = os.environ.get('CONDA_PREFIX', sys.prefix)
         conda_exe = shutil.which('conda') or os.environ.get('CONDA_EXE', 'conda')
         pkg_list = subprocess.check_output(
             [conda_exe, 'list', '--prefix', conda_prefix]
@@ -167,7 +165,7 @@ class MBCondaPackages:
             pkg_name = pkg_data[0]
             pkg_version = pkg_data[1]
             if self.include_builds:
-                pkg_version += pkg_data[2]
+                pkg_version += ' ' + pkg_data[2]
             if self.include_channels and len(pkg_data) == 4:
                 pkg_version += '(' + pkg_data[3] + ')'
             bm_data['conda']['packages'][pkg_name] = pkg_version

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -13,15 +13,6 @@ except ImportError:
     psutil = None
 
 
-def _existing_dir(value):
-    """argparse type: accept an existing directory path."""
-    import argparse
-
-    if not os.path.isdir(value):
-        raise argparse.ArgumentTypeError(f'directory not found: {value!r}')
-    return value
-
-
 class MBHostInfo:
     """Capture hostname, operating system, and (optionally) CPU and RAM info.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",    
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.scripts]
@@ -25,6 +30,7 @@ microbench = "microbench.__main__:main"
 Homepage = "https://github.com/alubbock/microbench"
 
 [project.optional-dependencies]
+redis = ["redis"]
 test = ["pytest", "pytest-asyncio", "pytest-cov", "pandas", "numpy", "line_profiler", "psutil"]
 docs = ["mkdocs-material", "mkdocstrings[python]", "mike", "pymdown-extensions"]
 

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -43,12 +43,12 @@ def test_conda_no_channel_doubling():
     """include_channels=True must not double the version string (B1 fix)."""
     results = _run_conda_bench(include_builds=True, include_channels=True)
     packages = results['conda'][0]['packages']
-    # numpy has a channel: expect "version+build(channel)", not doubled version
-    assert packages['numpy'] == '1.24.3py311ha0bc626_0(conda-forge)', (
+    # numpy has a channel: expect "version build(channel)" with a space before build
+    assert packages['numpy'] == '1.24.3 py311ha0bc626_0(conda-forge)', (
         f'Got: {packages["numpy"]!r}'
     )
-    # pandas has no channel: expect "version+build"
-    assert packages['pandas'] == '2.0.3py311h9a0d8c7_0', f'Got: {packages["pandas"]!r}'
+    # pandas has no channel: expect "version build" with a space before build
+    assert packages['pandas'] == '2.0.3 py311h9a0d8c7_0', f'Got: {packages["pandas"]!r}'
 
 
 def test_conda_include_builds_false():


### PR DESCRIPTION
## Summary

Closes all issues identified in the v2.0 review across code, documentation, README, and configuration. All 291 tests pass; `ruff` is clean.

## Code fixes (`1fd1c51`)

- Add `@functools.wraps` to sync decorator path in `bench.__call__` (async path already had it)
- `_MonitorThread`: move psutil availability check before signal handler installation; save and restore previous SIGINT/SIGTERM handlers in `terminate()` so Python's default `KeyboardInterrupt` handler and any `record_on_exit` handler are not destroyed
- Wrap ContextVar token reset in `try/finally` in both `_ContextManagerRun.__exit__` and `_AsyncContextManagerRun.__aexit__` so the token is always reset even if output fails
- Remove duplicate `conda_prefix` assignment in `MBCondaPackages.capture_conda_packages`
- Fix missing space separator in conda build string concatenation (`1.24.3py311h...` → `1.24.3 py311h...`)
- Guard `pkg.files` against `None` in `MBInstalledPackages.capture_packages`
- Fix stale error message: `'run_durations'` → `'call.durations'` in `summary()`
- Remove unnecessary f-string wrapper in `MicroBenchBase.to_json()`
- Remove dead `_existing_dir()` function from `mixins/system.py`
- Fix CLI parser description to list all 5 default mixins (was listing 3 of 5)

## Documentation fixes (`eb49a44`)

- Fix stale field name `mb_capture_errors` → `call.capture_errors` (`advanced.md`)
- Add `flat=True` to `get_results()` example (`async.md`)
- Fix monitoring JSON nesting: `monitor` → `call.monitor` (`monitoring.md`)
- Fix CHANGELOG contradictions ("deprecated" → "has been removed") and remove Sphinx `:class:` markup
- Add `HttpOutput` section to output guide with basic, auth, Slack subclass examples
- Add 10 missing public symbols to `api-reference.md` (`MicroBenchBase`, `HttpOutput`, `CLIArg`, `MBPythonInfo`, `MBPeakMemory`, `MBLoadedModules`, `MBWorkingDir`, `MBCgroupLimits`, `MBGitInfo`, `MBFileHash`)
- Add missing features to `index.md` feature list (sub-timings, context managers, async, quick stats) and `HttpOutput` to requirements table
- Add `outputs` parameter row to `configuration.md` constructor table
- Remove redundant `MBPythonInfo` from `getting-started.md` (already included in `MicroBench`)

## README restructure + pyproject.toml (`2e6dd07`)

- CLI quick start now comes before Python API quick start
- New "CLI vs Python API" guidance table
- Remove redundant `MBPythonInfo` from extended example; add clarifying note
- Add HTTP endpoint to flexible output bullet; add context managers, async, quick stats to feature list
- Add Python 3.10-3.14 version classifiers to `pyproject.toml`
- Add `redis` optional dependency group to `pyproject.toml`