### PR TITLE
docs: remove stale cli_compatible from extending guide and note in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ All notable changes to microbench are documented here.
 
 ### Documentation
 
+- **`cli_compatible` class attribute removed from built-in mixins**: this
+  attribute was never read at runtime — CLI availability is governed solely
+  by the `MIXIN_REGISTRY` in `cli/registry.py`. The extending guide example
+  has been updated to drop it; custom mixins that set it can safely remove
+  it without any behavioural change.
+
 - Fix documentation on writing custom mixins to note that they must be
   added to the registry if they are to be detected by the CLI.
 

--- a/docs/user-guide/extending.md
+++ b/docs/user-guide/extending.md
@@ -54,7 +54,6 @@ from microbench import CLIArg
 class MBOutputDir:
     """Record the output directory for this run."""
 
-    cli_compatible = True
     cli_args = [
         CLIArg(
             flags=['--output-dir'],


### PR DESCRIPTION
## Summary

- Removes `cli_compatible = True` from the custom mixin example in `docs/user-guide/extending.md` — the attribute was stripped from all built-in mixins in #107 (it was never read at runtime) but the guide wasn't updated.
- Adds a CHANGELOG entry under Unreleased → Documentation noting the removal and clarifying that custom mixins can safely drop it.