### PR TITLE
fix: cli return code is now first non-zero value

### DIFF
--- a/microbench/cli/main.py
+++ b/microbench/cli/main.py
@@ -377,4 +377,4 @@ def main(argv=None):
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()
 
-    sys.exit(max(bench._subprocess_returncodes, default=0))
+    sys.exit(next((code for code in bench._subprocess_returncodes if code != 0), 0))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_cli_records_command_and_timing():
     code, record, _ = _run_main(['--', 'sleep', '1'])
 
     assert code == 0
+    assert record['call']['invocation'] == 'CLI'
     assert record['call']['command'] == ['sleep', '1']
     assert record['call']['returncode'] == [0]
     assert 'start_time' in record['call']
@@ -253,8 +254,8 @@ def test_cli_iterations_and_warmup():
     assert len(record['call']['returncode']) == 4
 
 
-def test_cli_returncode_is_max_across_iterations():
-    """Process exits with the highest returncode seen across all iterations."""
+def test_cli_returncode_is_first_nonzero_across_iterations():
+    """Process exits with the first non-zero returncode seen across timed iterations."""
     mock_results = [
         MagicMock(returncode=0, stdout=None, stderr=None),
         MagicMock(returncode=2, stdout=None, stderr=None),
@@ -268,6 +269,40 @@ def test_cli_returncode_is_max_across_iterations():
 
     assert exc.value.code == 2
     assert json.loads(buf.getvalue())['call']['returncode'] == [0, 2, 1]
+
+
+def test_cli_returncode_preserves_first_nonzero_even_if_later_is_larger():
+    """A later larger returncode does not override the first failure."""
+    mock_results = [
+        MagicMock(returncode=0, stdout=None, stderr=None),
+        MagicMock(returncode=1, stdout=None, stderr=None),
+        MagicMock(returncode=2, stdout=None, stderr=None),
+    ]
+    buf = io.StringIO()
+    with patch('subprocess.run', side_effect=mock_results):
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit) as exc:
+                main(['--iterations', '3', '--', 'true'])
+
+    assert exc.value.code == 1
+    assert json.loads(buf.getvalue())['call']['returncode'] == [0, 1, 2]
+
+
+def test_cli_returncode_preserves_first_nonzero_signal_code():
+    """Negative subprocess returncodes are also returned if they are first non-zero."""
+    mock_results = [
+        MagicMock(returncode=0, stdout=None, stderr=None),
+        MagicMock(returncode=-15, stdout=None, stderr=None),
+        MagicMock(returncode=1, stdout=None, stderr=None),
+    ]
+    buf = io.StringIO()
+    with patch('subprocess.run', side_effect=mock_results):
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit) as exc:
+                main(['--iterations', '3', '--', 'true'])
+
+    assert exc.value.code == -15
+    assert json.loads(buf.getvalue())['call']['returncode'] == [0, -15, 1]
 
 
 def test_cli_multiple_mixins():
@@ -1253,6 +1288,42 @@ def test_cli_timeout_sigkill_required():
     assert record['call']['timed_out'] is True
     mock_proc.terminate.assert_called_once()
     mock_proc.kill.assert_called_once()
+
+
+def test_cli_timeout_during_warmup_does_not_set_timed_out():
+    """A timeout in warmup is discarded along with other warmup-only state."""
+    warmup_proc = _make_mock_popen()
+    warmup_proc.returncode = -15
+    warmup_proc.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),
+        None,
+        None,
+    ]
+
+    timed_proc = _make_mock_popen()
+    timed_proc.returncode = 0
+
+    buf = io.StringIO()
+    with patch('subprocess.Popen', side_effect=[warmup_proc, timed_proc]):
+        with patch('sys.stdout', buf):
+            with pytest.raises(SystemExit) as exc:
+                main(
+                    [
+                        '--no-mixin',
+                        '--warmup',
+                        '1',
+                        '--timeout',
+                        '5',
+                        '--',
+                        'sleep',
+                        '100',
+                    ]
+                )
+
+    assert exc.value.code == 0
+    record = json.loads(buf.getvalue())
+    assert record['call']['returncode'] == [0]
+    assert 'timed_out' not in record['call']
 
 
 def test_cli_version(capsys):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -381,6 +381,28 @@ def test_monitor_multiple_samples():
     )
 
 
