### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to microbench are documented here.
 
-## [Unreleased]
+## [2.1.0] - 2026-04-26
 
 ### New features
 


### PR DESCRIPTION
Updates CHANGELOG.md: replaces `[Unreleased]` with `[2.1.0] - 2026-04-26`. Tag `v2.1.0` will be pushed to main after merge.