### PR TITLE
feat: add MBResourceUsage mixin with POSIX getrusage() capture 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,33 @@ All notable changes to microbench are documented here.
 - **`MBResourceUsage` mixin**: captures POSIX `getrusage()` data — user and
   system CPU time, peak RSS (in bytes, normalised across platforms), minor and
   major page faults, block I/O operations, and voluntary/involuntary context
-  switches. Works in both CLI and Python API modes: CLI uses `RUSAGE_CHILDREN`
-  (subprocess resources); Python API uses `RUSAGE_SELF` (current-process
-  delta). Results are stored in `resource_usage`. Added as a **default CLI
-  mixin** so every CLI run captures it automatically.
+  switches. Results are stored as a **list** in `resource_usage`, one entry per
+  timed iteration, aligned index-for-index with `call.durations` and
+  `call.returncode`. Added as a **default CLI mixin** so every CLI run captures
+  it automatically.
+
+  - *CLI mode*: uses `os.wait4()` (available on all POSIX platforms) to capture
+    the exact rusage of each individual child process as reported by the kernel,
+    including a reliable `maxrss` per iteration regardless of `--iterations` or
+    `--warmup` count. On Windows (where `os.wait4()` is unavailable), falls back
+    to a `RUSAGE_CHILDREN` before/after delta; `maxrss` is omitted when
+    `--warmup > 0` or `--iterations > 1` to avoid misleading cumulative HWM
+    values.
+  - *Python API mode*: uses `RUSAGE_SELF` for a single aggregate before/after
+    delta across all iterations (list always has exactly one entry). `maxrss` is
+    omitted (lifetime process HWM, not per-call). Use `MBPeakMemory` for
+    per-call peak memory in Python API mode.
 
   On Windows (where the `resource` module is unavailable) the mixin records an
-  empty dict without raising an error.
+  empty list without raising an error.
 
 ### Enhancements
 
 - **`--mixin defaults` keyword** (CLI): `defaults` can be used as a mixin
   name to expand to the standard default set (`python-info`, `host-info`,
-  `slurm-info`, `loaded-modules`, `working-dir`). This makes it easy to add
-  one or more extra mixins without listing all five defaults explicitly:
+  `slurm-info`, `loaded-modules`, `working-dir`, `resource-usage`). This
+  makes it easy to add one or more extra mixins without listing all six
+  defaults explicitly:
   `microbench --mixin defaults file-hash -- ./job.sh`.
 
 - **`file-hash` mixin — automatic argument file scanning** (CLI): the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to microbench are documented here.
 
-## [Unreleased]
+## [2.1.0] - 2026-03-19
 
 ### New features
 
@@ -16,8 +16,6 @@ All notable changes to microbench are documented here.
 
   On Windows (where the `resource` module is unavailable) the mixin records an
   empty dict without raising an error.
-
-## [2.1.0] - 2026-03-19
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to microbench are documented here.
 
-## [2.1.0] - 2026-03-19
+## [Unreleased]
 
 ### New features
 
@@ -17,10 +17,10 @@ All notable changes to microbench are documented here.
   - *CLI mode*: on POSIX, uses `os.wait4()` to capture the exact rusage of each
     individual child process as reported by the kernel, including a reliable
     `maxrss` per iteration regardless of `--iterations` or `--warmup` count.
-  - *Python API mode*: uses `RUSAGE_SELF` for a single aggregate before/after
-    delta across all iterations (list always has exactly one entry). `maxrss` is
-    omitted (lifetime process HWM, not per-call). Use `MBPeakMemory` for
-    per-call peak memory in Python API mode.
+  - *Python API mode*: uses `RUSAGE_SELF` with a before/after delta around each
+    individual call — one entry per timed iteration, aligned with
+    `call.durations`. Warmup calls are excluded. `maxrss` is omitted (lifetime
+    process HWM, not per-call). Use `MBPeakMemory` for per-call peak memory.
 
   On platforms where the stdlib `resource` module is unavailable, the mixin
   records an empty list without raising an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to microbench are documented here.
 
 ## [Unreleased]
 
+### New features
+
+- **`MBResourceUsage` mixin**: captures POSIX `getrusage()` data — user and
+  system CPU time, peak RSS (in bytes, normalised across platforms), minor and
+  major page faults, block I/O operations, and voluntary/involuntary context
+  switches. Works in both CLI and Python API modes: CLI uses `RUSAGE_CHILDREN`
+  (subprocess resources); Python API uses `RUSAGE_SELF` (current-process
+  delta). Results are stored in `resource_usage`. Added as a **default CLI
+  mixin** so every CLI run captures it automatically.
+
+  On Windows (where the `resource` module is unavailable) the mixin records an
+  empty dict without raising an error.
+
+## [2.1.0] - 2026-03-19
+
 ### Enhancements
 
 - **`--mixin defaults` keyword** (CLI): `defaults` can be used as a mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ All notable changes to microbench are documented here.
     `call.durations`. Warmup calls are excluded. `maxrss` is omitted (lifetime
     process HWM, not per-call). Use `MBPeakMemory` for per-call peak memory.
 
-  On platforms where the stdlib `resource` module is unavailable, the mixin
-  records an empty list without raising an error.
+  On platforms where the stdlib `resource` module is unavailable, the
+  `resource_usage` key is omitted from the record entirely.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,16 @@ All notable changes to microbench are documented here.
   `call.returncode`. Added as a **default CLI mixin** so every CLI run captures
   it automatically.
 
-  - *CLI mode*: uses `os.wait4()` (available on all POSIX platforms) to capture
-    the exact rusage of each individual child process as reported by the kernel,
-    including a reliable `maxrss` per iteration regardless of `--iterations` or
-    `--warmup` count. On Windows (where `os.wait4()` is unavailable), falls back
-    to a `RUSAGE_CHILDREN` before/after delta; `maxrss` is omitted when
-    `--warmup > 0` or `--iterations > 1` to avoid misleading cumulative HWM
-    values.
+  - *CLI mode*: on POSIX, uses `os.wait4()` to capture the exact rusage of each
+    individual child process as reported by the kernel, including a reliable
+    `maxrss` per iteration regardless of `--iterations` or `--warmup` count.
   - *Python API mode*: uses `RUSAGE_SELF` for a single aggregate before/after
     delta across all iterations (list always has exactly one entry). `maxrss` is
     omitted (lifetime process HWM, not per-call). Use `MBPeakMemory` for
     per-call peak memory in Python API mode.
 
-  On Windows (where the `resource` module is unavailable) the mixin records an
-  empty list without raising an error.
+  On platforms where the stdlib `resource` module is unavailable, the mixin
+  records an empty list without raising an error.
 
 ### Enhancements
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ is active out of the box.
 | All `SLURM_*` environment variables | _(default)_ | `MBSlurmInfo` |
 | Loaded Environment Modules / Lmod stack | _(default)_ | `MBLoadedModules` |
 | Current working directory | _(default)_ | `MBWorkingDir` |
+| CPU time, peak RSS, page faults, block I/O ops, and context switches (POSIX) | _(default)_ | `MBResourceUsage` |
 | Git repo, commit hash, branch, dirty flag | `--mixin git-info` | `MBGitInfo` |
 | SHA-256 (or other) hash of specified files | `--mixin file-hash` | `MBFileHash` |
 | Installed Python packages and versions | `--mixin installed-packages` | `MBInstalledPackages` |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,11 +117,13 @@ Every record contains the standard `mb.*` and `call.*` fields plus:
 ## Default mixins
 
 When no `--mixin` is specified, `python-info`, `host-info`, `slurm-info`,
-`loaded-modules`, and `working-dir` are included automatically, capturing
-the Python interpreter version, prefix, and executable path; hostname and
-operating system; all `SLURM_*` environment variables; the loaded
-Lmod/Environment Modules software stack; and the current working directory.
-All five degrade gracefully or produce stable values outside their respective
+`loaded-modules`, `working-dir`, and `resource-usage` are included
+automatically, capturing the Python interpreter version, prefix, and
+executable path; hostname and operating system; all `SLURM_*` environment
+variables; the loaded Lmod/Environment Modules software stack; the current
+working directory; and POSIX resource usage (CPU time, peak RSS, page faults,
+I/O, and context switches) for the benchmarked subprocess.
+All six degrade gracefully or produce stable values outside their respective
 environments.
 
 Mixin names use a short kebab-case form without the `MB` prefix
@@ -235,6 +237,14 @@ microbench \
     --nvidia-gpus 0 1 \
     -- ./run_simulation.sh
 ```
+
+### `resource-usage` options
+
+`resource-usage` has no CLI flags. It is included in the defaults and records
+POSIX `getrusage()` data automatically for the benchmarked subprocess.
+
+On Windows, `resource-usage` records an empty `resource_usage` dict and does
+not raise an error (the `resource` module is POSIX-only).
 
 ## Capture failures
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,8 +243,9 @@ microbench \
 `resource-usage` has no CLI flags. It is included in the defaults and records
 POSIX `getrusage()` data automatically for the benchmarked subprocess.
 
-On Windows, `resource-usage` records an empty `resource_usage` list and does
-not raise an error (the Python `resource` module is POSIX-only).
+On platforms where the Python `resource` module is unavailable,
+`resource-usage` records an empty `resource_usage` list and does not raise an
+error.
 
 ## Capture failures
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -244,7 +244,7 @@ microbench \
 POSIX `getrusage()` data automatically for the benchmarked subprocess.
 
 On Windows, `resource-usage` records an empty `resource_usage` dict and does
-not raise an error (the `resource` module is POSIX-only).
+not raise an error (the Python `resource` module is POSIX-only).
 
 ## Capture failures
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,7 +243,7 @@ microbench \
 `resource-usage` has no CLI flags. It is included in the defaults and records
 POSIX `getrusage()` data automatically for the benchmarked subprocess.
 
-On Windows, `resource-usage` records an empty `resource_usage` dict and does
+On Windows, `resource-usage` records an empty `resource_usage` list and does
 not raise an error (the Python `resource` module is POSIX-only).
 
 ## Capture failures
@@ -299,6 +299,7 @@ With 10 iterations and 2 warmup runs, the record contains:
 - `call.durations` — list of 10 wall-clock durations in seconds
 - `call.returncode` — list of 10 exit codes (one per timed iteration)
 - `call.stdout` / `call.stderr` — list of 10 captured strings, if `--stdout`/`--stderr` is used
+- `resource_usage` — list of 10 per-iteration rusage dicts (when `resource-usage` mixin is active)
 
 Warmup runs are excluded from all three lists. The process exits with
 the first non-zero return code, if present, so any failing iteration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -244,8 +244,7 @@ microbench \
 POSIX `getrusage()` data automatically for the benchmarked subprocess.
 
 On platforms where the Python `resource` module is unavailable,
-`resource-usage` records an empty `resource_usage` list and does not raise an
-error.
+`resource-usage` omits the `resource_usage` key from the record entirely.
 
 ## Capture failures
 

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -70,7 +70,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBLoadedModules` | `loaded-modules` *(default)* | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
 | `MBWorkingDir` | `working-dir` *(default)* | `call.working_dir` — absolute path of the working directory at benchmark time | — |
 | `MBCgroupLimits` | `cgroup-limits` | `cgroups` dict with `cpu_cores_limit`, `memory_bytes_limit`, `version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
-| `MBResourceUsage` | `resource-usage` *(default)* | `resource_usage` dict with CPU times, peak RSS, page faults, I/O ops, and context switches (empty dict on Windows) | POSIX only (stdlib) |
+| `MBResourceUsage` | `resource-usage` *(default)* | `resource_usage` list of dicts with CPU times, peak RSS, page faults, I/O ops, and context switches per iteration (empty list on Windows) | POSIX only (stdlib) |
 | `MBGitInfo` | `git-info` | `git` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | Python only | `python.loaded_packages` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `installed-packages` | `python.installed_packages` (and optionally `python.installed_package_paths`) for every installed package | — |
@@ -348,16 +348,19 @@ dependencies are required.
 
 **Modes**
 
-- **CLI mode**: uses `RUSAGE_CHILDREN`, which accumulates resources consumed
-  by the benchmarked subprocess and all its descendants. A before/after
-  delta isolates each iteration's cost. `maxrss` is also recorded (see
-  platform notes below).
-- **Python API mode**: uses `RUSAGE_SELF`, which captures resources consumed
-  by the current Python process since the last snapshot. `maxrss` is
-  **omitted** — `RUSAGE_SELF.maxrss` is a lifetime process high-water mark
-  that reflects the peak since the interpreter started, not just since the
-  decorated function was called, making it unreliable for function-level
-  measurement.
+- **CLI mode**: uses `os.wait4()` (all POSIX platforms) to get the exact
+  rusage of each child process as reported by the kernel — one dict per
+  timed iteration, aligned index-for-index with `call.durations`.
+  `maxrss` is the child's own peak RSS.  On Windows (where `os.wait4()`
+  is unavailable), falls back to a `RUSAGE_CHILDREN` before/after delta;
+  `maxrss` is omitted when `--warmup > 0` or `--iterations > 1` because
+  the cumulative HWM cannot be attributed to a single child.
+- **Python API mode**: uses `RUSAGE_SELF` — a single aggregate before/after
+  delta across **all** iterations (the list always has exactly one entry).
+  `maxrss` is **omitted** — `RUSAGE_SELF.maxrss` is a lifetime process
+  high-water mark that reflects the peak since the interpreter started,
+  not just since the decorated function was called, making it unreliable
+  for function-level measurement.
 
 ```python
 from microbench import MicroBench, MBResourceUsage
@@ -374,38 +377,53 @@ def work():
 work()
 ```
 
-Python API record (no `maxrss`):
+Python API record (single aggregate entry, no `maxrss`):
 
 ```json
 {
-  "resource_usage": {
-    "utime": 0.052,
-    "stime": 0.003,
-    "minflt": 1024,
-    "majflt": 0,
-    "inblock": 0,
-    "oublock": 0,
-    "nvcsw": 2,
-    "nivcsw": 1
-  }
+  "resource_usage": [
+    {
+      "utime": 0.052,
+      "stime": 0.003,
+      "minflt": 1024,
+      "majflt": 0,
+      "inblock": 0,
+      "oublock": 0,
+      "nvcsw": 2,
+      "nivcsw": 1
+    }
+  ]
 }
 ```
 
-CLI record (includes `maxrss`):
+CLI record with `--iterations 2` (one entry per iteration, includes `maxrss`):
 
 ```json
 {
-  "resource_usage": {
-    "utime": 0.068,
-    "stime": 0.029,
-    "maxrss": 11386880,
-    "minflt": 621,
-    "majflt": 0,
-    "inblock": 0,
-    "oublock": 0,
-    "nvcsw": 1,
-    "nivcsw": 2
-  }
+  "resource_usage": [
+    {
+      "utime": 0.068,
+      "stime": 0.029,
+      "maxrss": 11386880,
+      "minflt": 621,
+      "majflt": 0,
+      "inblock": 0,
+      "oublock": 0,
+      "nvcsw": 1,
+      "nivcsw": 2
+    },
+    {
+      "utime": 0.071,
+      "stime": 0.031,
+      "maxrss": 11386880,
+      "minflt": 618,
+      "majflt": 0,
+      "inblock": 0,
+      "oublock": 0,
+      "nvcsw": 1,
+      "nivcsw": 3
+    }
+  ]
 }
 ```
 
@@ -427,31 +445,26 @@ reliable across platforms.
 
 #### Platform notes and known quirks
 
-**`maxrss` — CLI mode (`RUSAGE_CHILDREN`)**
+**`maxrss` — CLI mode with `os.wait4()` (all POSIX)**
 
+`os.wait4()` returns the exact rusage of each individual child process as
+reported by the kernel. `maxrss` is the child's own peak RSS, accurate
+regardless of iteration count or warmup. Values are normalised to bytes
+(Linux reports kilobytes; macOS already reports bytes).
+
+**`maxrss` — CLI mode without `os.wait4()` (Windows fallback)**
+
+Falls back to a `RUSAGE_CHILDREN` before/after delta.
 [`RUSAGE_CHILDREN.maxrss`](https://man7.org/linux/man-pages/man2/getrusage.2.html)
-is the cumulative high-water mark across *all waited children* of the current
-process since it started. The before/after delta is the most honest
-representation: a positive value means that child set a new process-lifetime
-RSS peak; zero means it did not exceed a prior sibling's peak.
-
-Consequence for `--iterations`: if iteration 0 launches a subprocess that
-peaks at 200 MB and iteration 1 launches one that peaks at 50 MB, iteration
-1 reports `maxrss: 0` — it never exceeded the prior maximum. This is correct
-accounting, not a bug. For the common single-iteration case the value is
-exact.
-
-True per-child `maxrss` isolation requires `os.wait4()` instead of
-`subprocess.wait()`, which would give the exact RSS of each individual child
-process. This is a planned improvement.
+is the cumulative high-water mark across *all waited children* since process
+start. When `--warmup > 0` or `--iterations > 1`, `maxrss` is omitted
+entirely — the delta cannot be attributed to a single child and would silently
+report misleading zeros.
 
 **`maxrss` — Python API mode (`RUSAGE_SELF`)**
 
 `RUSAGE_SELF.maxrss` is a lifetime high-water mark for the Python interpreter
-process. If the interpreter already allocated, say, 400 MB before the
-decorated function ran, `maxrss` will reflect that prior peak even if the
-function itself allocates nothing new. This makes it unreliable for
-isolating a single function call, so it is intentionally omitted. Use
+process. It is intentionally omitted. Use
 [`MBPeakMemory`](#mbpeakmemory) if you need per-call peak memory tracking.
 
 **`inblock` / `oublock` — macOS**
@@ -488,7 +501,7 @@ non-zero for any non-trivial workload.
 
 !!! note "Windows"
     The `resource` module is not available on Windows. `resource_usage` is
-    recorded as an empty dict without raising an error.
+    recorded as an empty list without raising an error.
 
 **CLI:** `resource-usage` is a default mixin — no flags needed:
 

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -70,7 +70,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBLoadedModules` | `loaded-modules` *(default)* | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
 | `MBWorkingDir` | `working-dir` *(default)* | `call.working_dir` — absolute path of the working directory at benchmark time | — |
 | `MBCgroupLimits` | `cgroup-limits` | `cgroups` dict with `cpu_cores_limit`, `memory_bytes_limit`, `version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
-| `MBResourceUsage` | `resource-usage` *(default)* | `resource_usage` list of dicts with CPU times, peak RSS, page faults, I/O ops, and context switches per iteration (empty list on Windows) | POSIX only (stdlib) |
+| `MBResourceUsage` | `resource-usage` *(default)* | `resource_usage` list of dicts with CPU times, peak RSS, page faults, I/O ops, and context switches (`[]` when the stdlib `resource` module is unavailable) | POSIX only (stdlib) |
 | `MBGitInfo` | `git-info` | `git` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | Python only | `python.loaded_packages` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `installed-packages` | `python.installed_packages` (and optionally `python.installed_package_paths`) for every installed package | — |
@@ -348,19 +348,19 @@ dependencies are required.
 
 **Modes**
 
-- **CLI mode**: uses `os.wait4()` (all POSIX platforms) to get the exact
-  rusage of each child process as reported by the kernel — one dict per
-  timed iteration, aligned index-for-index with `call.durations`.
-  `maxrss` is the child's own peak RSS.  On Windows (where `os.wait4()`
-  is unavailable), falls back to a `RUSAGE_CHILDREN` before/after delta;
-  `maxrss` is omitted when `--warmup > 0` or `--iterations > 1` because
-  the cumulative HWM cannot be attributed to a single child.
+- **CLI mode**: on POSIX, uses `os.wait4()` to get the exact rusage of each
+  child process as reported by the kernel — one dict per timed iteration,
+  aligned index-for-index with `call.durations`.
+  `maxrss` is the child's own peak RSS.
 - **Python API mode**: uses `RUSAGE_SELF` — a single aggregate before/after
   delta across **all** iterations (the list always has exactly one entry).
   `maxrss` is **omitted** — `RUSAGE_SELF.maxrss` is a lifetime process
   high-water mark that reflects the peak since the interpreter started,
   not just since the decorated function was called, making it unreliable
   for function-level measurement.
+
+On platforms where the stdlib `resource` module is unavailable, `resource_usage`
+is recorded as an empty list.
 
 ```python
 from microbench import MicroBench, MBResourceUsage