+def test_monitor_preserved_when_exception_raised():
+    """Monitor samples are still written when the benchmarked call raises."""
+
+    class MonitorBench(MicroBench):
+        @staticmethod
+        def monitor(process):
+            return {'rss': process.memory_info().rss}
+
+    bench = MonitorBench()
+
+    @bench
+    def boom():
+        raise RuntimeError('boom')
+
+    with pytest.raises(RuntimeError, match='boom'):
+        boom()
+
+    results = bench.get_results()
+    assert len(results[0]['call']['monitor']) > 0
+    assert results[0]['exception']['type'] == 'RuntimeError'
+
+
 def test_functioncall_args_not_double_encoded():
     """MBFunctionCall must store raw values, not JSON strings (B5 fix).
 
@@ -781,6 +803,57 @@ def test_record_on_exit_sigterm_writes_record():
     assert results[0]['exit_signal'] == 'SIGTERM'
 
 
+def test_record_on_exit_sigterm_chains_previous_handler():
+    """The SIGTERM wrapper calls any previously installed SIGTERM handler."""
+    bench = MicroBench()
+    orig_excepthook = sys.excepthook
+    orig_sigterm = _signal.getsignal(_signal.SIGTERM)
+    calls = []
+
+    def previous_handler(signum, frame):
+        calls.append((signum, frame))
+
+    try:
+        _signal.signal(_signal.SIGTERM, previous_handler)
+        bench.record_on_exit('sim', handle_sigterm=True)
+        handler = _signal.getsignal(_signal.SIGTERM)
+        with patch('os.kill'), patch('signal.signal'):
+            handler(_signal.SIGTERM, None)
+        results = bench.get_results()
+    finally:
+        sys.excepthook = orig_excepthook
+        _signal.signal(_signal.SIGTERM, orig_sigterm)
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    assert calls == [(_signal.SIGTERM, None)]
+    assert results[0]['exit_signal'] == 'SIGTERM'
+
+
+def test_record_on_exit_capture_optional_records_capture_errors():
+    """capture_optional=True also protects failing capture methods at exit time."""
+
+    class Bench(MicroBench):
+        capture_optional = True
+
+        def capture_will_fail(self, bm_data):
+            raise RuntimeError('exit capture failed')
+
+    bench = Bench()
+    orig_excepthook = sys.excepthook
+    try:
+        bench.record_on_exit('sim')
+        results = _invoke_record_on_exit(bench)
+    finally:
+        sys.excepthook = orig_excepthook
+        _atexit.unregister(bench._record_on_exit_handler)
+
+    errors = results[0]['call']['capture_errors']
+    assert len(errors) == 1
+    assert errors[0]['method'] == 'capture_will_fail'
+    assert 'RuntimeError' in errors[0]['error']
+    assert 'exit capture failed' in errors[0]['error']
+
+
 def test_record_on_exit_handle_sigterm_false():
     """handle_sigterm=False leaves the SIGTERM handler unchanged."""
     bench = MicroBench()
@@ -1003,6 +1076,34 @@ async def test_async_decorator_functioncall():
 
 
 @pytest.mark.asyncio
+async def test_async_decorator_concurrent_calls_isolated():
+    """Concurrent async decorated calls keep per-task timing and arg state isolated."""
+
+    class Bench(MicroBench, MBFunctionCall):
+        pass
+
+    bench = Bench()
+
+    @bench
+    async def async_pipeline(name):
+        with bench.time(f'{name}_step'):
+            await asyncio.sleep(0)
+        return name
+
+    results = await asyncio.gather(async_pipeline('a'), async_pipeline('b'))
+    assert results == ['a', 'b']
+
+    records = bench.get_results()
+    assert len(records) == 2
+    by_arg = {r['call']['args'][0]: r for r in records}
+
+    assert by_arg['a']['call']['timings'][0]['name'] == 'a_step'
+    assert by_arg['b']['call']['timings'][0]['name'] == 'b_step'
+    assert by_arg['a']['call']['kwargs'] == {}
+    assert by_arg['b']['call']['kwargs'] == {}
+
+
+@pytest.mark.asyncio
 async def test_async_arecord_standard_fields():
     """bench.arecord() works as an async context manager with standard fields."""
     bench = MicroBench()
@@ -1082,6 +1183,30 @@ async def test_async_monitor_thread():
     assert not monitor_bench._monitor_thread.is_alive()
     results = monitor_bench.get_results()
     assert len(results[0]['call']['monitor']) > 0
+
+
+@pytest.mark.asyncio
+async def test_async_monitor_preserved_when_exception_raised():
+    """Async monitor samples are still written when the benchmarked call raises."""
+
+    class MonitorBench(MicroBench):
+        @staticmethod
+        def monitor(process):
+            return {'rss': process.memory_info().rss}
+
+    bench = MonitorBench()
+
+    @bench
+    async def boom():
+        await asyncio.sleep(0)
+        raise RuntimeError('async boom')
+
+    with pytest.raises(RuntimeError, match='async boom'):
+        await boom()
+
+    results = bench.get_results()
+    assert len(results[0]['call']['monitor']) > 0
+    assert results[0]['exception']['type'] == 'RuntimeError'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The CLI return code is now the first non-zero value from its timed (non warmup) subprocess runs, if present, or zero otherwise.