### PR TITLE
docs: fix minor issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ Be sure to review the breaking changes before upgrading.
   - `FileOutput` — writes JSONL to a file path or file-like object (wraps the
     previous default behaviour).
   - `RedisOutput` — writes to a Redis list.
+  - `HttpOutput` - New for v2 - POST each benchmark result to an HTTP/HTTPS endpoint.
 
   The existing `outfile` parameter and class-level `outfile` attribute continue
   to work as shorthand for a single `FileOutput`. Passing both `outfile` and

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ is active out of the box.
 | Cgroup CPU/RAM limits (containers, Linux only) | `--mixin cgroup-limits` | `MBCgroupLimits` |
 | Function call arguments | — | `MBFunctionCall` |
 | Function return value | — | `MBReturnValue` |
-| Peak RSS memory over a function call | — | `MBPeakMemory` |
+| Peak memory over a function call via `tracemalloc` | — | `MBPeakMemory` |
 | Python packages loaded into the caller's globals | — | `MBGlobalPackages` |
 | Line-by-line performance profile | — | `MBLineProfiler` |
 


### PR DESCRIPTION
* Correct the description of MBPeakMemory, which uses Python's memory allocator rather than reading the RSS value
* Add HTTPOutput to the CHANGELOG