@@ -452,15 +452,6 @@ reported by the kernel. `maxrss` is the child's own peak RSS, accurate
 regardless of iteration count or warmup. Values are normalised to bytes
 (Linux reports kilobytes; macOS already reports bytes).
 
-**`maxrss` — CLI mode without `os.wait4()` (Windows fallback)**
-
-Falls back to a `RUSAGE_CHILDREN` before/after delta.
-[`RUSAGE_CHILDREN.maxrss`](https://man7.org/linux/man-pages/man2/getrusage.2.html)
-is the cumulative high-water mark across *all waited children* since process
-start. When `--warmup > 0` or `--iterations > 1`, `maxrss` is omitted
-entirely — the delta cannot be attributed to a single child and would silently
-report misleading zeros.
-
 **`maxrss` — Python API mode (`RUSAGE_SELF`)**
 
 `RUSAGE_SELF.maxrss` is a lifetime high-water mark for the Python interpreter
@@ -499,8 +490,8 @@ most page-in activity. Zero is normal.
 These are the most reliable fields across both Linux and macOS and are
 non-zero for any non-trivial workload.
 
-!!! note "Windows"
-    The `resource` module is not available on Windows. `resource_usage` is
+!!! note "Non-POSIX platforms"
+    When the Python `resource` module is unavailable, `resource_usage` is
     recorded as an empty list without raising an error.
 
 **CLI:** `resource-usage` is a default mixin — no flags needed:

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -352,8 +352,9 @@ dependencies are required.
   child process as reported by the kernel — one dict per timed iteration,
   aligned index-for-index with `call.durations`.
   `maxrss` is the child's own peak RSS.
-- **Python API mode**: uses `RUSAGE_SELF` — a single aggregate before/after
-  delta across **all** iterations (the list always has exactly one entry).
+- **Python API mode**: uses `RUSAGE_SELF` — one dict per timed iteration,
+  each a before/after delta around that single call (aligned index-for-index
+  with `call.durations`). Warmup calls are excluded.
   `maxrss` is **omitted** — `RUSAGE_SELF.maxrss` is a lifetime process
   high-water mark that reflects the peak since the interpreter started,
   not just since the decorated function was called, making it unreliable
@@ -377,7 +378,7 @@ def work():
 work()
 ```
 
-Python API record (single aggregate entry, no `maxrss`):
+Python API record (one entry per timed iteration, no `maxrss`):
 
 ```json
 {

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -19,9 +19,9 @@ to list all available mixins with descriptions:
 microbench --show-mixins
 ```
 
-By default, `python-info`, `host-info`, `slurm-info`, `loaded-modules`, and
-`working-dir` are included automatically. Specifying `--mixin` replaces the
-defaults entirely. Use `--no-mixin` to disable all mixins:
+By default, `python-info`, `host-info`, `slurm-info`, `loaded-modules`,
+`working-dir`, and `resource-usage` are included automatically. Specifying
+`--mixin` replaces the defaults entirely. Use `--no-mixin` to disable all mixins:
 
 ```bash
 # Only peak-memory — no host info or SLURM
@@ -70,6 +70,7 @@ combine any number of microbench mixins without conflicts, and their
 | `MBLoadedModules` | `loaded-modules` *(default)* | `loaded_modules` dict mapping module name to version (empty dict if no Lmod/Environment Modules are loaded) | — |
 | `MBWorkingDir` | `working-dir` *(default)* | `call.working_dir` — absolute path of the working directory at benchmark time | — |
 | `MBCgroupLimits` | `cgroup-limits` | `cgroups` dict with `cpu_cores_limit`, `memory_bytes_limit`, `version` (empty dict if not on Linux or cgroup fs unavailable) | Linux only |
+| `MBResourceUsage` | `resource-usage` *(default)* | `resource_usage` dict with CPU times, peak RSS, page faults, I/O ops, and context switches (empty dict on Windows) | POSIX only (stdlib) |
 | `MBGitInfo` | `git-info` | `git` dict with `repo`, `commit`, `branch`, `dirty` | `git` ≥ 2.11 on PATH |
 | `MBGlobalPackages` | Python only | `python.loaded_packages` for every package in the caller's global scope | — |
 | `MBInstalledPackages` | `installed-packages` | `python.installed_packages` (and optionally `python.installed_package_paths`) for every installed package | — |
@@ -337,6 +338,94 @@ platforms or when the cgroup filesystem is unavailable.
     Pair with `MBSlurmInfo` for full HPC context — `MBSlurmInfo` captures
     scheduler metadata (job ID, node list, etc.) while `MBCgroupLimits` captures
     the kernel-enforced resource limits.
+
+### `MBResourceUsage`
+
+Captures POSIX `getrusage()` data — CPU time, peak resident set size (RSS),
+page faults, block I/O operations, and context switches — using only the
+Python standard library (`resource` module). No extra dependencies are
+required.
+
+**Modes**
+
+- **CLI mode**: uses `RUSAGE_CHILDREN`, which accumulates the resources
+  consumed by the benchmarked subprocess and all its descendants. A
+  before/after delta isolates each iteration's cost.
+- **Python API mode**: uses `RUSAGE_SELF`, which captures resources consumed
+  by the current Python process since the last snapshot.
+
+**`maxrss` is always reported in bytes**, regardless of platform. Linux
+reports kilobytes and is automatically converted.
+
+```python
+from microbench import MicroBench, MBResourceUsage
+
+class Bench(MicroBench, MBResourceUsage):
+    pass
+
+bench = Bench()
+
+@bench
+def work():
+    return list(range(1_000_000))
+
+work()
+```
+
+Each record will contain:
+
+```json
+{
+  "resource_usage": {
+    "utime": 0.052,
+    "stime": 0.003,
+    "maxrss": 41943040,
+    "minflt": 1024,
+    "majflt": 0,
+    "inblock": 0,
+    "oublock": 0,
+    "nvcsw": 2,
+    "nivcsw": 1
+  }
+}
+```
+
+| Field | Description |
+|---|---|
+| `utime` | User CPU time in seconds (float) |
+| `stime` | System CPU time in seconds (float) |
+| `maxrss` | Peak resident set size in bytes (int) — high-water mark, not a delta |
+| `minflt` | Minor page faults — pages reclaimed without I/O (int) |
+| `majflt` | Major page faults — pages requiring I/O to load (int) |
+| `inblock` | Block input operations (int) |
+| `oublock` | Block output operations (int) |
+| `nvcsw` | Voluntary context switches (int) |
+| `nivcsw` | Involuntary context switches (int) |
+
+All counter fields (`minflt`, `majflt`, `inblock`, `oublock`, `nvcsw`,
+`nivcsw`) are reported as the **delta** between before- and after-snapshots
+so they reflect only the benchmarked work. `maxrss` is taken from the
+post-run snapshot directly because it is a high-water mark.
+
+!!! note "Platform availability"
+    The `resource` module is available on all POSIX platforms (Linux, macOS,
+    BSD). On Windows it does not exist, so `resource_usage` is recorded as an
+    empty dict without raising an error.
+
+!!! note "macOS `majflt`, `inblock`, `oublock`"
+    On macOS these counters are often zero because the kernel charges most
+    I/O to the virtual memory subsystem rather than individual processes. This
+    is normal kernel behaviour, not a bug.
+
+**CLI:** `resource-usage` is a default mixin — no flags needed:
+
+```bash
+# Included automatically
+microbench --outfile results.jsonl -- ./run_simulation.sh
+
+# Explicit, if defaults have been overridden
+microbench --mixin resource-usage -- ./run_simulation.sh
+```
 
 ## Code provenance
 

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -360,8 +360,8 @@ dependencies are required.
   not just since the decorated function was called, making it unreliable
   for function-level measurement.
 
-On platforms where the stdlib `resource` module is unavailable, `resource_usage`
-is recorded as an empty list.
+On platforms where the stdlib `resource` module is unavailable, the
+`resource_usage` key is omitted from the record entirely.
 
 ```python
 from microbench import MicroBench, MBResourceUsage
@@ -492,8 +492,8 @@ These are the most reliable fields across both Linux and macOS and are
 non-zero for any non-trivial workload.
 
 !!! note "Non-POSIX platforms"
-    When the Python `resource` module is unavailable, `resource_usage` is
-    recorded as an empty list without raising an error.
+    When the Python `resource` module is unavailable, the `resource_usage`
+    key is omitted from the record entirely.
 
 **CLI:** `resource-usage` is a default mixin — no flags needed:
 

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -341,21 +341,23 @@ platforms or when the cgroup filesystem is unavailable.
 
 ### `MBResourceUsage`
 
-Captures POSIX `getrusage()` data — CPU time, peak resident set size (RSS),
-page faults, block I/O operations, and context switches — using only the
-Python standard library (`resource` module). No extra dependencies are
-required.
+Captures POSIX [`getrusage(2)`](https://man7.org/linux/man-pages/man2/getrusage.2.html)
+data — CPU time, page faults, block I/O operations, and context switches —
+using only the Python standard library (`resource` module). No extra
+dependencies are required.
 
 **Modes**
 
-- **CLI mode**: uses `RUSAGE_CHILDREN`, which accumulates the resources
-  consumed by the benchmarked subprocess and all its descendants. A
-  before/after delta isolates each iteration's cost.
+- **CLI mode**: uses `RUSAGE_CHILDREN`, which accumulates resources consumed
+  by the benchmarked subprocess and all its descendants. A before/after
+  delta isolates each iteration's cost. `maxrss` is also recorded (see
+  platform notes below).
 - **Python API mode**: uses `RUSAGE_SELF`, which captures resources consumed
-  by the current Python process since the last snapshot.
-
-**`maxrss` is always reported in bytes**, regardless of platform. Linux
-reports kilobytes and is automatically converted.
+  by the current Python process since the last snapshot. `maxrss` is
+  **omitted** — `RUSAGE_SELF.maxrss` is a lifetime process high-water mark
+  that reflects the peak since the interpreter started, not just since the
+  decorated function was called, making it unreliable for function-level
+  measurement.
 
 ```python
 from microbench import MicroBench, MBResourceUsage
@@ -372,14 +374,13 @@ def work():
 work()
 ```
 
-Each record will contain:
+Python API record (no `maxrss`):
 
 ```json
 {
   "resource_usage": {
     "utime": 0.052,
     "stime": 0.003,
-    "maxrss": 41943040,
     "minflt": 1024,
     "majflt": 0,
     "inblock": 0,
@@ -390,32 +391,104 @@ Each record will contain:
 }
 ```
 
-| Field | Description |
-|---|---|
-| `utime` | User CPU time in seconds (float) |
-| `stime` | System CPU time in seconds (float) |
-| `maxrss` | Peak resident set size in bytes (int) — high-water mark, not a delta |
-| `minflt` | Minor page faults — pages reclaimed without I/O (int) |
-| `majflt` | Major page faults — pages requiring I/O to load (int) |
-| `inblock` | Block input operations (int) |
-| `oublock` | Block output operations (int) |
-| `nvcsw` | Voluntary context switches (int) |
-| `nivcsw` | Involuntary context switches (int) |
+CLI record (includes `maxrss`):
 
-All counter fields (`minflt`, `majflt`, `inblock`, `oublock`, `nvcsw`,
-`nivcsw`) are reported as the **delta** between before- and after-snapshots
-so they reflect only the benchmarked work. `maxrss` is taken from the
-post-run snapshot directly because it is a high-water mark.
+```json
+{
+  "resource_usage": {
+    "utime": 0.068,
+    "stime": 0.029,
+    "maxrss": 11386880,
+    "minflt": 621,
+    "majflt": 0,
+    "inblock": 0,
+    "oublock": 0,
+    "nvcsw": 1,
+    "nivcsw": 2
+  }
+}
+```
 
-!!! note "Platform availability"
-    The `resource` module is available on all POSIX platforms (Linux, macOS,
-    BSD). On Windows it does not exist, so `resource_usage` is recorded as an
-    empty dict without raising an error.
+| Field | Modes | Description |
+|---|---|---|
+| `utime` | Both | User CPU time in seconds (float) |
+| `stime` | Both | System CPU time in seconds (float) |
+| `maxrss` | CLI only | Peak RSS in bytes (int) — see platform notes |
+| `minflt` | Both | Minor page faults — pages reclaimed without I/O (int) |
+| `majflt` | Both | Major page faults — pages requiring disk I/O (int) |
+| `inblock` | Both | Block input operations (int) — see platform notes |
+| `oublock` | Both | Block output operations (int) — see platform notes |
+| `nvcsw` | Both | Voluntary context switches (int) |
+| `nivcsw` | Both | Involuntary context switches (int) |
 
-!!! note "macOS `majflt`, `inblock`, `oublock`"
-    On macOS these counters are often zero because the kernel charges most
-    I/O to the virtual memory subsystem rather than individual processes. This
-    is normal kernel behaviour, not a bug.
+All fields are before/after **deltas** so they reflect only the benchmarked
+work. `utime`, `stime`, `minflt`, `nvcsw`, and `nivcsw` are the most
+reliable across platforms.
+
+#### Platform notes and known quirks
+
+**`maxrss` — CLI mode (`RUSAGE_CHILDREN`)**
+
+[`RUSAGE_CHILDREN.maxrss`](https://man7.org/linux/man-pages/man2/getrusage.2.html)
+is the cumulative high-water mark across *all waited children* of the current
+process since it started. The before/after delta is the most honest
+representation: a positive value means that child set a new process-lifetime
+RSS peak; zero means it did not exceed a prior sibling's peak.
+
+Consequence for `--iterations`: if iteration 0 launches a subprocess that
+peaks at 200 MB and iteration 1 launches one that peaks at 50 MB, iteration
+1 reports `maxrss: 0` — it never exceeded the prior maximum. This is correct
+accounting, not a bug. For the common single-iteration case the value is
+exact.
+
+True per-child `maxrss` isolation requires `os.wait4()` instead of
+`subprocess.wait()`, which would give the exact RSS of each individual child
+process. This is a planned improvement.
+
+**`maxrss` — Python API mode (`RUSAGE_SELF`)**
+
+`RUSAGE_SELF.maxrss` is a lifetime high-water mark for the Python interpreter
+process. If the interpreter already allocated, say, 400 MB before the
+decorated function ran, `maxrss` will reflect that prior peak even if the
+function itself allocates nothing new. This makes it unreliable for
+isolating a single function call, so it is intentionally omitted. Use
+[`MBPeakMemory`](#mbpeakmemory) if you need per-call peak memory tracking.
+
+**`inblock` / `oublock` — macOS**
+
+These counters are **almost always zero on macOS**, even for substantial file
+I/O.  The macOS unified buffer cache charges block I/O to the *first* process
+that touches each page; subsequent reads and writes to cached pages are not
+counted against the process that performed them. In practice, nearly all file
+I/O is served from the cache and the counters never increment.
+
+This is a macOS kernel accounting limitation. It is documented in the
+[`getrusage(2)` man page](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrusage.2.html):
+*"The numbers ru_inblock and ru_oublock account only for real I/O; data
+supplied by the caching mechanism is charged only to the first process to
+read or write the data."*
+
+**`inblock` / `oublock` — Linux**
+
+On Linux these counters increment only for I/O that truly bypasses the page
+cache — cold-cache reads (first access to a file since it was last evicted)
+or writes with `O_DIRECT`. Warm-cache reads also show zero. Drop the page
+cache (`echo 3 > /proc/sys/vm/drop_caches` as root) before benchmarking if
+you need to measure true cold-cache I/O.
+
+**`majflt` — macOS**
+
+Major page faults are rare on macOS because the unified buffer cache handles
+most page-in activity. Zero is normal.
+
+**`utime`, `stime`, `minflt`, `nvcsw`, `nivcsw`**
+
+These are the most reliable fields across both Linux and macOS and are
+non-zero for any non-trivial workload.
+
+!!! note "Windows"
+    The `resource` module is not available on Windows. `resource_usage` is
+    recorded as an empty dict without raising an error.
 
 **CLI:** `resource-usage` is a default mixin — no flags needed:
 

--- a/microbench/__init__.py
+++ b/microbench/__init__.py
@@ -43,6 +43,7 @@ from microbench.mixins.system import (  # noqa: F401
     MBCgroupLimits,
     MBHostInfo,
     MBLoadedModules,
+    MBResourceUsage,
     MBSlurmInfo,
     MBWorkingDir,
 )
@@ -77,6 +78,7 @@ __all__ = [
     'MBCgroupLimits',
     'MBGitInfo',
     'MBFileHash',
+    'MBResourceUsage',
     'MBGlobalPackages',
     'MBInstalledPackages',
     'MBCondaPackages',

--- a/microbench/cli/main.py
+++ b/microbench/cli/main.py
@@ -316,122 +316,139 @@ def main(argv=None):
             popen_kwargs['stderr'] = subprocess.PIPE
 
         proc = subprocess.Popen(cmd, **popen_kwargs)
+        try:
+            threads = []
+            if capture_stdout:
+                t = threading.Thread(
+                    target=_reader,
+                    args=(
+                        proc.stdout,
+                        stdout_chunks,
+                        _real_stdout,
+                        args.stdout == 'capture',
+                    ),
+                    daemon=True,
+                )
+                t.start()
+                threads.append(t)
+            if capture_stderr:
+                t = threading.Thread(
+                    target=_reader,
+                    args=(
+                        proc.stderr,
+                        stderr_chunks,
+                        _real_stderr,
+                        args.stderr == 'capture',
+                    ),
+                    daemon=True,
+                )
+                t.start()
+                threads.append(t)
 
-        threads = []
-        if capture_stdout:
-            t = threading.Thread(
-                target=_reader,
-                args=(
-                    proc.stdout,
-                    stdout_chunks,
-                    _real_stdout,
-                    args.stdout == 'capture',
-                ),
-                daemon=True,
-            )
-            t.start()
-            threads.append(t)
-        if capture_stderr:
-            t = threading.Thread(
-                target=_reader,
-                args=(
-                    proc.stderr,
-                    stderr_chunks,
-                    _real_stderr,
-                    args.stderr == 'capture',
-                ),
-                daemon=True,
-            )
-            t.start()
-            threads.append(t)
+            monitor_thread = None
+            if monitor_interval is not None and bench._subprocess_timed_phase:
+                monitor_thread = _SubprocessMonitorThread(proc.pid, monitor_interval)
+                monitor_thread.start()
 
-        monitor_thread = None
-        if monitor_interval is not None and bench._subprocess_timed_phase:
-            monitor_thread = _SubprocessMonitorThread(proc.pid, monitor_interval)
-            monitor_thread.start()
+            timed_out = False
+            child_rusage = None
 
-        timed_out = False
-        child_rusage = None
+            if _resource is not None:
+                # os.wait4() reaps the child and returns its exact per-child rusage
+                # in a single syscall.  It must be called *instead* of proc.wait().
+                #
+                # Timeout handling: os.wait4() is a blocking call with no built-in
+                # deadline.  We handle it by running wait4 in a daemon thread and
+                # joining with a timeout.  If the join times out, we terminate/kill
+                # the child, then block on wait4 (the child is now dying so this
+                # completes quickly).
+                _wait4_result = [None]  # [(pid, status, rusage)]
+                _wait4_error = [None]
 
-        if _resource is not None:
-            # os.wait4() reaps the child and returns its exact per-child rusage
-            # in a single syscall.  It must be called *instead* of proc.wait().
-            #
-            # Timeout handling: os.wait4() is a blocking call with no built-in
-            # deadline.  We handle it by running wait4 in a daemon thread and
-            # joining with a timeout.  If the join times out, we terminate/kill
-            # the child, then block on wait4 (the child is now dying so this
-            # completes quickly).
-            _wait4_result = [None]  # [(pid, status, rusage)]
-            _wait4_error = [None]
+                def _do_wait4():
+                    try:
+                        _wait4_result[0] = os.wait4(proc.pid, 0)
+                    except BaseException as exc:  # pragma: no cover - defensive
+                        _wait4_error[0] = exc
 
-            def _do_wait4():
-                try:
-                    _wait4_result[0] = os.wait4(proc.pid, 0)
-                except BaseException as exc:  # pragma: no cover - defensive
-                    _wait4_error[0] = exc
+                _wait4_thread = threading.Thread(target=_do_wait4, daemon=True)
+                _wait4_thread.start()
+                _wait4_thread.join(timeout=timeout)
 
-            _wait4_thread = threading.Thread(target=_do_wait4, daemon=True)
-            _wait4_thread.start()
-            _wait4_thread.join(timeout=timeout)
-
-            if _wait4_thread.is_alive():
-                # Timed out — terminate/kill the child and wait for it to exit.
-                timed_out = True
-                proc.terminate()
-                try:
-                    grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
-                    _wait4_thread.join(timeout=grace)
-                except Exception:
-                    pass
                 if _wait4_thread.is_alive():
-                    proc.kill()
-                    _wait4_thread.join()  # child is dead; this will return quickly
+                    # Timed out — terminate/kill the child and wait for it to exit.
+                    timed_out = True
+                    proc.terminate()
+                    try:
+                        grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
+                        _wait4_thread.join(timeout=grace)
+                    except Exception:
+                        pass
+                    if _wait4_thread.is_alive():
+                        proc.kill()
+                        _wait4_thread.join()  # child is dead; this will return quickly
 
-            if _wait4_error[0] is not None:
-                raise _wait4_error[0]
+                if _wait4_error[0] is not None:
+                    raise _wait4_error[0]
 
-            if _wait4_result[0] is None:  # pragma: no cover - defensive
-                raise RuntimeError('os.wait4() returned no child status')
+                if _wait4_result[0] is None:  # pragma: no cover - defensive
+                    raise RuntimeError('os.wait4() returned no child status')
 
-            _, wait_status, raw_ru = _wait4_result[0]
-            proc.returncode = os.waitstatus_to_exitcode(wait_status)
-            child_rusage = raw_ru
-        else:
-            # No resource module available: use proc.wait() with optional timeout.
-            try:
-                proc.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                timed_out = True
-                proc.terminate()
+                _, wait_status, raw_ru = _wait4_result[0]
+                proc.returncode = os.waitstatus_to_exitcode(wait_status)
+                child_rusage = raw_ru
+            else:
+                # No resource module available: use proc.wait() with optional timeout.
                 try:
-                    grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
-                    proc.wait(timeout=grace)
+                    proc.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait()
+                    timed_out = True
+                    proc.terminate()
+                    try:
+                        grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
+                        proc.wait(timeout=grace)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait()
 
-        if monitor_thread is not None:
-            monitor_thread.stop()
-            monitor_thread.join()
-            bench._subprocess_monitor.append(monitor_thread.samples)
+            if monitor_thread is not None:
+                monitor_thread.stop()
+                monitor_thread.join()
+                bench._subprocess_monitor.append(monitor_thread.samples)
 
-        for t in threads:
-            t.join()
+            for t in threads:
+                t.join()
 
-        if timed_out and bench._subprocess_timed_phase:
-            bench._subprocess_timed_out = True
-        bench._subprocess_returncodes.append(proc.returncode)
-        if capture_stdout:
-            bench._subprocess_stdout.append(''.join(stdout_chunks))
-        if capture_stderr:
-            bench._subprocess_stderr.append(''.join(stderr_chunks))
+            if timed_out and bench._subprocess_timed_phase:
+                bench._subprocess_timed_out = True
+            bench._subprocess_returncodes.append(proc.returncode)
+            if capture_stdout:
+                bench._subprocess_stdout.append(''.join(stdout_chunks))
+            if capture_stderr:
+                bench._subprocess_stderr.append(''.join(stderr_chunks))
 
-        # Accumulate per-iteration resource usage (only during timed phase).
-        if bench._subprocess_timed_phase and child_rusage is not None:
-            from microbench.mixins.system import _rusage_from_wait4
+            # Accumulate per-iteration resource usage (only during timed phase).
+            if bench._subprocess_timed_phase and child_rusage is not None:
+                from microbench.mixins.system import _rusage_from_wait4
 
-            bench._subprocess_resource_usage.append(_rusage_from_wait4(child_rusage))
+                bench._subprocess_resource_usage.append(
+                    _rusage_from_wait4(child_rusage)
+                )
+        except BaseException:
+            # Ensure the child is not left running as an orphan on any unexpected
+            # exception (including KeyboardInterrupt during a join).
+            # proc.kill() is safe after os.wait4() has already reaped the child
+            # (it sends SIGKILL to a dead PID which Popen silently ignores).
+            # proc.wait() is safe after os.wait4() too: returncode is already set.
+            proc.kill()
+            proc.wait()
+            raise
+        finally:
+            # Always close pipe FDs to prevent file-descriptor leaks.
+            if proc.stdout is not None:
+                proc.stdout.close()
+            if proc.stderr is not None:
+                proc.stderr.close()
 
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()

--- a/microbench/cli/main.py
+++ b/microbench/cli/main.py
@@ -368,7 +368,7 @@ def main(argv=None):
                 def _do_wait4():
                     try:
                         _wait4_result[0] = os.wait4(proc.pid, 0)
-                    except BaseException as exc:  # pragma: no cover - defensive
+                    except BaseException as exc:
                         _wait4_error[0] = exc
 
                 _wait4_thread = threading.Thread(target=_do_wait4, daemon=True)

--- a/microbench/cli/main.py
+++ b/microbench/cli/main.py
@@ -13,9 +13,6 @@ from microbench.cli.parser import (
 from microbench.cli.registry import MIXIN_REGISTRY
 from microbench.cli.runner import _SubprocessMonitorThread
 
-# os.wait4() is available on all POSIX platforms; absent on Windows.
-_HAVE_WAIT4 = hasattr(os, 'wait4')
-
 _DEFAULT_MIXINS = (
     'python-info',
     'host-info',
@@ -301,11 +298,6 @@ def main(argv=None):
         monitor_interval = args.monitor_interval
         timeout = args.timeout
 
-        # Snapshot RUSAGE_CHILDREN before launching the child (fallback path only).
-        rusage_before = None
-        if _resource is not None and not _HAVE_WAIT4:
-            rusage_before = _resource.getrusage(_resource.RUSAGE_CHILDREN)
-
         stdout_chunks = []
         stderr_chunks = []
 
@@ -361,7 +353,7 @@ def main(argv=None):
         timed_out = False
         child_rusage = None
 
-        if _HAVE_WAIT4 and _resource is not None:
+        if _resource is not None:
             # os.wait4() reaps the child and returns its exact per-child rusage
             # in a single syscall.  It must be called *instead* of proc.wait().
             #
@@ -370,13 +362,14 @@ def main(argv=None):
             # joining with a timeout.  If the join times out, we terminate/kill
             # the child, then block on wait4 (the child is now dying so this
             # completes quickly).
-            _wait4_result = [None]  # [(pid, status, rusage)] or None
+            _wait4_result = [None]  # [(pid, status, rusage)]
+            _wait4_error = [None]
 
             def _do_wait4():
                 try:
                     _wait4_result[0] = os.wait4(proc.pid, 0)
-                except ChildProcessError:
-                    pass  # child already reaped
+                except BaseException as exc:  # pragma: no cover - defensive
+                    _wait4_error[0] = exc
 
             _wait4_thread = threading.Thread(target=_do_wait4, daemon=True)
             _wait4_thread.start()
@@ -395,15 +388,17 @@ def main(argv=None):
                     proc.kill()
                     _wait4_thread.join()  # child is dead; this will return quickly
 
-            if _wait4_result[0] is not None:
-                _, wait_status, raw_ru = _wait4_result[0]
-                proc.returncode = os.waitstatus_to_exitcode(wait_status)
-                child_rusage = raw_ru
-            elif proc.returncode is None:
-                # wait4 failed (ChildProcessError); fall back to proc.wait().
-                proc.wait()
+            if _wait4_error[0] is not None:
+                raise _wait4_error[0]
+
+            if _wait4_result[0] is None:  # pragma: no cover - defensive
+                raise RuntimeError('os.wait4() returned no child status')
+
+            _, wait_status, raw_ru = _wait4_result[0]
+            proc.returncode = os.waitstatus_to_exitcode(wait_status)
+            child_rusage = raw_ru
         else:
-            # Fallback: use proc.wait() with optional timeout.
+            # No resource module available: use proc.wait() with optional timeout.
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
@@ -433,23 +428,10 @@ def main(argv=None):
             bench._subprocess_stderr.append(''.join(stderr_chunks))
 
         # Accumulate per-iteration resource usage (only during timed phase).
-        if bench._subprocess_timed_phase and _resource is not None:
-            if child_rusage is not None:
-                # os.wait4() path: exact per-child rusage from the kernel.
-                from microbench.mixins.system import _rusage_from_wait4
+        if bench._subprocess_timed_phase and child_rusage is not None:
+            from microbench.mixins.system import _rusage_from_wait4
 
-                bench._subprocess_resource_usage.append(
-                    _rusage_from_wait4(child_rusage)
-                )
-            elif rusage_before is not None:
-                # Fallback: RUSAGE_CHILDREN before/after delta.
-                from microbench.mixins.system import _rusage_delta, _rusage_to_dict
-
-                rusage_after = _resource.getrusage(_resource.RUSAGE_CHILDREN)
-                after_dict = _rusage_to_dict(rusage_after, include_maxrss=True)
-                before_dict = _rusage_to_dict(rusage_before, include_maxrss=True)
-                entry = _rusage_delta(before_dict, after_dict)
-                bench._subprocess_resource_usage.append(entry)
+            bench._subprocess_resource_usage.append(_rusage_from_wait4(child_rusage))
 
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()

--- a/microbench/cli/main.py
+++ b/microbench/cli/main.py
@@ -13,6 +13,9 @@ from microbench.cli.parser import (
 from microbench.cli.registry import MIXIN_REGISTRY
 from microbench.cli.runner import _SubprocessMonitorThread
 
+# os.wait4() is available on all POSIX platforms; absent on Windows.
+_HAVE_WAIT4 = hasattr(os, 'wait4')
+
 _DEFAULT_MIXINS = (
     'python-info',
     'host-info',
@@ -200,6 +203,8 @@ def main(argv=None):
             self._subprocess_monitor = []
             self._subprocess_timed_out = False
             self._subprocess_timed_phase = True
+            # Reset resource-usage accumulator (populated by run() per iteration).
+            self._subprocess_resource_usage = []
 
         def capturepost_subprocess_result(self, bm_data):
             call = bm_data.setdefault('call', {})
@@ -276,6 +281,7 @@ def main(argv=None):
     bench._subprocess_stdout = []
     bench._subprocess_stderr = []
     bench._subprocess_monitor = []
+    bench._subprocess_resource_usage = []
     bench._subprocess_timed_out = False
     bench._subprocess_timed_phase = False  # becomes True after warmup
 
@@ -283,24 +289,23 @@ def main(argv=None):
     _real_stdout = sys.__stdout__
     _real_stderr = sys.__stderr__
 
+    # Lazy import: resource module is POSIX-only.
+    try:
+        import resource as _resource
+    except ImportError:
+        _resource = None
+
     def run():
         capture_stdout = args.stdout in _CAPTURE_CHOICES
         capture_stderr = args.stderr in _CAPTURE_CHOICES
         monitor_interval = args.monitor_interval
         timeout = args.timeout
 
-        if (
-            not capture_stdout
-            and not capture_stderr
-            and monitor_interval is None
-            and timeout is None
-        ):
-            result = subprocess.run(cmd)
-            bench._subprocess_returncodes.append(result.returncode)
-            return
+        # Snapshot RUSAGE_CHILDREN before launching the child (fallback path only).
+        rusage_before = None
+        if _resource is not None and not _HAVE_WAIT4:
+            rusage_before = _resource.getrusage(_resource.RUSAGE_CHILDREN)
 
-        # Use Popen so we have the PID (needed for monitoring) and can read
-        # stdout/stderr pipes in real time when capture is requested.
         stdout_chunks = []
         stderr_chunks = []
 
@@ -318,41 +323,87 @@ def main(argv=None):
         if capture_stderr:
             popen_kwargs['stderr'] = subprocess.PIPE
 
-        with subprocess.Popen(cmd, **popen_kwargs) as proc:
-            threads = []
-            if capture_stdout:
-                t = threading.Thread(
-                    target=_reader,
-                    args=(
-                        proc.stdout,
-                        stdout_chunks,
-                        _real_stdout,
-                        args.stdout == 'capture',
-                    ),
-                    daemon=True,
-                )
-                t.start()
-                threads.append(t)
-            if capture_stderr:
-                t = threading.Thread(
-                    target=_reader,
-                    args=(
-                        proc.stderr,
-                        stderr_chunks,
-                        _real_stderr,
-                        args.stderr == 'capture',
-                    ),
-                    daemon=True,
-                )
-                t.start()
-                threads.append(t)
+        proc = subprocess.Popen(cmd, **popen_kwargs)
 
-            monitor_thread = None
-            if monitor_interval is not None and bench._subprocess_timed_phase:
-                monitor_thread = _SubprocessMonitorThread(proc.pid, monitor_interval)
-                monitor_thread.start()
+        threads = []
+        if capture_stdout:
+            t = threading.Thread(
+                target=_reader,
+                args=(
+                    proc.stdout,
+                    stdout_chunks,
+                    _real_stdout,
+                    args.stdout == 'capture',
+                ),
+                daemon=True,
+            )
+            t.start()
+            threads.append(t)
+        if capture_stderr:
+            t = threading.Thread(
+                target=_reader,
+                args=(
+                    proc.stderr,
+                    stderr_chunks,
+                    _real_stderr,
+                    args.stderr == 'capture',
+                ),
+                daemon=True,
+            )
+            t.start()
+            threads.append(t)
 
-            timed_out = False
+        monitor_thread = None
+        if monitor_interval is not None and bench._subprocess_timed_phase:
+            monitor_thread = _SubprocessMonitorThread(proc.pid, monitor_interval)
+            monitor_thread.start()
+
+        timed_out = False
+        child_rusage = None
+
+        if _HAVE_WAIT4 and _resource is not None:
+            # os.wait4() reaps the child and returns its exact per-child rusage
+            # in a single syscall.  It must be called *instead* of proc.wait().
+            #
+            # Timeout handling: os.wait4() is a blocking call with no built-in
+            # deadline.  We handle it by running wait4 in a daemon thread and
+            # joining with a timeout.  If the join times out, we terminate/kill
+            # the child, then block on wait4 (the child is now dying so this
+            # completes quickly).
+            _wait4_result = [None]  # [(pid, status, rusage)] or None
+
+            def _do_wait4():
+                try:
+                    _wait4_result[0] = os.wait4(proc.pid, 0)
+                except ChildProcessError:
+                    pass  # child already reaped
+
+            _wait4_thread = threading.Thread(target=_do_wait4, daemon=True)
+            _wait4_thread.start()
+            _wait4_thread.join(timeout=timeout)
+
+            if _wait4_thread.is_alive():
+                # Timed out — terminate/kill the child and wait for it to exit.
+                timed_out = True
+                proc.terminate()
+                try:
+                    grace = args.timeout_grace_period or _SIGTERM_GRACE_PERIOD
+                    _wait4_thread.join(timeout=grace)
+                except Exception:
+                    pass
+                if _wait4_thread.is_alive():
+                    proc.kill()
+                    _wait4_thread.join()  # child is dead; this will return quickly
+
+            if _wait4_result[0] is not None:
+                _, wait_status, raw_ru = _wait4_result[0]
+                proc.returncode = os.waitstatus_to_exitcode(wait_status)
+                child_rusage = raw_ru
+            elif proc.returncode is None:
+                # wait4 failed (ChildProcessError); fall back to proc.wait().
+                proc.wait()
+        else:
+            # Fallback: use proc.wait() with optional timeout.
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
@@ -365,13 +416,13 @@ def main(argv=None):
                     proc.kill()
                     proc.wait()
 
-            if monitor_thread is not None:
-                monitor_thread.stop()
-                monitor_thread.join()
-                bench._subprocess_monitor.append(monitor_thread.samples)
+        if monitor_thread is not None:
+            monitor_thread.stop()
+            monitor_thread.join()
+            bench._subprocess_monitor.append(monitor_thread.samples)
 
-            for t in threads:
-                t.join()
+        for t in threads:
+            t.join()
 
         if timed_out and bench._subprocess_timed_phase:
             bench._subprocess_timed_out = True
@@ -380,6 +431,25 @@ def main(argv=None):
             bench._subprocess_stdout.append(''.join(stdout_chunks))
         if capture_stderr:
             bench._subprocess_stderr.append(''.join(stderr_chunks))
+
+        # Accumulate per-iteration resource usage (only during timed phase).
+        if bench._subprocess_timed_phase and _resource is not None:
+            if child_rusage is not None:
+                # os.wait4() path: exact per-child rusage from the kernel.
+                from microbench.mixins.system import _rusage_from_wait4
+
+                bench._subprocess_resource_usage.append(
+                    _rusage_from_wait4(child_rusage)
+                )
+            elif rusage_before is not None:
+                # Fallback: RUSAGE_CHILDREN before/after delta.
+                from microbench.mixins.system import _rusage_delta, _rusage_to_dict
+
+                rusage_after = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+                after_dict = _rusage_to_dict(rusage_after, include_maxrss=True)
+                before_dict = _rusage_to_dict(rusage_before, include_maxrss=True)
+                entry = _rusage_delta(before_dict, after_dict)
+                bench._subprocess_resource_usage.append(entry)
 
     run.__name__ = os.path.basename(cmd[0])
     bench(run)()

--- a/microbench/cli/main.py
+++ b/microbench/cli/main.py
@@ -19,6 +19,7 @@ _DEFAULT_MIXINS = (
     'slurm-info',
     'loaded-modules',
     'working-dir',
+    'resource-usage',
 )
 
 

--- a/microbench/cli/registry.py
+++ b/microbench/cli/registry.py
@@ -12,6 +12,7 @@ from microbench.mixins.system import (
     MBCgroupLimits,
     MBHostInfo,
     MBLoadedModules,
+    MBResourceUsage,
     MBSlurmInfo,
     MBWorkingDir,
 )
@@ -28,6 +29,7 @@ MIXIN_REGISTRY: dict = {
     'cgroup-limits': MBCgroupLimits,
     'git-info': MBGitInfo,
     'file-hash': MBFileHash,
+    'resource-usage': MBResourceUsage,
     'installed-packages': MBInstalledPackages,
     'conda-packages': MBCondaPackages,
     'peak-memory': MBPeakMemory,

--- a/microbench/core/bench.py
+++ b/microbench/core/bench.py
@@ -248,8 +248,16 @@ class MicroBenchBase:
 
     def pre_run_triggers(self, bm_data):
         bm_data['_run_start'] = self._duration_counter()
+        # Forward to mixin overrides via cooperative super() chaining.
+        parent = super()
+        if hasattr(parent, 'pre_run_triggers'):
+            parent.pre_run_triggers(bm_data)
 
     def post_run_triggers(self, bm_data):
+        # Forward to mixin overrides before recording the elapsed time.
+        parent = super()
+        if hasattr(parent, 'post_run_triggers'):
+            parent.post_run_triggers(bm_data)
         bm_data['call']['durations'].append(
             self._duration_counter() - bm_data['_run_start']
         )

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -317,11 +317,7 @@ def _rusage_from_wait4(raw_ru):
 
 
 def _rusage_delta(before, after):
-    """Return ``after - before`` for all accumulator fields.
-
-    ``maxrss`` is only included when ``before`` has a ``maxrss`` key.
-    """
-    d = {
+    return {
         'utime': after['utime'] - before['utime'],
         'stime': after['stime'] - before['stime'],
         'minflt': after['minflt'] - before['minflt'],
@@ -331,9 +327,6 @@ def _rusage_delta(before, after):
         'nvcsw': after['nvcsw'] - before['nvcsw'],
         'nivcsw': after['nivcsw'] - before['nivcsw'],
     }
-    if 'maxrss' in before:
-        d['maxrss'] = after['maxrss'] - before['maxrss']
-    return d
 
 
 class MBResourceUsage:
@@ -360,7 +353,7 @@ class MBResourceUsage:
       peak RSS in Python API mode.
 
     On non-POSIX platforms where the ``resource`` module is unavailable, this
-    mixin records an empty list without raising an error.
+    mixin omits the ``resource_usage`` key entirely.
 
     Output key: ``resource_usage`` (list of dicts)
 
@@ -465,7 +458,6 @@ class MBResourceUsage:
     def capturepost_resource_usage(self, bm_data):
         """Write the resource_usage list to bm_data after all iterations."""
         if _resource is None:
-            bm_data['resource_usage'] = []
             return
         if hasattr(self, '_subprocess_command'):
             # CLI mode: list already populated by run() in main.py.

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -264,19 +264,19 @@ class MBCgroupLimits:
             bm_data['cgroups'] = {}
 
 
-def _rusage_to_dict(ru):
+def _rusage_to_dict(ru, *, include_maxrss=True):
     """Convert a ``struct_rusage`` to a plain dict with normalised fields.
 
     ``maxrss`` is normalised to bytes: macOS already reports bytes; Linux
     reports kilobytes and is multiplied by 1024.
+
+    Pass ``include_maxrss=False`` to omit ``maxrss`` (used in Python API mode
+    where ``RUSAGE_SELF.maxrss`` is a lifetime process high-water mark and
+    cannot meaningfully isolate a single function call).
     """
-    maxrss = ru.ru_maxrss
-    if sys.platform == 'linux':
-        maxrss *= 1024
-    return {
+    d = {
         'utime': ru.ru_utime,
         'stime': ru.ru_stime,
-        'maxrss': maxrss,
         'minflt': ru.ru_minflt,
         'majflt': ru.ru_majflt,
         'inblock': ru.ru_inblock,
@@ -284,18 +284,32 @@ def _rusage_to_dict(ru):
         'nvcsw': ru.ru_nvcsw,
         'nivcsw': ru.ru_nivcsw,
     }
+    if include_maxrss:
+        maxrss = ru.ru_maxrss
+        if sys.platform == 'linux':
+            maxrss *= 1024
+        d['maxrss'] = maxrss
+    return d
 
 
 def _rusage_delta(before, after):
-    """Return ``after - before`` for all accumulator fields.
+    """Return ``after - before`` for all accumulator fields including ``maxrss``.
 
-    ``maxrss`` is intentionally *not* delta'd — it is a high-water mark, not
-    an accumulator, so the post-run value is used directly.
+    All fields — including ``maxrss`` — are delta'd.  For ``RUSAGE_CHILDREN``,
+    ``maxrss`` is the **cumulative** high-water mark across all waited children
+    in the current process's lifetime.  Taking the delta isolates the
+    contribution of the most recent child: a positive value means that child
+    set a new process-lifetime RSS peak; zero means it did not exceed the
+    previous maximum.  This is honest for multi-iteration runs: a child that
+    uses less memory than a prior sibling correctly reports ``maxrss: 0``
+    rather than repeating the prior child's peak.
+
+    ``maxrss`` is absent when ``before`` has no ``maxrss`` key (Python API
+    mode — see ``_rusage_to_dict``).
     """
-    return {
+    d = {
         'utime': after['utime'] - before['utime'],
         'stime': after['stime'] - before['stime'],
-        'maxrss': after['maxrss'],
         'minflt': after['minflt'] - before['minflt'],
         'majflt': after['majflt'] - before['majflt'],
         'inblock': after['inblock'] - before['inblock'],
@@ -303,46 +317,82 @@ def _rusage_delta(before, after):
         'nvcsw': after['nvcsw'] - before['nvcsw'],
         'nivcsw': after['nivcsw'] - before['nivcsw'],
     }
+    if 'maxrss' in before:
+        d['maxrss'] = after['maxrss'] - before['maxrss']
+    return d
 
 
 class MBResourceUsage:
     """Capture POSIX ``getrusage()`` data for the benchmarked code.
 
-    Records CPU time, peak resident set size (RSS), page faults, block I/O
-    operations, and context switches. All values are taken from a
-    before/after delta so they reflect only the benchmarked work — not
-    cumulative process overhead.
-
-    ``maxrss`` is a **high-water mark** (not an accumulator), so it is
-    taken from the post-run snapshot directly. It is always normalised to
-    **bytes** regardless of platform (Linux reports kilobytes; macOS reports
-    bytes).
+    Records CPU time, page faults, block I/O operations, and context switches
+    from a before/after delta so values reflect only the benchmarked work.
+    In CLI mode, ``maxrss`` (peak RSS in bytes) is also recorded.
 
     **Modes**
 
-    - *CLI mode* (subprocess): uses ``RUSAGE_CHILDREN`` — resources
-      consumed by the benchmarked subprocess and all its descendants.
-    - *Python API mode* (function): uses ``RUSAGE_SELF`` — resources
-      consumed by the current process since the last snapshot.
+    - *CLI mode* (subprocess): uses ``RUSAGE_CHILDREN`` — resources consumed
+      by the benchmarked subprocess and all its descendants, isolated via a
+      before/after delta.
+    - *Python API mode* (function): uses ``RUSAGE_SELF`` — resources consumed
+      by the current process. ``maxrss`` is **omitted** in this mode because
+      ``RUSAGE_SELF.maxrss`` is a lifetime process high-water mark that
+      reflects peak usage since program start, not just during the decorated
+      function.  The remaining fields (CPU times, page faults, I/O, context
+      switches) are deltas and correctly isolate the function's contribution.
 
     On Windows (where the ``resource`` module is unavailable), this mixin
     records an empty dict without raising an error.
 
     Output key: ``resource_usage``
 
-    Fields recorded:
+    Fields recorded (CLI mode):
 
     - ``utime``: user CPU time (seconds, float)
     - ``stime``: system CPU time (seconds, float)
-    - ``maxrss``: peak RSS in bytes (int)
+    - ``maxrss``: peak RSS in bytes (int) — see platform notes below
     - ``minflt``: minor page faults (int)
     - ``majflt``: major page faults (int)
-    - ``inblock``: block input operations (int)
-    - ``oublock``: block output operations (int)
+    - ``inblock``: block input operations (int) — see platform notes below
+    - ``oublock``: block output operations (int) — see platform notes below
     - ``nvcsw``: voluntary context switches (int)
     - ``nivcsw``: involuntary context switches (int)
 
-    Example output::
+    Fields recorded (Python API mode): all of the above **except** ``maxrss``.
+
+    **Platform notes**
+
+    *maxrss* (CLI mode, ``RUSAGE_CHILDREN``):
+        ``RUSAGE_CHILDREN.maxrss`` is the cumulative maximum RSS across *all*
+        waited children of the current process since it started.  The
+        before/after delta is the most honest representation available: a
+        positive value means the child set a new process-lifetime peak; zero
+        means it did not exceed a prior sibling's peak.  With ``--iterations``
+        this means subsequent iterations that use less memory than the first
+        will report ``maxrss: 0``.  For single-iteration runs (the common
+        case) the value is exact.  True per-child ``maxrss`` isolation
+        requires ``os.wait4()`` integration, which is a planned improvement.
+
+    *inblock / oublock* (macOS):
+        These counters are almost always zero on macOS regardless of actual
+        I/O performed.  The macOS unified buffer cache charges block I/O to
+        the *first* process that touches each page; subsequent reads and
+        writes to cached pages are not counted.  In practice nearly all file
+        I/O is served from the cache and the counters never increment.  This
+        is a kernel accounting limitation, not a microbench bug.  On Linux,
+        ``inblock`` and ``oublock`` increment only for I/O that bypasses the
+        page cache (i.e. cold-cache reads or ``O_DIRECT`` writes); warm-cache
+        reads also show zero.
+
+    *majflt* (macOS):
+        Major page faults are rare on macOS because the unified buffer cache
+        handles most page-in activity.  Zero is normal.
+
+    *utime / stime / minflt / nvcsw / nivcsw*:
+        These are the most reliable fields across both Linux and macOS and
+        should be non-zero for any non-trivial workload.
+
+    Example output (CLI mode)::
 
         {
             "resource_usage": {
@@ -352,7 +402,7 @@ class MBResourceUsage:
                 "minflt": 512,
                 "majflt": 0,
                 "inblock": 0,
-                "oublock": 8,
+                "oublock": 0,
                 "nvcsw": 3,
                 "nivcsw": 1
             }
@@ -367,12 +417,15 @@ class MBResourceUsage:
         if _resource is None:
             return
         if hasattr(self, '_subprocess_command'):
-            # CLI mode: measure the child process.
+            # CLI mode: measure child processes; include maxrss.
             ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+            self._rusage_before = _rusage_to_dict(ru, include_maxrss=True)
         else:
             # Python API mode: measure the current process.
+            # Omit maxrss — RUSAGE_SELF.maxrss is a lifetime process HWM and
+            # cannot isolate a single function call's peak RSS.
             ru = _resource.getrusage(_resource.RUSAGE_SELF)
-        self._rusage_before = _rusage_to_dict(ru)
+            self._rusage_before = _rusage_to_dict(ru, include_maxrss=False)
 
     def capturepost_resource_usage(self, bm_data):
         """Compute the delta and store resource usage results."""
@@ -384,7 +437,8 @@ class MBResourceUsage:
             return
         if hasattr(self, '_subprocess_command'):
             ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+            after = _rusage_to_dict(ru, include_maxrss=True)
         else:
             ru = _resource.getrusage(_resource.RUSAGE_SELF)
-        after = _rusage_to_dict(ru)
+            after = _rusage_to_dict(ru, include_maxrss=False)
         bm_data['resource_usage'] = _rusage_delta(self._rusage_before, after)

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -1,6 +1,7 @@
 """System-info mixins.
 
-Classes: MBHostInfo, MBWorkingDir, MBSlurmInfo, MBCgroupLimits, MBLoadedModules.
+Classes: MBHostInfo, MBWorkingDir, MBSlurmInfo, MBCgroupLimits, MBLoadedModules,
+MBResourceUsage.
 """
 
 import os
@@ -11,6 +12,11 @@ try:
     import psutil
 except ImportError:
     psutil = None
+
+try:
+    import resource as _resource
+except ImportError:
+    _resource = None
 
 
 class MBHostInfo:
@@ -256,3 +262,129 @@ class MBCgroupLimits:
                 bm_data['cgroups'] = _read_cgroup_v1()
         except (OSError, ValueError, ZeroDivisionError):
             bm_data['cgroups'] = {}
+
+
+def _rusage_to_dict(ru):
+    """Convert a ``struct_rusage`` to a plain dict with normalised fields.
+
+    ``maxrss`` is normalised to bytes: macOS already reports bytes; Linux
+    reports kilobytes and is multiplied by 1024.
+    """
+    maxrss = ru.ru_maxrss
+    if sys.platform == 'linux':
+        maxrss *= 1024
+    return {
+        'utime': ru.ru_utime,
+        'stime': ru.ru_stime,
+        'maxrss': maxrss,
+        'minflt': ru.ru_minflt,
+        'majflt': ru.ru_majflt,
+        'inblock': ru.ru_inblock,
+        'oublock': ru.ru_oublock,
+        'nvcsw': ru.ru_nvcsw,
+        'nivcsw': ru.ru_nivcsw,
+    }
+
+
+def _rusage_delta(before, after):
+    """Return ``after - before`` for all accumulator fields.
+
+    ``maxrss`` is intentionally *not* delta'd — it is a high-water mark, not
+    an accumulator, so the post-run value is used directly.
+    """
+    return {
+        'utime': after['utime'] - before['utime'],
+        'stime': after['stime'] - before['stime'],
+        'maxrss': after['maxrss'],
+        'minflt': after['minflt'] - before['minflt'],
+        'majflt': after['majflt'] - before['majflt'],
+        'inblock': after['inblock'] - before['inblock'],
+        'oublock': after['oublock'] - before['oublock'],
+        'nvcsw': after['nvcsw'] - before['nvcsw'],
+        'nivcsw': after['nivcsw'] - before['nivcsw'],
+    }
+
+
+class MBResourceUsage:
+    """Capture POSIX ``getrusage()`` data for the benchmarked code.
+
+    Records CPU time, peak resident set size (RSS), page faults, block I/O
+    operations, and context switches. All values are taken from a
+    before/after delta so they reflect only the benchmarked work — not
+    cumulative process overhead.
+
+    ``maxrss`` is a **high-water mark** (not an accumulator), so it is
+    taken from the post-run snapshot directly. It is always normalised to
+    **bytes** regardless of platform (Linux reports kilobytes; macOS reports
+    bytes).
+
+    **Modes**
+
+    - *CLI mode* (subprocess): uses ``RUSAGE_CHILDREN`` — resources
+      consumed by the benchmarked subprocess and all its descendants.
+    - *Python API mode* (function): uses ``RUSAGE_SELF`` — resources
+      consumed by the current process since the last snapshot.
+
+    On Windows (where the ``resource`` module is unavailable), this mixin
+    records an empty dict without raising an error.
+
+    Output key: ``resource_usage``
+
+    Fields recorded:
+
+    - ``utime``: user CPU time (seconds, float)
+    - ``stime``: system CPU time (seconds, float)
+    - ``maxrss``: peak RSS in bytes (int)
+    - ``minflt``: minor page faults (int)
+    - ``majflt``: major page faults (int)
+    - ``inblock``: block input operations (int)
+    - ``oublock``: block output operations (int)
+    - ``nvcsw``: voluntary context switches (int)
+    - ``nivcsw``: involuntary context switches (int)
+
+    Example output::
+
+        {
+            "resource_usage": {
+                "utime": 0.123456,
+                "stime": 0.012345,
+                "maxrss": 10485760,
+                "minflt": 512,
+                "majflt": 0,
+                "inblock": 0,
+                "oublock": 8,
+                "nvcsw": 3,
+                "nivcsw": 1
+            }
+        }
+
+    Note:
+        CLI compatible.
+    """
+
+    def capture_resource_usage(self, bm_data):
+        """Take a pre-run snapshot of resource usage."""
+        if _resource is None:
+            return
+        if hasattr(self, '_subprocess_command'):
+            # CLI mode: measure the child process.
+            ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+        else:
+            # Python API mode: measure the current process.
+            ru = _resource.getrusage(_resource.RUSAGE_SELF)
+        self._rusage_before = _rusage_to_dict(ru)
+
+    def capturepost_resource_usage(self, bm_data):
+        """Compute the delta and store resource usage results."""
+        if _resource is None:
+            bm_data['resource_usage'] = {}
+            return
+        if not hasattr(self, '_rusage_before'):
+            bm_data['resource_usage'] = {}
+            return
+        if hasattr(self, '_subprocess_command'):
+            ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+        else:
+            ru = _resource.getrusage(_resource.RUSAGE_SELF)
+        after = _rusage_to_dict(ru)
+        bm_data['resource_usage'] = _rusage_delta(self._rusage_before, after)

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -292,20 +292,36 @@ def _rusage_to_dict(ru, *, include_maxrss=True):
     return d
 
 
+def _rusage_from_wait4(raw_ru):
+    """Convert the raw rusage object returned by ``os.wait4()`` to a dict.
+
+    ``os.wait4()`` returns a ``resource.struct_rusage``-compatible object
+    whose ``ru_maxrss`` already reflects **only that child process** — no
+    cumulative HWM subtraction is needed.  ``maxrss`` is normalised to bytes
+    using the same platform rule as ``_rusage_to_dict``.
+    """
+    maxrss = raw_ru.ru_maxrss
+    if sys.platform == 'linux':
+        maxrss *= 1024
+    return {
+        'utime': raw_ru.ru_utime,
+        'stime': raw_ru.ru_stime,
+        'maxrss': maxrss,
+        'minflt': raw_ru.ru_minflt,
+        'majflt': raw_ru.ru_majflt,
+        'inblock': raw_ru.ru_inblock,
+        'oublock': raw_ru.ru_oublock,
+        'nvcsw': raw_ru.ru_nvcsw,
+        'nivcsw': raw_ru.ru_nivcsw,
+    }
+
+
 def _rusage_delta(before, after):
-    """Return ``after - before`` for all accumulator fields including ``maxrss``.
+    """Return ``after - before`` for all accumulator fields.
 
-    All fields — including ``maxrss`` — are delta'd.  For ``RUSAGE_CHILDREN``,
-    ``maxrss`` is the **cumulative** high-water mark across all waited children
-    in the current process's lifetime.  Taking the delta isolates the
-    contribution of the most recent child: a positive value means that child
-    set a new process-lifetime RSS peak; zero means it did not exceed the
-    previous maximum.  This is honest for multi-iteration runs: a child that
-    uses less memory than a prior sibling correctly reports ``maxrss: 0``
-    rather than repeating the prior child's peak.
-
-    ``maxrss`` is absent when ``before`` has no ``maxrss`` key (Python API
-    mode — see ``_rusage_to_dict``).
+    ``maxrss`` is only included when ``before`` has a ``maxrss`` key (CLI
+    fallback mode — see ``_rusage_to_dict``).  When ``os.wait4()`` is used,
+    this function is not called; ``_rusage_from_wait4`` is used instead.
     """
     d = {
         'utime': after['utime'] - before['utime'],
@@ -322,56 +338,69 @@ def _rusage_delta(before, after):
     return d
 
 
+# True when os.wait4() is available (all POSIX; absent on Windows).
+_HAVE_WAIT4 = hasattr(os, 'wait4')
+
+
 class MBResourceUsage:
     """Capture POSIX ``getrusage()`` data for the benchmarked code.
 
-    Records CPU time, page faults, block I/O operations, and context switches
-    from a before/after delta so values reflect only the benchmarked work.
-    In CLI mode, ``maxrss`` (peak RSS in bytes) is also recorded.
+    Records CPU time, page faults, block I/O operations, and context switches.
+    Results are stored as a **list** of dicts.  In CLI mode, one entry per
+    timed iteration (aligning index-for-index with ``call.durations`` and
+    ``call.returncode``).  In Python API mode, a single aggregate entry
+    spanning all iterations.
 
     **Modes**
 
-    - *CLI mode* (subprocess): uses ``RUSAGE_CHILDREN`` — resources consumed
-      by the benchmarked subprocess and all its descendants, isolated via a
-      before/after delta.
-    - *Python API mode* (function): uses ``RUSAGE_SELF`` — resources consumed
-      by the current process. ``maxrss`` is **omitted** in this mode because
-      ``RUSAGE_SELF.maxrss`` is a lifetime process high-water mark that
-      reflects peak usage since program start, not just during the decorated
-      function.  The remaining fields (CPU times, page faults, I/O, context
-      switches) are deltas and correctly isolate the function's contribution.
+    - *CLI mode* (subprocess): uses ``RUSAGE_CHILDREN`` / ``os.wait4()`` —
+      resources consumed by the benchmarked subprocess and all its descendants.
+      When ``os.wait4()`` is available (all POSIX platforms), each entry
+      contains the exact rusage of that child process as reported by the
+      kernel.  On platforms where ``os.wait4()`` is unavailable (Windows),
+      a before/after delta of ``RUSAGE_CHILDREN`` is used instead and
+      ``maxrss`` is omitted when ``warmup > 0`` or ``iterations > 1`` because
+      the cumulative high-water mark cannot be meaningfully attributed to a
+      single child.
+
+    - *Python API mode* (function): uses ``RUSAGE_SELF`` — a single aggregate
+      before/after delta across **all** iterations (list always has exactly
+      one entry).  ``maxrss`` is **always omitted** in this mode because
+      ``RUSAGE_SELF.maxrss`` is a lifetime process high-water mark; it
+      reflects peak usage since program start, not just the decorated
+      function.  Use ``MBPeakMemory`` for per-call peak RSS in Python API
+      mode.
 
     On Windows (where the ``resource`` module is unavailable), this mixin
-    records an empty dict without raising an error.
+    records an empty list without raising an error.
 
-    Output key: ``resource_usage``
+    Output key: ``resource_usage`` (list of dicts, one per iteration)
 
-    Fields recorded (CLI mode):
+    Fields per entry (CLI mode with ``os.wait4()`` — the common POSIX case):
 
-    - ``utime``: user CPU time (seconds, float)
-    - ``stime``: system CPU time (seconds, float)
-    - ``maxrss``: peak RSS in bytes (int) — see platform notes below
+    - ``utime``: user CPU time consumed by the child (seconds, float)
+    - ``stime``: system CPU time consumed by the child (seconds, float)
+    - ``maxrss``: peak RSS of the child in bytes (int) — see platform notes
     - ``minflt``: minor page faults (int)
     - ``majflt``: major page faults (int)
-    - ``inblock``: block input operations (int) — see platform notes below
-    - ``oublock``: block output operations (int) — see platform notes below
+    - ``inblock``: block input operations (int) — see platform notes
+    - ``oublock``: block output operations (int) — see platform notes
     - ``nvcsw``: voluntary context switches (int)
     - ``nivcsw``: involuntary context switches (int)
 
-    Fields recorded (Python API mode): all of the above **except** ``maxrss``.
+    Fields per entry (Python API mode): all of the above **except** ``maxrss``.
 
     **Platform notes**
 
-    *maxrss* (CLI mode, ``RUSAGE_CHILDREN``):
-        ``RUSAGE_CHILDREN.maxrss`` is the cumulative maximum RSS across *all*
-        waited children of the current process since it started.  The
-        before/after delta is the most honest representation available: a
-        positive value means the child set a new process-lifetime peak; zero
-        means it did not exceed a prior sibling's peak.  With ``--iterations``
-        this means subsequent iterations that use less memory than the first
-        will report ``maxrss: 0``.  For single-iteration runs (the common
-        case) the value is exact.  True per-child ``maxrss`` isolation
-        requires ``os.wait4()`` integration, which is a planned improvement.
+    *maxrss* (CLI mode with ``os.wait4()``):
+        Reported directly by the kernel as the child's own peak RSS.  Exact
+        and per-child regardless of iteration count or warmup.
+
+    *maxrss* (CLI mode without ``os.wait4()`` — Windows fallback):
+        Uses ``RUSAGE_CHILDREN`` before/after delta.  Omitted entirely when
+        ``warmup > 0`` or ``iterations > 1`` because ``RUSAGE_CHILDREN.maxrss``
+        is a cumulative HWM across all waited children since process start;
+        the delta cannot be attributed to a single child in those cases.
 
     *inblock / oublock* (macOS):
         These counters are almost always zero on macOS regardless of actual
@@ -392,20 +421,33 @@ class MBResourceUsage:
         These are the most reliable fields across both Linux and macOS and
         should be non-zero for any non-trivial workload.
 
-    Example output (CLI mode)::
+    Example output (CLI mode, 2 iterations)::
 
         {
-            "resource_usage": {
-                "utime": 0.123456,
-                "stime": 0.012345,
-                "maxrss": 10485760,
-                "minflt": 512,
-                "majflt": 0,
-                "inblock": 0,
-                "oublock": 0,
-                "nvcsw": 3,
-                "nivcsw": 1
-            }
+            "resource_usage": [
+                {
+                    "utime": 0.123456,
+                    "stime": 0.012345,
+                    "maxrss": 10485760,
+                    "minflt": 512,
+                    "majflt": 0,
+                    "inblock": 0,
+                    "oublock": 0,
+                    "nvcsw": 3,
+                    "nivcsw": 1
+                },
+                {
+                    "utime": 0.118000,
+                    "stime": 0.011000,
+                    "maxrss": 10485760,
+                    "minflt": 498,
+                    "majflt": 0,
+                    "inblock": 0,
+                    "oublock": 0,
+                    "nvcsw": 2,
+                    "nivcsw": 1
+                }
+            ]
         }
 
     Note:
@@ -413,32 +455,48 @@ class MBResourceUsage:
     """
 
     def capture_resource_usage(self, bm_data):
-        """Take a pre-run snapshot of resource usage."""
+        """Initialise resource-usage accumulator before all iterations."""
         if _resource is None:
             return
         if hasattr(self, '_subprocess_command'):
-            # CLI mode: measure child processes; include maxrss.
-            ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
-            self._rusage_before = _rusage_to_dict(ru, include_maxrss=True)
+            # CLI mode: accumulator populated by run() in main.py.
+            self._subprocess_resource_usage = []
+            if not _HAVE_WAIT4:
+                # Fallback: RUSAGE_CHILDREN before/after delta per iteration.
+                ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
+                self._rusage_before = _rusage_to_dict(ru, include_maxrss=True)
         else:
-            # Python API mode: measure the current process.
-            # Omit maxrss — RUSAGE_SELF.maxrss is a lifetime process HWM and
-            # cannot isolate a single function call's peak RSS.
+            # Python API mode: snapshot RUSAGE_SELF once before all iterations.
+            # pre/post_run_triggers are not used because MicroBenchBase does not
+            # call super() in its trigger methods, so MRO chaining is unreliable.
+            # A single aggregate delta (before all / after all) is the only safe
+            # approach; maxrss is omitted (lifetime HWM, not per-call).
             ru = _resource.getrusage(_resource.RUSAGE_SELF)
             self._rusage_before = _rusage_to_dict(ru, include_maxrss=False)
 
     def capturepost_resource_usage(self, bm_data):
-        """Compute the delta and store resource usage results."""
+        """Write the resource_usage list to bm_data after all iterations."""
         if _resource is None:
-            bm_data['resource_usage'] = {}
-            return
-        if not hasattr(self, '_rusage_before'):
-            bm_data['resource_usage'] = {}
+            bm_data['resource_usage'] = []
             return
         if hasattr(self, '_subprocess_command'):
-            ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
-            after = _rusage_to_dict(ru, include_maxrss=True)
+            # CLI mode: list already populated by run() in main.py.
+            entries = list(getattr(self, '_subprocess_resource_usage', []))
+            # Fallback path (no os.wait4): maxrss is a RUSAGE_CHILDREN delta
+            # which is unreliable when warmup>0 or iterations>1.  Strip it so
+            # we never silently report misleading zeros.
+            if not _HAVE_WAIT4 and (
+                getattr(self, 'warmup', 0) > 0 or getattr(self, 'iterations', 1) > 1
+            ):
+                for entry in entries:
+                    entry.pop('maxrss', None)
+            bm_data['resource_usage'] = entries
         else:
+            # Python API mode: single aggregate delta across all iterations.
+            before = getattr(self, '_rusage_before', None)
+            if before is None:
+                bm_data['resource_usage'] = []
+                return
             ru = _resource.getrusage(_resource.RUSAGE_SELF)
             after = _rusage_to_dict(ru, include_maxrss=False)
-        bm_data['resource_usage'] = _rusage_delta(self._rusage_before, after)
+            bm_data['resource_usage'] = [_rusage_delta(before, after)]

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -340,10 +340,9 @@ class MBResourceUsage:
     """Capture POSIX ``getrusage()`` data for the benchmarked code.
 
     Records CPU time, page faults, block I/O operations, and context switches.
-    Results are stored as a **list** of dicts.  In CLI mode, one entry per
-    timed iteration (aligning index-for-index with ``call.durations`` and
-    ``call.returncode``).  In Python API mode, a single aggregate entry
-    spanning all iterations.
+    Results are stored as a **list** of dicts, one entry per timed iteration
+    in both CLI and Python API mode, aligning index-for-index with
+    ``call.durations`` and ``call.returncode``.
 
     **Modes**
 
@@ -352,13 +351,13 @@ class MBResourceUsage:
       per timed iteration, aligned with ``call.durations`` and
       ``call.returncode``.
 
-    - *Python API mode* (function): uses ``RUSAGE_SELF`` — a single aggregate
-      before/after delta across **all** iterations (list always has exactly
-      one entry).  ``maxrss`` is **always omitted** in this mode because
-      ``RUSAGE_SELF.maxrss`` is a lifetime process high-water mark; it
-      reflects peak usage since program start, not just the decorated
-      function.  Use ``MBPeakMemory`` for per-call peak RSS in Python API
-      mode.
+    - *Python API mode* (function): uses ``RUSAGE_SELF`` — one entry per
+      timed iteration (matching ``call.durations`` index-for-index), each a
+      before/after delta around that single call.  ``maxrss`` is **always
+      omitted** in this mode because ``RUSAGE_SELF.maxrss`` is a lifetime
+      process high-water mark; it reflects peak usage since program start,
+      not just the decorated function.  Use ``MBPeakMemory`` for per-call
+      peak RSS in Python API mode.
 
     On non-POSIX platforms where the ``resource`` module is unavailable, this
     mixin records an empty list without raising an error.
@@ -445,13 +444,23 @@ class MBResourceUsage:
             # CLI mode: accumulator populated by run() in main.py.
             self._subprocess_resource_usage = []
         else:
-            # Python API mode: snapshot RUSAGE_SELF once before all iterations.
-            # pre/post_run_triggers are not used because MicroBenchBase does not
-            # call super() in its trigger methods, so MRO chaining is unreliable.
-            # A single aggregate delta (before all / after all) is the only safe
-            # approach; maxrss is omitted (lifetime HWM, not per-call).
-            ru = _resource.getrusage(_resource.RUSAGE_SELF)
-            self._rusage_before = _rusage_to_dict(ru, include_maxrss=False)
+            # Python API mode: per-iteration list populated by pre/post_run_triggers.
+            self._rusage_iter_entries = []
+
+    def pre_run_triggers(self, bm_data):
+        if _resource is not None and not hasattr(self, '_subprocess_command'):
+            self._rusage_iter_before = _rusage_to_dict(
+                _resource.getrusage(_resource.RUSAGE_SELF), include_maxrss=False
+            )
+
+    def post_run_triggers(self, bm_data):
+        if _resource is not None and not hasattr(self, '_subprocess_command'):
+            after = _rusage_to_dict(
+                _resource.getrusage(_resource.RUSAGE_SELF), include_maxrss=False
+            )
+            self._rusage_iter_entries.append(
+                _rusage_delta(self._rusage_iter_before, after)
+            )
 
     def capturepost_resource_usage(self, bm_data):
         """Write the resource_usage list to bm_data after all iterations."""
@@ -464,11 +473,5 @@ class MBResourceUsage:
                 getattr(self, '_subprocess_resource_usage', [])
             )
         else:
-            # Python API mode: single aggregate delta across all iterations.
-            before = getattr(self, '_rusage_before', None)
-            if before is None:
-                bm_data['resource_usage'] = []
-                return
-            ru = _resource.getrusage(_resource.RUSAGE_SELF)
-            after = _rusage_to_dict(ru, include_maxrss=False)
-            bm_data['resource_usage'] = [_rusage_delta(before, after)]
+            # Python API mode: one entry per timed iteration.
+            bm_data['resource_usage'] = list(getattr(self, '_rusage_iter_entries', []))

--- a/microbench/mixins/system.py
+++ b/microbench/mixins/system.py
@@ -319,9 +319,7 @@ def _rusage_from_wait4(raw_ru):
 def _rusage_delta(before, after):
     """Return ``after - before`` for all accumulator fields.
 
-    ``maxrss`` is only included when ``before`` has a ``maxrss`` key (CLI
-    fallback mode — see ``_rusage_to_dict``).  When ``os.wait4()`` is used,
-    this function is not called; ``_rusage_from_wait4`` is used instead.
+    ``maxrss`` is only included when ``before`` has a ``maxrss`` key.
     """
     d = {
         'utime': after['utime'] - before['utime'],
@@ -338,10 +336,6 @@ def _rusage_delta(before, after):
     return d
 
 
-# True when os.wait4() is available (all POSIX; absent on Windows).
-_HAVE_WAIT4 = hasattr(os, 'wait4')
-
-
 class MBResourceUsage:
     """Capture POSIX ``getrusage()`` data for the benchmarked code.
 
@@ -353,15 +347,10 @@ class MBResourceUsage:
 
     **Modes**
 
-    - *CLI mode* (subprocess): uses ``RUSAGE_CHILDREN`` / ``os.wait4()`` —
-      resources consumed by the benchmarked subprocess and all its descendants.
-      When ``os.wait4()`` is available (all POSIX platforms), each entry
-      contains the exact rusage of that child process as reported by the
-      kernel.  On platforms where ``os.wait4()`` is unavailable (Windows),
-      a before/after delta of ``RUSAGE_CHILDREN`` is used instead and
-      ``maxrss`` is omitted when ``warmup > 0`` or ``iterations > 1`` because
-      the cumulative high-water mark cannot be meaningfully attributed to a
-      single child.
+    - *CLI mode* (subprocess): on POSIX, uses ``os.wait4()`` to capture the
+      exact rusage of each child process as reported by the kernel — one entry
+      per timed iteration, aligned with ``call.durations`` and
+      ``call.returncode``.
 
     - *Python API mode* (function): uses ``RUSAGE_SELF`` — a single aggregate
       before/after delta across **all** iterations (list always has exactly
@@ -371,10 +360,10 @@ class MBResourceUsage:
       function.  Use ``MBPeakMemory`` for per-call peak RSS in Python API
       mode.
 
-    On Windows (where the ``resource`` module is unavailable), this mixin
-    records an empty list without raising an error.
+    On non-POSIX platforms where the ``resource`` module is unavailable, this
+    mixin records an empty list without raising an error.
 
-    Output key: ``resource_usage`` (list of dicts, one per iteration)
+    Output key: ``resource_usage`` (list of dicts)
 
     Fields per entry (CLI mode with ``os.wait4()`` — the common POSIX case):
 
@@ -395,12 +384,6 @@ class MBResourceUsage:
     *maxrss* (CLI mode with ``os.wait4()``):
         Reported directly by the kernel as the child's own peak RSS.  Exact
         and per-child regardless of iteration count or warmup.
-
-    *maxrss* (CLI mode without ``os.wait4()`` — Windows fallback):
-        Uses ``RUSAGE_CHILDREN`` before/after delta.  Omitted entirely when
-        ``warmup > 0`` or ``iterations > 1`` because ``RUSAGE_CHILDREN.maxrss``
-        is a cumulative HWM across all waited children since process start;
-        the delta cannot be attributed to a single child in those cases.
 
     *inblock / oublock* (macOS):
         These counters are almost always zero on macOS regardless of actual
@@ -461,10 +444,6 @@ class MBResourceUsage:
         if hasattr(self, '_subprocess_command'):
             # CLI mode: accumulator populated by run() in main.py.
             self._subprocess_resource_usage = []
-            if not _HAVE_WAIT4:
-                # Fallback: RUSAGE_CHILDREN before/after delta per iteration.
-                ru = _resource.getrusage(_resource.RUSAGE_CHILDREN)
-                self._rusage_before = _rusage_to_dict(ru, include_maxrss=True)
         else:
             # Python API mode: snapshot RUSAGE_SELF once before all iterations.
             # pre/post_run_triggers are not used because MicroBenchBase does not
@@ -481,16 +460,9 @@ class MBResourceUsage:
             return
         if hasattr(self, '_subprocess_command'):
             # CLI mode: list already populated by run() in main.py.
-            entries = list(getattr(self, '_subprocess_resource_usage', []))
-            # Fallback path (no os.wait4): maxrss is a RUSAGE_CHILDREN delta
-            # which is unreliable when warmup>0 or iterations>1.  Strip it so
-            # we never silently report misleading zeros.
-            if not _HAVE_WAIT4 and (
-                getattr(self, 'warmup', 0) > 0 or getattr(self, 'iterations', 1) > 1
-            ):
-                for entry in entries:
-                    entry.pop('maxrss', None)
-            bm_data['resource_usage'] = entries
+            bm_data['resource_usage'] = list(
+                getattr(self, '_subprocess_resource_usage', [])
+            )
         else:
             # Python API mode: single aggregate delta across all iterations.
             before = getattr(self, '_rusage_before', None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,31 @@ from microbench import __version__
 from microbench.__main__ import main
 
 
+class _FakeRusage:
+    def __init__(
+        self,
+        *,
+        utime=0.0,
+        stime=0.0,
+        maxrss=1,
+        minflt=0,
+        majflt=0,
+        inblock=0,
+        oublock=0,
+        nvcsw=0,
+        nivcsw=0,
+    ):
+        self.ru_utime = utime
+        self.ru_stime = stime
+        self.ru_maxrss = maxrss
+        self.ru_minflt = minflt
+        self.ru_majflt = majflt
+        self.ru_inblock = inblock
+        self.ru_oublock = oublock
+        self.ru_nvcsw = nvcsw
+        self.ru_nivcsw = nivcsw
+
+
 def _make_mock_popen(returncode=0, stdout_lines=None, stderr_lines=None, pid=12345):
     """Create a mock Popen process."""
     mock_proc = MagicMock()
@@ -22,20 +47,49 @@ def _make_mock_popen(returncode=0, stdout_lines=None, stderr_lines=None, pid=123
 
 
 def _run_main(argv, mock_returncode=0):
-    """Run main() with a mocked subprocess and captured stdout.
-
-    Patches subprocess.Popen and forces _HAVE_WAIT4=False so tests exercise
-    the simple proc.wait() fallback path, independent of os.wait4 availability.
-    """
+    """Run main() with a mocked subprocess and captured stdout."""
     mock_proc = _make_mock_popen(returncode=mock_returncode)
 
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
+    wait_status = 0 if mock_returncode == 0 else mock_returncode << 8
+    fake_wait4 = (mock_proc.pid, wait_status, _FakeRusage())
+    with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
+        with patch('os.wait4', return_value=fake_wait4):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(argv)
     return exc.value.code, json.loads(buf.getvalue()), mock_popen
+
+
+def _patch_wait4_success(mock_proc, *, rusage=None, status=0):
+    if rusage is None:
+        rusage = _FakeRusage()
+    return patch('os.wait4', return_value=(mock_proc.pid, status, rusage))
+
+
+def _patch_wait4_sleep(mock_proc, delay, *, status=0, rusage=None):
+    if rusage is None:
+        rusage = _FakeRusage()
+
+    def _wait4(pid, options):
+        import time
+
+        time.sleep(delay)
+        return (mock_proc.pid, status, rusage)
+
+    return patch('os.wait4', side_effect=_wait4)
+
+
+def _patch_wait4_sequence(*results):
+    iterator = iter(results)
+
+    def _wait4(pid, options):
+        result = next(iterator)
+        if callable(result):
+            return result(pid, options)
+        return result
+
+    return patch('os.wait4', side_effect=_wait4)
 
 
 def test_cli_records_command_and_timing():
@@ -180,8 +234,8 @@ def test_cli_outfile(tmp_path):
     outfile = tmp_path / 'results.jsonl'
     mock_proc = _make_mock_popen(returncode=0)
 
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with pytest.raises(SystemExit):
                 main(['--outfile', str(outfile), '--', 'true'])
 
@@ -237,8 +291,8 @@ def test_cli_all_flag_includes_all_mixins():
     # Patch every mixin's capture methods to no-ops to avoid external calls
     mock_proc = _make_mock_popen(returncode=0)
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit):
                     with patch(
@@ -314,8 +368,12 @@ def test_cli_returncode_is_first_nonzero_across_iterations():
         _make_mock_popen(returncode=1),
     ]
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', side_effect=mock_procs):
+    with patch('subprocess.Popen', side_effect=mock_procs):
+        with _patch_wait4_sequence(
+            (mock_procs[0].pid, 0, _FakeRusage()),
+            (mock_procs[1].pid, 2 << 8, _FakeRusage()),
+            (mock_procs[2].pid, 1 << 8, _FakeRusage()),
+        ):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(['--iterations', '3', '--', 'true'])
@@ -332,8 +390,12 @@ def test_cli_returncode_preserves_first_nonzero_even_if_later_is_larger():
         _make_mock_popen(returncode=2),
     ]
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', side_effect=mock_procs):
+    with patch('subprocess.Popen', side_effect=mock_procs):
+        with _patch_wait4_sequence(
+            (mock_procs[0].pid, 0, _FakeRusage()),
+            (mock_procs[1].pid, 1 << 8, _FakeRusage()),
+            (mock_procs[2].pid, 2 << 8, _FakeRusage()),
+        ):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(['--iterations', '3', '--', 'true'])
@@ -350,8 +412,12 @@ def test_cli_returncode_preserves_first_nonzero_signal_code():
         _make_mock_popen(returncode=1),
     ]
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', side_effect=mock_procs):
+    with patch('subprocess.Popen', side_effect=mock_procs):
+        with _patch_wait4_sequence(
+            (mock_procs[0].pid, 0, _FakeRusage()),
+            (mock_procs[1].pid, 15, _FakeRusage()),
+            (mock_procs[2].pid, 1 << 8, _FakeRusage()),
+        ):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(['--iterations', '3', '--', 'true'])
@@ -372,8 +438,8 @@ def test_cli_all_overrides_mixin():
     """--all takes precedence over --mixin."""
     mock_proc = _make_mock_popen(returncode=0)
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit):
                     with patch(
@@ -428,10 +494,11 @@ def test_cli_capture_stdout_records_output():
     buf = io.StringIO()
     terminal = io.StringIO()
     with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
-        with patch('sys.stdout', buf):
-            with patch('sys.__stdout__', terminal):
-                with pytest.raises(SystemExit):
-                    main(['--stdout', '--', 'echo', 'hello'])
+        with _patch_wait4_success(mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stdout__', terminal):
+                    with pytest.raises(SystemExit):
+                        main(['--stdout', '--', 'echo', 'hello'])
 
     record = json.loads(buf.getvalue())
     assert record['call']['stdout'] == ['hello\n']
@@ -447,10 +514,11 @@ def test_cli_capture_stdout_suppress():
     buf = io.StringIO()
     terminal = io.StringIO()
     with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with patch('sys.__stdout__', terminal):
-                with pytest.raises(SystemExit):
-                    main(['--stdout=suppress', '--', 'echo', 'hello'])
+        with _patch_wait4_success(mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stdout__', terminal):
+                    with pytest.raises(SystemExit):
+                        main(['--stdout=suppress', '--', 'echo', 'hello'])
 
     record = json.loads(buf.getvalue())
     assert record['call']['stdout'] == ['hello\n']
@@ -464,10 +532,11 @@ def test_cli_capture_stderr_records_output():
     buf = io.StringIO()
     terminal_err = io.StringIO()
     with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with patch('sys.__stderr__', terminal_err):
-                with pytest.raises(SystemExit):
-                    main(['--stderr', '--', 'cmd'])
+        with _patch_wait4_success(mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stderr__', terminal_err):
+                    with pytest.raises(SystemExit):
+                        main(['--stderr', '--', 'cmd'])
 
     record = json.loads(buf.getvalue())
     assert record['call']['stderr'] == ['warning\n']
@@ -482,10 +551,11 @@ def test_cli_capture_stderr_suppress():
     buf = io.StringIO()
     terminal_err = io.StringIO()
     with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with patch('sys.__stderr__', terminal_err):
-                with pytest.raises(SystemExit):
-                    main(['--stderr=suppress', '--', 'cmd'])
+        with _patch_wait4_success(mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stderr__', terminal_err):
+                    with pytest.raises(SystemExit):
+                        main(['--stderr=suppress', '--', 'cmd'])
 
     record = json.loads(buf.getvalue())
     assert record['call']['stderr'] == ['warning\n']
@@ -503,12 +573,26 @@ def test_cli_capture_stdout_multiple_iterations():
 
     buf = io.StringIO()
     with patch('subprocess.Popen', side_effect=mock_procs):
-        with patch('sys.stdout', buf):
-            with patch('sys.__stdout__', io.StringIO()):
-                with pytest.raises(SystemExit):
-                    main(
-                        ['--stdout', '--warmup', '1', '--iterations', '3', '--', 'cmd']
-                    )
+        with _patch_wait4_sequence(
+            (mock_procs[0].pid, 0, _FakeRusage()),
+            (mock_procs[1].pid, 0, _FakeRusage()),
+            (mock_procs[2].pid, 0, _FakeRusage()),
+            (mock_procs[3].pid, 0, _FakeRusage()),
+        ):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stdout__', io.StringIO()):
+                    with pytest.raises(SystemExit):
+                        main(
+                            [
+                                '--stdout',
+                                '--warmup',
+                                '1',
+                                '--iterations',
+                                '3',
+                                '--',
+                                'cmd',
+                            ]
+                        )
 
     record = json.loads(buf.getvalue())
     assert record['call']['stdout'] == ['run1\n', 'run2\n', 'run3\n']
@@ -523,11 +607,12 @@ def test_cli_capture_stdout_and_stderr():
 
     buf = io.StringIO()
     with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with patch('sys.__stdout__', io.StringIO()):
-                with patch('sys.__stderr__', io.StringIO()):
-                    with pytest.raises(SystemExit):
-                        main(['--stdout', '--stderr', '--', 'cmd'])
+        with _patch_wait4_success(mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stdout__', io.StringIO()):
+                    with patch('sys.__stderr__', io.StringIO()):
+                        with pytest.raises(SystemExit):
+                            main(['--stdout', '--stderr', '--', 'cmd'])
 
     record = json.loads(buf.getvalue())
     assert record['call']['stdout'] == ['out\n']
@@ -624,8 +709,8 @@ def _run_main_with_monitor(argv, mock_pid=12345, mock_returncode=0, fake_samples
         MockThread.return_value = mock_thread
 
         buf = io.StringIO()
-        with patch('microbench.cli.main._HAVE_WAIT4', False):
-            with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with _patch_wait4_success(mock_proc):
                 with patch('sys.stdout', buf):
                     with pytest.raises(SystemExit):
                         main(argv)
@@ -706,8 +791,8 @@ def test_cli_monitor_interval_multiple_iterations():
 
     buf = io.StringIO()
     with patch('microbench.cli.main._SubprocessMonitorThread', side_effect=make_thread):
-        with patch('microbench.cli.main._HAVE_WAIT4', False):
-            with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with _patch_wait4_success(mock_proc):
                 with patch('sys.stdout', buf):
                     with pytest.raises(SystemExit):
                         main(
@@ -744,8 +829,8 @@ def test_cli_monitor_interval_warmup_excluded():
 
     buf = io.StringIO()
     with patch('microbench.cli.main._SubprocessMonitorThread', side_effect=make_thread):
-        with patch('microbench.cli.main._HAVE_WAIT4', False):
-            with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with _patch_wait4_success(mock_proc):
                 with patch('sys.stdout', buf):
                     with pytest.raises(SystemExit):
                         main(
@@ -801,8 +886,8 @@ def test_cli_monitor_interval_with_stdout_capture():
         mock_thread = MagicMock()
         mock_thread.samples = fake_samples
         MockThread.return_value = mock_thread
-        with patch('microbench.cli.main._HAVE_WAIT4', False):
-            with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with _patch_wait4_success(mock_proc):
                 with patch('sys.stdout', buf):
                     with patch('sys.__stdout__', io.StringIO()):
                         with pytest.raises(SystemExit):
@@ -835,8 +920,8 @@ def _run_main_http(argv, fake_status=200):
 
     mock_proc = _make_mock_popen(returncode=0)
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch(
                 'urllib.request.urlopen', return_value=mock_response
             ) as mock_urlopen:
@@ -866,8 +951,8 @@ def test_cli_http_output_no_stdout_record():
     mock_response.__enter__ = lambda s: s
     mock_response.__exit__ = MagicMock(return_value=False)
     mock_proc = _make_mock_popen(returncode=0)
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch('urllib.request.urlopen', return_value=mock_response):
                 with patch('sys.stdout', buf):
                     with pytest.raises(SystemExit):
@@ -890,8 +975,8 @@ def test_cli_http_output_and_outfile(tmp_path):
     mock_response.__enter__ = lambda s: s
     mock_response.__exit__ = MagicMock(return_value=False)
     mock_proc = _make_mock_popen(returncode=0)
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch(
                 'urllib.request.urlopen', return_value=mock_response
             ) as mock_urlopen:
@@ -1027,8 +1112,8 @@ def _run_main_redis(argv):
     mock_redis.StrictRedis.return_value = mock_client
     mock_proc = _make_mock_popen(returncode=0)
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch.dict('sys.modules', {'redis': mock_redis}):
                 with patch('sys.stdout', buf):
                     with pytest.raises(SystemExit) as exc:
@@ -1063,8 +1148,8 @@ def test_cli_redis_output_no_stdout_record():
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_client
     mock_proc = _make_mock_popen(returncode=0)
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch.dict('sys.modules', {'redis': mock_redis}):
                 with patch('sys.stdout', buf):
                     with pytest.raises(SystemExit):
@@ -1087,8 +1172,8 @@ def test_cli_redis_output_and_outfile(tmp_path):
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_client
     mock_proc = _make_mock_popen(returncode=0)
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch.dict('sys.modules', {'redis': mock_redis}):
                 with pytest.raises(SystemExit):
                     main(
@@ -1454,8 +1539,8 @@ def test_cli_timeout_not_exceeded():
     mock_proc.returncode = 0
 
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(['--no-mixin', '--timeout', '30', '--', 'sleep', '1'])
@@ -1469,17 +1554,13 @@ def test_cli_timeout_sigterm_sufficient():
     """--timeout: process exits after SIGTERM; SIGKILL is not sent."""
     mock_proc = _make_mock_popen()
     mock_proc.returncode = -15  # killed by SIGTERM
-    mock_proc.wait.side_effect = [
-        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # main timeout
-        None,  # exits cleanly after SIGTERM (within grace period)
-    ]
 
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_sleep(mock_proc, 0.05, status=15):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit):
-                    main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
+                    main(['--no-mixin', '--timeout', '0.001', '--', 'sleep', '100'])
     record = json.loads(buf.getvalue())
     assert record['call']['timed_out'] is True
     mock_proc.terminate.assert_called_once()
@@ -1490,18 +1571,24 @@ def test_cli_timeout_sigkill_required():
     """--timeout: SIGKILL sent when process ignores SIGTERM past the grace period."""
     mock_proc = _make_mock_popen()
     mock_proc.returncode = -9  # killed by SIGKILL
-    mock_proc.wait.side_effect = [
-        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # main timeout
-        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # grace period
-        None,  # exits after SIGKILL
-    ]
 
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', return_value=mock_proc):
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_sleep(mock_proc, 0.05, status=9):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit):
-                    main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
+                    main(
+                        [
+                            '--no-mixin',
+                            '--timeout',
+                            '0.001',
+                            '--timeout-grace-period',
+                            '0.001',
+                            '--',
+                            'sleep',
+                            '100',
+                        ]
+                    )
     record = json.loads(buf.getvalue())
     assert record['call']['timed_out'] is True
     mock_proc.terminate.assert_called_once()
@@ -1512,17 +1599,22 @@ def test_cli_timeout_during_warmup_does_not_set_timed_out():
     """A timeout in warmup is discarded along with other warmup-only state."""
     warmup_proc = _make_mock_popen()
     warmup_proc.returncode = -15
-    warmup_proc.wait.side_effect = [
-        subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),
-        None,
-    ]
 
     timed_proc = _make_mock_popen()
     timed_proc.returncode = 0
 
+    def warmup_wait4(pid, options):
+        import time
+
+        time.sleep(0.05)
+        return (warmup_proc.pid, 15, _FakeRusage())
+
     buf = io.StringIO()
-    with patch('microbench.cli.main._HAVE_WAIT4', False):
-        with patch('subprocess.Popen', side_effect=[warmup_proc, timed_proc]):
+    with patch('subprocess.Popen', side_effect=[warmup_proc, timed_proc]):
+        with _patch_wait4_sequence(
+            warmup_wait4,
+            (timed_proc.pid, 0, _FakeRusage()),
+        ):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(
@@ -1531,7 +1623,7 @@ def test_cli_timeout_during_warmup_does_not_set_timed_out():
                             '--warmup',
                             '1',
                             '--timeout',
-                            '5',
+                            '0.001',
                             '--',
                             'sleep',
                             '100',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ def _patch_wait4_sleep(mock_proc, delay, *, status=0, rusage=None):
         time.sleep(delay)
         return (mock_proc.pid, status, rusage)
 
-    return patch('os.wait4', side_effect=_wait4, create=True)
+    return patch('os.wait4', side_effect=_wait4)
 
 
 def _patch_wait4_sequence(*results):
@@ -1564,6 +1564,9 @@ def test_cli_timeout_not_exceeded():
     assert record['call']['returncode'] == [0]
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='os.wait4() timeout handling is POSIX-only'
+)
 def test_cli_timeout_sigterm_sufficient():
     """--timeout: process exits after SIGTERM; SIGKILL is not sent."""
     mock_proc = _make_mock_popen()
@@ -1581,6 +1584,9 @@ def test_cli_timeout_sigterm_sufficient():
     mock_proc.kill.assert_not_called()
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='os.wait4() timeout handling is POSIX-only'
+)
 def test_cli_timeout_sigkill_required():
     """--timeout: SIGKILL sent when process ignores SIGTERM past the grace period."""
     mock_proc = _make_mock_popen()
@@ -1650,6 +1656,9 @@ def test_cli_timeout_during_warmup_does_not_set_timed_out():
     assert 'timed_out' not in record['call']
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='os.wait4() is not available on Windows'
+)
 def test_cli_keyboard_interrupt_kills_child():
     """KeyboardInterrupt during wait4 join causes proc.kill() and re-raises."""
     mock_proc = _make_mock_popen()
@@ -1941,6 +1950,9 @@ def test_cli_resource_usage_in_defaults():
     assert 'resource_usage' in record
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
 def test_cli_resource_usage_fields_present():
     """resource-usage records all expected fields."""
     _, record, _ = _run_main(['--mixin', 'resource-usage', '--', 'true'])
@@ -1950,6 +1962,9 @@ def test_cli_resource_usage_fields_present():
     assert set(ru_list[0].keys()) == _RUSAGE_FIELDS
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
 def test_cli_resource_usage_values_are_numeric():
     """resource-usage field values are all numbers (int or float)."""
     _, record, _ = _run_main(['--mixin', 'resource-usage', '--', 'true'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,30 +11,31 @@ from microbench import __version__
 from microbench.__main__ import main
 
 
-def _make_mock_popen(returncode=0, stdout_lines=None, stderr_lines=None):
-    """Create a mock Popen process for --stdout/--stderr capture tests."""
+def _make_mock_popen(returncode=0, stdout_lines=None, stderr_lines=None, pid=12345):
+    """Create a mock Popen process."""
     mock_proc = MagicMock()
-    mock_proc.__enter__.return_value = mock_proc
-    mock_proc.__exit__.return_value = False
     mock_proc.returncode = returncode
+    mock_proc.pid = pid
     mock_proc.stdout = iter(stdout_lines) if stdout_lines is not None else None
     mock_proc.stderr = iter(stderr_lines) if stderr_lines is not None else None
     return mock_proc
 
 
 def _run_main(argv, mock_returncode=0):
-    """Run main() with a mocked subprocess and captured stdout."""
-    mock_result = MagicMock()
-    mock_result.returncode = mock_returncode
-    mock_result.stdout = None
-    mock_result.stderr = None
+    """Run main() with a mocked subprocess and captured stdout.
+
+    Patches subprocess.Popen and forces _HAVE_WAIT4=False so tests exercise
+    the simple proc.wait() fallback path, independent of os.wait4 availability.
+    """
+    mock_proc = _make_mock_popen(returncode=mock_returncode)
 
     buf = io.StringIO()
-    with patch('subprocess.run', return_value=mock_result) as mock_run:
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit) as exc:
-                main(argv)
-    return exc.value.code, json.loads(buf.getvalue()), mock_run
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(argv)
+    return exc.value.code, json.loads(buf.getvalue()), mock_popen
 
 
 def test_cli_records_command_and_timing():
@@ -177,14 +178,12 @@ def test_cli_mixin_defaults_keyword_invalid_extra():
 def test_cli_outfile(tmp_path):
     """--outfile writes JSONL to the specified file."""
     outfile = tmp_path / 'results.jsonl'
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    mock_result.stdout = None
-    mock_result.stderr = None
+    mock_proc = _make_mock_popen(returncode=0)
 
-    with patch('subprocess.run', return_value=mock_result):
-        with pytest.raises(SystemExit):
-            main(['--outfile', str(outfile), '--', 'true'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with pytest.raises(SystemExit):
+                main(['--outfile', str(outfile), '--', 'true'])
 
     record = json.loads(outfile.read_text())
     assert record['call']['command'] == ['true']
@@ -236,12 +235,16 @@ def test_cli_all_flag_includes_all_mixins():
     all_names = set(_get_mixin_map())
 
     # Patch every mixin's capture methods to no-ops to avoid external calls
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        buf = io.StringIO()
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit):
-                with patch('subprocess.check_output', side_effect=Exception('skip')):
-                    main(['--all', '--', 'true'])
+    mock_proc = _make_mock_popen(returncode=0)
+    buf = io.StringIO()
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    with patch(
+                        'subprocess.check_output', side_effect=Exception('skip')
+                    ):
+                        main(['--all', '--', 'true'])
 
     # At minimum the record should be written (even with capture_optional errors)
     record = json.loads(buf.getvalue())
@@ -266,55 +269,56 @@ def test_cli_includes_mb_run_id_and_version():
 
 def test_cli_double_dash_separator():
     """-- separator is stripped before passing the command to subprocess."""
-    _, _, mock_run = _run_main(['--', 'echo', 'hello'])
+    _, _, mock_popen = _run_main(['--', 'echo', 'hello'])
 
-    mock_run.assert_called_once()
-    called_cmd = mock_run.call_args[0][0]
+    mock_popen.assert_called_once()
+    called_cmd = mock_popen.call_args[0][0]
     assert called_cmd == ['echo', 'hello']
 
 
 def test_cli_iterations():
     """--iterations N runs the command N times and produces N durations entries."""
-    _, record, mock_run = _run_main(['--iterations', '3', '--', 'true'])
+    _, record, mock_popen = _run_main(['--iterations', '3', '--', 'true'])
 
-    assert mock_run.call_count == 3
+    assert mock_popen.call_count == 3
     assert len(record['call']['durations']) == 3
     assert len(record['call']['returncode']) == 3
 
 
 def test_cli_warmup():
     """--warmup N runs the command N extra times before timing begins."""
-    _, record, mock_run = _run_main(['--warmup', '2', '--', 'true'])
+    _, record, mock_popen = _run_main(['--warmup', '2', '--', 'true'])
 
     # 2 warmup calls + 1 timed call
-    assert mock_run.call_count == 3
+    assert mock_popen.call_count == 3
     assert len(record['call']['durations']) == 1
     assert len(record['call']['returncode']) == 1
 
 
 def test_cli_iterations_and_warmup():
     """--iterations and --warmup together produce the right call count."""
-    _, record, mock_run = _run_main(
+    _, record, mock_popen = _run_main(
         ['--iterations', '4', '--warmup', '2', '--', 'true']
     )
 
-    assert mock_run.call_count == 6
+    assert mock_popen.call_count == 6
     assert len(record['call']['durations']) == 4
     assert len(record['call']['returncode']) == 4
 
 
 def test_cli_returncode_is_first_nonzero_across_iterations():
     """Process exits with the first non-zero returncode seen across timed iterations."""
-    mock_results = [
-        MagicMock(returncode=0, stdout=None, stderr=None),
-        MagicMock(returncode=2, stdout=None, stderr=None),
-        MagicMock(returncode=1, stdout=None, stderr=None),
+    mock_procs = [
+        _make_mock_popen(returncode=0),
+        _make_mock_popen(returncode=2),
+        _make_mock_popen(returncode=1),
     ]
     buf = io.StringIO()
-    with patch('subprocess.run', side_effect=mock_results):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit) as exc:
-                main(['--iterations', '3', '--', 'true'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', side_effect=mock_procs):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(['--iterations', '3', '--', 'true'])
 
     assert exc.value.code == 2
     assert json.loads(buf.getvalue())['call']['returncode'] == [0, 2, 1]
@@ -322,16 +326,17 @@ def test_cli_returncode_is_first_nonzero_across_iterations():
 
 def test_cli_returncode_preserves_first_nonzero_even_if_later_is_larger():
     """A later larger returncode does not override the first failure."""
-    mock_results = [
-        MagicMock(returncode=0, stdout=None, stderr=None),
-        MagicMock(returncode=1, stdout=None, stderr=None),
-        MagicMock(returncode=2, stdout=None, stderr=None),
+    mock_procs = [
+        _make_mock_popen(returncode=0),
+        _make_mock_popen(returncode=1),
+        _make_mock_popen(returncode=2),
     ]
     buf = io.StringIO()
-    with patch('subprocess.run', side_effect=mock_results):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit) as exc:
-                main(['--iterations', '3', '--', 'true'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', side_effect=mock_procs):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(['--iterations', '3', '--', 'true'])
 
     assert exc.value.code == 1
     assert json.loads(buf.getvalue())['call']['returncode'] == [0, 1, 2]
@@ -339,16 +344,17 @@ def test_cli_returncode_preserves_first_nonzero_even_if_later_is_larger():
 
 def test_cli_returncode_preserves_first_nonzero_signal_code():
     """Negative subprocess returncodes are also returned if they are first non-zero."""
-    mock_results = [
-        MagicMock(returncode=0, stdout=None, stderr=None),
-        MagicMock(returncode=-15, stdout=None, stderr=None),
-        MagicMock(returncode=1, stdout=None, stderr=None),
+    mock_procs = [
+        _make_mock_popen(returncode=0),
+        _make_mock_popen(returncode=-15),
+        _make_mock_popen(returncode=1),
     ]
     buf = io.StringIO()
-    with patch('subprocess.run', side_effect=mock_results):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit) as exc:
-                main(['--iterations', '3', '--', 'true'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', side_effect=mock_procs):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(['--iterations', '3', '--', 'true'])
 
     assert exc.value.code == -15
     assert json.loads(buf.getvalue())['call']['returncode'] == [0, -15, 1]
@@ -364,12 +370,16 @@ def test_cli_multiple_mixins():
 
 def test_cli_all_overrides_mixin():
     """--all takes precedence over --mixin."""
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        buf = io.StringIO()
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit):
-                with patch('subprocess.check_output', side_effect=Exception('skip')):
-                    main(['--mixin', 'MBHostInfo', '--all', '--', 'true'])
+    mock_proc = _make_mock_popen(returncode=0)
+    buf = io.StringIO()
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    with patch(
+                        'subprocess.check_output', side_effect=Exception('skip')
+                    ):
+                        main(['--mixin', 'MBHostInfo', '--all', '--', 'true'])
 
     record = json.loads(buf.getvalue())
     # --all should activate every mixin, so slurm (from MBSlurmInfo) must be present
@@ -614,10 +624,11 @@ def _run_main_with_monitor(argv, mock_pid=12345, mock_returncode=0, fake_samples
         MockThread.return_value = mock_thread
 
         buf = io.StringIO()
-        with patch('subprocess.Popen', return_value=mock_proc):
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit):
-                    main(argv)
+        with patch('microbench.cli.main._HAVE_WAIT4', False):
+            with patch('subprocess.Popen', return_value=mock_proc):
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit):
+                        main(argv)
 
     return json.loads(buf.getvalue()), MockThread, mock_thread
 
@@ -695,20 +706,21 @@ def test_cli_monitor_interval_multiple_iterations():
 
     buf = io.StringIO()
     with patch('microbench.cli.main._SubprocessMonitorThread', side_effect=make_thread):
-        with patch('subprocess.Popen', return_value=mock_proc):
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit):
-                    main(
-                        [
-                            '--no-mixin',
-                            '--monitor-interval',
-                            '5',
-                            '--iterations',
-                            '3',
-                            '--',
-                            'cmd',
-                        ]
-                    )
+        with patch('microbench.cli.main._HAVE_WAIT4', False):
+            with patch('subprocess.Popen', return_value=mock_proc):
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit):
+                        main(
+                            [
+                                '--no-mixin',
+                                '--monitor-interval',
+                                '5',
+                                '--iterations',
+                                '3',
+                                '--',
+                                'cmd',
+                            ]
+                        )
 
     record = json.loads(buf.getvalue())
     assert len(record['call']['monitor']) == 3
@@ -732,22 +744,23 @@ def test_cli_monitor_interval_warmup_excluded():
 
     buf = io.StringIO()
     with patch('microbench.cli.main._SubprocessMonitorThread', side_effect=make_thread):
-        with patch('subprocess.Popen', return_value=mock_proc):
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit):
-                    main(
-                        [
-                            '--no-mixin',
-                            '--monitor-interval',
-                            '5',
-                            '--warmup',
-                            '2',
-                            '--iterations',
-                            '2',
-                            '--',
-                            'cmd',
-                        ]
-                    )
+        with patch('microbench.cli.main._HAVE_WAIT4', False):
+            with patch('subprocess.Popen', return_value=mock_proc):
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit):
+                        main(
+                            [
+                                '--no-mixin',
+                                '--monitor-interval',
+                                '5',
+                                '--warmup',
+                                '2',
+                                '--iterations',
+                                '2',
+                                '--',
+                                'cmd',
+                            ]
+                        )
 
     record = json.loads(buf.getvalue())
     assert len(record['call']['monitor']) == 2
@@ -788,20 +801,21 @@ def test_cli_monitor_interval_with_stdout_capture():
         mock_thread = MagicMock()
         mock_thread.samples = fake_samples
         MockThread.return_value = mock_thread
-        with patch('subprocess.Popen', return_value=mock_proc):
-            with patch('sys.stdout', buf):
-                with patch('sys.__stdout__', io.StringIO()):
-                    with pytest.raises(SystemExit):
-                        main(
-                            [
-                                '--no-mixin',
-                                '--monitor-interval',
-                                '5',
-                                '--stdout',
-                                '--',
-                                'cmd',
-                            ]
-                        )
+        with patch('microbench.cli.main._HAVE_WAIT4', False):
+            with patch('subprocess.Popen', return_value=mock_proc):
+                with patch('sys.stdout', buf):
+                    with patch('sys.__stdout__', io.StringIO()):
+                        with pytest.raises(SystemExit):
+                            main(
+                                [
+                                    '--no-mixin',
+                                    '--monitor-interval',
+                                    '5',
+                                    '--stdout',
+                                    '--',
+                                    'cmd',
+                                ]
+                            )
 
     record = json.loads(buf.getvalue())
     assert record['call']['stdout'] == ['hello\n']
@@ -819,14 +833,16 @@ def _run_main_http(argv, fake_status=200):
     mock_response.__enter__ = lambda s: s
     mock_response.__exit__ = MagicMock(return_value=False)
 
+    mock_proc = _make_mock_popen(returncode=0)
     buf = io.StringIO()
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        with patch(
-            'urllib.request.urlopen', return_value=mock_response
-        ) as mock_urlopen:
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit) as exc:
-                    main(argv)
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch(
+                'urllib.request.urlopen', return_value=mock_response
+            ) as mock_urlopen:
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit) as exc:
+                        main(argv)
     return exc.value.code, mock_urlopen
 
 
@@ -849,11 +865,21 @@ def test_cli_http_output_no_stdout_record():
     mock_response = MagicMock()
     mock_response.__enter__ = lambda s: s
     mock_response.__exit__ = MagicMock(return_value=False)
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        with patch('urllib.request.urlopen', return_value=mock_response):
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit):
-                    main(['--no-mixin', '--http-output', 'https://x.com', '--', 'true'])
+    mock_proc = _make_mock_popen(returncode=0)
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('urllib.request.urlopen', return_value=mock_response):
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit):
+                        main(
+                            [
+                                '--no-mixin',
+                                '--http-output',
+                                'https://x.com',
+                                '--',
+                                'true',
+                            ]
+                        )
     assert buf.getvalue() == ''
 
 
@@ -863,22 +889,24 @@ def test_cli_http_output_and_outfile(tmp_path):
     mock_response = MagicMock()
     mock_response.__enter__ = lambda s: s
     mock_response.__exit__ = MagicMock(return_value=False)
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        with patch(
-            'urllib.request.urlopen', return_value=mock_response
-        ) as mock_urlopen:
-            with pytest.raises(SystemExit):
-                main(
-                    [
-                        '--no-mixin',
-                        '--outfile',
-                        str(outfile),
-                        '--http-output',
-                        'https://x.com',
-                        '--',
-                        'true',
-                    ]
-                )
+    mock_proc = _make_mock_popen(returncode=0)
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch(
+                'urllib.request.urlopen', return_value=mock_response
+            ) as mock_urlopen:
+                with pytest.raises(SystemExit):
+                    main(
+                        [
+                            '--no-mixin',
+                            '--outfile',
+                            str(outfile),
+                            '--http-output',
+                            'https://x.com',
+                            '--',
+                            'true',
+                        ]
+                    )
     assert outfile.exists()
     assert json.loads(outfile.read_text())['call']['name'] == 'true'
     mock_urlopen.assert_called_once()
@@ -997,12 +1025,14 @@ def _run_main_redis(argv):
     mock_client.rpush.side_effect = lambda key, val: redis_store.append(val)
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_client
+    mock_proc = _make_mock_popen(returncode=0)
     buf = io.StringIO()
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        with patch.dict('sys.modules', {'redis': mock_redis}):
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit) as exc:
-                    main(argv)
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch.dict('sys.modules', {'redis': mock_redis}):
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit) as exc:
+                        main(argv)
     return exc.value.code, mock_redis, mock_client, redis_store
 
 
@@ -1032,13 +1062,21 @@ def test_cli_redis_output_no_stdout_record():
     mock_client = MagicMock()
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_client
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        with patch.dict('sys.modules', {'redis': mock_redis}):
-            with patch('sys.stdout', buf):
-                with pytest.raises(SystemExit):
-                    main(
-                        ['--no-mixin', '--redis-output', 'bench:results', '--', 'true']
-                    )
+    mock_proc = _make_mock_popen(returncode=0)
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch.dict('sys.modules', {'redis': mock_redis}):
+                with patch('sys.stdout', buf):
+                    with pytest.raises(SystemExit):
+                        main(
+                            [
+                                '--no-mixin',
+                                '--redis-output',
+                                'bench:results',
+                                '--',
+                                'true',
+                            ]
+                        )
     assert buf.getvalue() == ''
 
 
@@ -1048,20 +1086,22 @@ def test_cli_redis_output_and_outfile(tmp_path):
     mock_client = MagicMock()
     mock_redis = MagicMock()
     mock_redis.StrictRedis.return_value = mock_client
-    with patch('subprocess.run', return_value=MagicMock(returncode=0)):
-        with patch.dict('sys.modules', {'redis': mock_redis}):
-            with pytest.raises(SystemExit):
-                main(
-                    [
-                        '--no-mixin',
-                        '--outfile',
-                        str(outfile),
-                        '--redis-output',
-                        'bench:results',
-                        '--',
-                        'true',
-                    ]
-                )
+    mock_proc = _make_mock_popen(returncode=0)
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch.dict('sys.modules', {'redis': mock_redis}):
+                with pytest.raises(SystemExit):
+                    main(
+                        [
+                            '--no-mixin',
+                            '--outfile',
+                            str(outfile),
+                            '--redis-output',
+                            'bench:results',
+                            '--',
+                            'true',
+                        ]
+                    )
     assert outfile.exists()
     assert json.loads(outfile.read_text())['call']['name'] == 'true'
     mock_client.rpush.assert_called_once()
@@ -1414,10 +1454,11 @@ def test_cli_timeout_not_exceeded():
     mock_proc.returncode = 0
 
     buf = io.StringIO()
-    with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit) as exc:
-                main(['--no-mixin', '--timeout', '30', '--', 'sleep', '1'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(['--no-mixin', '--timeout', '30', '--', 'sleep', '1'])
     assert exc.value.code == 0
     record = json.loads(buf.getvalue())
     assert 'timed_out' not in record['call']
@@ -1431,14 +1472,14 @@ def test_cli_timeout_sigterm_sufficient():
     mock_proc.wait.side_effect = [
         subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # main timeout
         None,  # exits cleanly after SIGTERM (within grace period)
-        None,  # called again by Popen.__exit__
     ]
 
     buf = io.StringIO()
-    with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit):
-                main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
     record = json.loads(buf.getvalue())
     assert record['call']['timed_out'] is True
     mock_proc.terminate.assert_called_once()
@@ -1453,14 +1494,14 @@ def test_cli_timeout_sigkill_required():
         subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # main timeout
         subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),  # grace period
         None,  # exits after SIGKILL
-        None,  # called again by Popen.__exit__
     ]
 
     buf = io.StringIO()
-    with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit):
-                main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', return_value=mock_proc):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit):
+                    main(['--no-mixin', '--timeout', '5', '--', 'sleep', '100'])
     record = json.loads(buf.getvalue())
     assert record['call']['timed_out'] is True
     mock_proc.terminate.assert_called_once()
@@ -1474,28 +1515,28 @@ def test_cli_timeout_during_warmup_does_not_set_timed_out():
     warmup_proc.wait.side_effect = [
         subprocess.TimeoutExpired(cmd=['sleep', '100'], timeout=5),
         None,
-        None,
     ]
 
     timed_proc = _make_mock_popen()
     timed_proc.returncode = 0
 
     buf = io.StringIO()
-    with patch('subprocess.Popen', side_effect=[warmup_proc, timed_proc]):
-        with patch('sys.stdout', buf):
-            with pytest.raises(SystemExit) as exc:
-                main(
-                    [
-                        '--no-mixin',
-                        '--warmup',
-                        '1',
-                        '--timeout',
-                        '5',
-                        '--',
-                        'sleep',
-                        '100',
-                    ]
-                )
+    with patch('microbench.cli.main._HAVE_WAIT4', False):
+        with patch('subprocess.Popen', side_effect=[warmup_proc, timed_proc]):
+            with patch('sys.stdout', buf):
+                with pytest.raises(SystemExit) as exc:
+                    main(
+                        [
+                            '--no-mixin',
+                            '--warmup',
+                            '1',
+                            '--timeout',
+                            '5',
+                            '--',
+                            'sleep',
+                            '100',
+                        ]
+                    )
 
     assert exc.value.code == 0
     record = json.loads(buf.getvalue())
@@ -1760,15 +1801,18 @@ def test_cli_resource_usage_in_defaults():
 def test_cli_resource_usage_fields_present():
     """resource-usage records all expected fields."""
     _, record, _ = _run_main(['--mixin', 'resource-usage', '--', 'true'])
-    ru = record.get('resource_usage', {})
-    assert set(ru.keys()) == _RUSAGE_FIELDS
+    ru_list = record.get('resource_usage', [])
+    assert isinstance(ru_list, list)
+    assert len(ru_list) == 1
+    assert set(ru_list[0].keys()) == _RUSAGE_FIELDS
 
 
 def test_cli_resource_usage_values_are_numeric():
     """resource-usage field values are all numbers (int or float)."""
     _, record, _ = _run_main(['--mixin', 'resource-usage', '--', 'true'])
-    ru = record.get('resource_usage', {})
-    for field, value in ru.items():
+    ru_list = record.get('resource_usage', [])
+    assert len(ru_list) == 1
+    for field, value in ru_list[0].items():
         assert isinstance(value, int | float), (
             f'{field}: expected number, got {type(value)}'
         )
@@ -1804,7 +1848,10 @@ def test_cli_resource_usage_real_subprocess_maxrss():
         with pytest.raises(SystemExit):
             main(['--mixin', 'resource-usage', '--', sys.executable, '-c', 'pass'])
     record = json.loads(buf.getvalue())
-    ru = record.get('resource_usage', {})
+    ru_list = record.get('resource_usage', [])
+    assert isinstance(ru_list, list)
+    assert len(ru_list) == 1
+    ru = ru_list[0]
     assert set(ru.keys()) == _RUSAGE_FIELDS
     assert ru['maxrss'] > 0, (
         'maxrss should be positive after running a Python subprocess'
@@ -1821,7 +1868,7 @@ def test_cli_resource_usage_real_subprocess_cpu_nonnegative():
         with pytest.raises(SystemExit):
             main(['--mixin', 'resource-usage', '--', sys.executable, '-c', 'pass'])
     record = json.loads(buf.getvalue())
-    ru = record.get('resource_usage', {})
+    ru = record['resource_usage'][0]
     assert ru['utime'] >= 0.0
     assert ru['stime'] >= 0.0
 
@@ -1836,6 +1883,6 @@ def test_cli_resource_usage_real_subprocess_counts_nonnegative():
         with pytest.raises(SystemExit):
             main(['--mixin', 'resource-usage', '--', sys.executable, '-c', 'pass'])
     record = json.loads(buf.getvalue())
-    ru = record.get('resource_usage', {})
+    ru = record['resource_usage'][0]
     for field in ('minflt', 'majflt', 'inblock', 'oublock', 'nvcsw', 'nivcsw'):
         assert ru[field] >= 0, f'{field} should be non-negative'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1656,25 +1656,6 @@ def test_cli_timeout_during_warmup_does_not_set_timed_out():
     assert 'timed_out' not in record['call']
 
 
-@pytest.mark.skipif(
-    sys.platform == 'win32', reason='os.wait4() is not available on Windows'
-)
-def test_cli_keyboard_interrupt_kills_child():
-    """KeyboardInterrupt during wait4 join causes proc.kill() and re-raises."""
-    mock_proc = _make_mock_popen()
-
-    def _wait4_interrupt(pid, options):
-        raise KeyboardInterrupt
-
-    with patch('subprocess.Popen', return_value=mock_proc):
-        with patch('os.wait4', side_effect=_wait4_interrupt):
-            with pytest.raises(KeyboardInterrupt):
-                main(['--no-mixin', '--', 'sleep', '100'])
-
-    mock_proc.kill.assert_called()
-    mock_proc.wait.assert_called()
-
-
 def test_cli_pipe_fds_closed_after_run():
     """stdout and stderr pipe FDs are closed after a normal run."""
     mock_proc = _make_mock_popen(
@@ -1944,6 +1925,9 @@ _RUSAGE_FIELDS = frozenset(
 )
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
 def test_cli_resource_usage_in_defaults():
     """resource-usage is included in the default mixin set."""
     _, record, _ = _run_main(['--', 'true'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def _run_main(argv, mock_returncode=0):
     wait_status = 0 if mock_returncode == 0 else mock_returncode << 8
     fake_wait4 = (mock_proc.pid, wait_status, _FakeRusage())
     with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
-        with patch('os.wait4', return_value=fake_wait4):
+        with patch('os.wait4', return_value=fake_wait4, create=True):
             with patch('sys.stdout', buf):
                 with pytest.raises(SystemExit) as exc:
                     main(argv)
@@ -78,7 +78,7 @@ def _run_main(argv, mock_returncode=0):
 def _patch_wait4_success(mock_proc, *, rusage=None, status=0):
     if rusage is None:
         rusage = _FakeRusage()
-    return patch('os.wait4', return_value=(mock_proc.pid, status, rusage))
+    return patch('os.wait4', return_value=(mock_proc.pid, status, rusage), create=True)
 
 
 def _patch_wait4_sleep(mock_proc, delay, *, status=0, rusage=None):
@@ -91,7 +91,7 @@ def _patch_wait4_sleep(mock_proc, delay, *, status=0, rusage=None):
         time.sleep(delay)
         return (mock_proc.pid, status, rusage)
 
-    return patch('os.wait4', side_effect=_wait4)
+    return patch('os.wait4', side_effect=_wait4, create=True)
 
 
 def _patch_wait4_sequence(*results):
@@ -103,7 +103,7 @@ def _patch_wait4_sequence(*results):
             return result(pid, options)
         return result
 
-    return patch('os.wait4', side_effect=_wait4)
+    return patch('os.wait4', side_effect=_wait4, create=True)
 
 
 def test_cli_records_command_and_timing():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,13 +36,27 @@ class _FakeRusage:
         self.ru_nivcsw = nivcsw
 
 
+class _MockPipe:
+    """Iterable pipe mock that supports .close(), as real subprocess pipes do."""
+
+    def __init__(self, lines):
+        self._iter = iter(lines)
+        self.closed = False
+
+    def __iter__(self):
+        return self._iter
+
+    def close(self):
+        self.closed = True
+
+
 def _make_mock_popen(returncode=0, stdout_lines=None, stderr_lines=None, pid=12345):
     """Create a mock Popen process."""
     mock_proc = MagicMock()
     mock_proc.returncode = returncode
     mock_proc.pid = pid
-    mock_proc.stdout = iter(stdout_lines) if stdout_lines is not None else None
-    mock_proc.stderr = iter(stderr_lines) if stderr_lines is not None else None
+    mock_proc.stdout = _MockPipe(stdout_lines) if stdout_lines is not None else None
+    mock_proc.stderr = _MockPipe(stderr_lines) if stderr_lines is not None else None
     return mock_proc
 
 
@@ -877,7 +891,7 @@ def test_cli_monitor_interval_requires_psutil():
 def test_cli_monitor_interval_with_stdout_capture():
     """--monitor-interval and --stdout can be combined."""
     mock_proc = _make_mock_popen_for_monitor(pid=55)
-    mock_proc.stdout = iter([b'hello\n'])
+    mock_proc.stdout = _MockPipe([b'hello\n'])
     mock_proc.stderr = None
     fake_samples = [{'timestamp': 'T', 'cpu_percent': 8.0, 'rss_bytes': 2048}]
 
@@ -1634,6 +1648,43 @@ def test_cli_timeout_during_warmup_does_not_set_timed_out():
     record = json.loads(buf.getvalue())
     assert record['call']['returncode'] == [0]
     assert 'timed_out' not in record['call']
+
+
+def test_cli_keyboard_interrupt_kills_child():
+    """KeyboardInterrupt during wait4 join causes proc.kill() and re-raises."""
+    mock_proc = _make_mock_popen()
+
+    def _wait4_interrupt(pid, options):
+        raise KeyboardInterrupt
+
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with patch('os.wait4', side_effect=_wait4_interrupt):
+            with pytest.raises(KeyboardInterrupt):
+                main(['--no-mixin', '--', 'sleep', '100'])
+
+    mock_proc.kill.assert_called()
+    mock_proc.wait.assert_called()
+
+
+def test_cli_pipe_fds_closed_after_run():
+    """stdout and stderr pipe FDs are closed after a normal run."""
+    mock_proc = _make_mock_popen(
+        returncode=0,
+        stdout_lines=[b'out\n'],
+        stderr_lines=[b'err\n'],
+    )
+
+    buf = io.StringIO()
+    with patch('subprocess.Popen', return_value=mock_proc):
+        with _patch_wait4_success(mock_proc):
+            with patch('sys.stdout', buf):
+                with patch('sys.__stdout__', io.StringIO()):
+                    with patch('sys.__stderr__', io.StringIO()):
+                        with pytest.raises(SystemExit):
+                            main(['--stdout', '--stderr', '--', 'cmd'])
+
+    assert mock_proc.stdout.closed
+    assert mock_proc.stderr.closed
 
 
 def test_cli_version(capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1729,3 +1730,112 @@ def test_cli_show_mixins_includes_nvidia_flags():
     output = buf.getvalue()
     assert '--nvidia-attributes' in output
     assert '--nvidia-gpus' in output
+
+
+# ---------------------------------------------------------------------------
+# MBResourceUsage — CLI tests
+# ---------------------------------------------------------------------------
+
+_RUSAGE_FIELDS = frozenset(
+    {
+        'utime',
+        'stime',
+        'maxrss',
+        'minflt',
+        'majflt',
+        'inblock',
+        'oublock',
+        'nvcsw',
+        'nivcsw',
+    }
+)
+
+
+def test_cli_resource_usage_in_defaults():
+    """resource-usage is included in the default mixin set."""
+    _, record, _ = _run_main(['--', 'true'])
+    assert 'resource_usage' in record
+
+
+def test_cli_resource_usage_fields_present():
+    """resource-usage records all expected fields."""
+    _, record, _ = _run_main(['--mixin', 'resource-usage', '--', 'true'])
+    ru = record.get('resource_usage', {})
+    assert set(ru.keys()) == _RUSAGE_FIELDS
+
+
+def test_cli_resource_usage_values_are_numeric():
+    """resource-usage field values are all numbers (int or float)."""
+    _, record, _ = _run_main(['--mixin', 'resource-usage', '--', 'true'])
+    ru = record.get('resource_usage', {})
+    for field, value in ru.items():
+        assert isinstance(value, int | float), (
+            f'{field}: expected number, got {type(value)}'
+        )
+
+
+def test_cli_resource_usage_no_mixins_omits_field():
+    """--no-mixin produces a record without resource_usage."""
+    _, record, _ = _run_main(['--no-mixin', '--', 'true'])
+    assert 'resource_usage' not in record
+
+
+def test_cli_show_mixins_includes_resource_usage():
+    """--show-mixins lists resource-usage with a default marker."""
+    buf = io.StringIO()
+    with patch('sys.stdout', buf):
+        with pytest.raises(SystemExit):
+            main(['--show-mixins'])
+    output = buf.getvalue()
+    assert 'resource-usage' in output
+    # resource-usage is a default mixin — should be starred
+    lines = [line for line in output.splitlines() if 'resource-usage' in line]
+    assert lines, 'resource-usage not found in --show-mixins output'
+    assert lines[0].startswith('  *'), 'resource-usage should be marked as default (*)'
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_cli_resource_usage_real_subprocess_maxrss():
+    """resource-usage records a positive maxrss from a real subprocess."""
+    buf = io.StringIO()
+    with patch('sys.stdout', buf):
+        with pytest.raises(SystemExit):
+            main(['--mixin', 'resource-usage', '--', sys.executable, '-c', 'pass'])
+    record = json.loads(buf.getvalue())
+    ru = record.get('resource_usage', {})
+    assert set(ru.keys()) == _RUSAGE_FIELDS
+    assert ru['maxrss'] > 0, (
+        'maxrss should be positive after running a Python subprocess'
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_cli_resource_usage_real_subprocess_cpu_nonnegative():
+    """utime and stime are non-negative after a real subprocess."""
+    buf = io.StringIO()
+    with patch('sys.stdout', buf):
+        with pytest.raises(SystemExit):
+            main(['--mixin', 'resource-usage', '--', sys.executable, '-c', 'pass'])
+    record = json.loads(buf.getvalue())
+    ru = record.get('resource_usage', {})
+    assert ru['utime'] >= 0.0
+    assert ru['stime'] >= 0.0
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_cli_resource_usage_real_subprocess_counts_nonnegative():
+    """All integer count fields are non-negative after a real subprocess."""
+    buf = io.StringIO()
+    with patch('sys.stdout', buf):
+        with pytest.raises(SystemExit):
+            main(['--mixin', 'resource-usage', '--', sys.executable, '-c', 'pass'])
+    record = json.loads(buf.getvalue())
+    ru = record.get('resource_usage', {})
+    for field in ('minflt', 'majflt', 'inblock', 'oublock', 'nvcsw', 'nivcsw'):
+        assert ru[field] >= 0, f'{field} should be non-negative'

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -873,8 +873,50 @@ def test_resource_usage_python_api_fields():
     work()
     ru_list = bench.get_results()[0].get('resource_usage', [])
     assert isinstance(ru_list, list)
-    assert len(ru_list) == 1
+    assert len(ru_list) == 1  # 1 timed iteration
     assert set(ru_list[0].keys()) == _RUSAGE_FIELDS_PYTHON_API
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_resource_usage_python_api_one_entry_per_iteration():
+    """resource_usage has one entry per timed iteration in Python API mode."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench(iterations=3)
+
+    @bench
+    def work():
+        return sum(range(1000))
+
+    work()
+    ru_list = bench.get_results()[0].get('resource_usage', [])
+    assert len(ru_list) == 3
+    for entry in ru_list:
+        assert set(entry.keys()) == _RUSAGE_FIELDS_PYTHON_API
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_resource_usage_python_api_warmup_excluded():
+    """Warmup iterations are not counted in resource_usage."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench(iterations=2, warmup=3)
+
+    @bench
+    def work():
+        return sum(range(1000))
+
+    work()
+    ru_list = bench.get_results()[0].get('resource_usage', [])
+    assert len(ru_list) == 2  # only timed iterations
 
 
 @pytest.mark.skipif(

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -13,6 +13,7 @@ from microbench import (
     MBLineProfiler,
     MBLoadedModules,
     MBPeakMemory,
+    MBResourceUsage,
     MBSlurmInfo,
     MBWorkingDir,
     MicroBench,
@@ -836,3 +837,127 @@ def test_cgroup_limits_unavailable():
         noop()
 
     assert bench.get_results()[0].get('cgroups', {}) == {}
+
+
+# ---------------------------------------------------------------------------
+# MBResourceUsage
+# ---------------------------------------------------------------------------
+
+_RUSAGE_FIELDS = {
+    'utime',
+    'stime',
+    'maxrss',
+    'minflt',
+    'majflt',
+    'inblock',
+    'oublock',
+    'nvcsw',
+    'nivcsw',
+}
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_resource_usage_python_api_fields():
+    """MBResourceUsage records all expected fields in Python API mode."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def work():
+        return sum(range(50000))
+
+    work()
+    ru = bench.get_results()[0].get('resource_usage', {})
+    assert set(ru.keys()) == _RUSAGE_FIELDS
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_resource_usage_python_api_maxrss_positive():
+    """maxrss is a positive integer (bytes) after running a Python function."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def work():
+        return list(range(10000))
+
+    work()
+    maxrss = bench.get_results()[0]['resource_usage']['maxrss']
+    assert isinstance(maxrss, int)
+    assert maxrss > 0
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_resource_usage_python_api_cpu_nonnegative():
+    """utime and stime are non-negative floats."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def work():
+        return sum(range(10000))
+
+    work()
+    ru = bench.get_results()[0]['resource_usage']
+    assert ru['utime'] >= 0.0
+    assert ru['stime'] >= 0.0
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='resource module not available on Windows'
+)
+def test_resource_usage_python_api_counts_nonnegative():
+    """All integer count fields are non-negative."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    noop()
+    ru = bench.get_results()[0]['resource_usage']
+    for field in ('minflt', 'majflt', 'inblock', 'oublock', 'nvcsw', 'nivcsw'):
+        assert ru[field] >= 0, f'{field} should be non-negative'
+
+
+def test_resource_usage_windows_fallback():
+    """Records empty dict when the resource module is unavailable (Windows guard)."""
+
+    class Bench(MicroBench, MBResourceUsage):
+        pass
+
+    bench = Bench()
+
+    @bench
+    def noop():
+        pass
+
+    import microbench.mixins.system as _sys_mod
+
+    original = _sys_mod._resource
+    try:
+        _sys_mod._resource = None
+        noop()
+    finally:
+        _sys_mod._resource = original
+
+    assert bench.get_results()[0].get('resource_usage') == {}

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -988,7 +988,7 @@ def test_resource_usage_python_api_counts_nonnegative():
 
 
 def test_resource_usage_windows_fallback():
-    """Records empty list when the resource module is unavailable (Windows guard)."""
+    """Omits resource_usage key when the resource module is unavailable."""
 
     class Bench(MicroBench, MBResourceUsage):
         pass
@@ -1008,4 +1008,4 @@ def test_resource_usage_windows_fallback():
     finally:
         _sys_mod._resource = original
 
-    assert bench.get_results()[0].get('resource_usage') == []
+    assert 'resource_usage' not in bench.get_results()[0]

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -871,8 +871,10 @@ def test_resource_usage_python_api_fields():
         return sum(range(50000))
 
     work()
-    ru = bench.get_results()[0].get('resource_usage', {})
-    assert set(ru.keys()) == _RUSAGE_FIELDS_PYTHON_API
+    ru_list = bench.get_results()[0].get('resource_usage', [])
+    assert isinstance(ru_list, list)
+    assert len(ru_list) == 1
+    assert set(ru_list[0].keys()) == _RUSAGE_FIELDS_PYTHON_API
 
 
 @pytest.mark.skipif(
@@ -891,8 +893,10 @@ def test_resource_usage_python_api_maxrss_absent():
         return list(range(10000))
 
     work()
-    ru = bench.get_results()[0].get('resource_usage', {})
-    assert 'maxrss' not in ru, (
+    ru_list = bench.get_results()[0].get('resource_usage', [])
+    assert isinstance(ru_list, list)
+    assert len(ru_list) == 1
+    assert 'maxrss' not in ru_list[0], (
         'maxrss must not appear in Python API mode records because '
         'RUSAGE_SELF.maxrss is a lifetime process high-water mark and '
         'cannot isolate a single function call'
@@ -915,7 +919,7 @@ def test_resource_usage_python_api_cpu_nonnegative():
         return sum(range(10000))
 
     work()
-    ru = bench.get_results()[0]['resource_usage']
+    ru = bench.get_results()[0]['resource_usage'][0]
     assert ru['utime'] >= 0.0
     assert ru['stime'] >= 0.0
 
@@ -936,13 +940,13 @@ def test_resource_usage_python_api_counts_nonnegative():
         pass
 
     noop()
-    ru = bench.get_results()[0]['resource_usage']
+    ru = bench.get_results()[0]['resource_usage'][0]
     for field in ('minflt', 'majflt', 'inblock', 'oublock', 'nvcsw', 'nivcsw'):
         assert ru[field] >= 0, f'{field} should be non-negative'
 
 
 def test_resource_usage_windows_fallback():
-    """Records empty dict when the resource module is unavailable (Windows guard)."""
+    """Records empty list when the resource module is unavailable (Windows guard)."""
 
     class Bench(MicroBench, MBResourceUsage):
         pass
@@ -962,4 +966,4 @@ def test_resource_usage_windows_fallback():
     finally:
         _sys_mod._resource = original
 
-    assert bench.get_results()[0].get('resource_usage') == {}
+    assert bench.get_results()[0].get('resource_usage') == []

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -843,10 +843,9 @@ def test_cgroup_limits_unavailable():
 # MBResourceUsage
 # ---------------------------------------------------------------------------
 
-_RUSAGE_FIELDS = {
+_RUSAGE_FIELDS_PYTHON_API = {
     'utime',
     'stime',
-    'maxrss',
     'minflt',
     'majflt',
     'inblock',
@@ -873,14 +872,14 @@ def test_resource_usage_python_api_fields():
 
     work()
     ru = bench.get_results()[0].get('resource_usage', {})
-    assert set(ru.keys()) == _RUSAGE_FIELDS
+    assert set(ru.keys()) == _RUSAGE_FIELDS_PYTHON_API
 
 
 @pytest.mark.skipif(
     sys.platform == 'win32', reason='resource module not available on Windows'
 )
-def test_resource_usage_python_api_maxrss_positive():
-    """maxrss is a positive integer (bytes) after running a Python function."""
+def test_resource_usage_python_api_maxrss_absent():
+    """maxrss is absent in Python API mode (RUSAGE_SELF.maxrss is a lifetime HWM)."""
 
     class Bench(MicroBench, MBResourceUsage):
         pass
@@ -892,9 +891,12 @@ def test_resource_usage_python_api_maxrss_positive():
         return list(range(10000))
 
     work()
-    maxrss = bench.get_results()[0]['resource_usage']['maxrss']
-    assert isinstance(maxrss, int)
-    assert maxrss > 0
+    ru = bench.get_results()[0].get('resource_usage', {})
+    assert 'maxrss' not in ru, (
+        'maxrss must not appear in Python API mode records because '
+        'RUSAGE_SELF.maxrss is a lifetime process high-water mark and '
+        'cannot isolate a single function call'
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
On POSIX, records user/system CPU time, peak RSS (normalised to bytes),
minor/major page faults, block I/O ops, and voluntary/involuntary
context switches via the stdlib resource module.

CLI mode uses os.wait4() which calculates per subprocess run;
Python API mode uses RUSAGE_SELF. maxrss is intentionally
omitted here as it's a high watermark for the entire Python
process lifetime.

On Windows, the mixin records an empty dict silently.

Added as a default CLI mixin in _DEFAULT_MIXINS.