### PR TITLE
chore(deps): bump ruff to v0.16.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,9 +108,10 @@ Be sure to review the breaking changes before upgrading.
 
   bench = MicroBench()
 
+
   @bench
-  def my_function():
-      ...
+  def my_function(): ...
+
 
   for _ in range(10):
       my_function()
@@ -149,6 +150,7 @@ Be sure to review the breaking changes before upgrading.
   @bench
   async def fetch():
       await asyncio.sleep(0.01)
+
 
   asyncio.run(fetch())
 
@@ -288,10 +290,12 @@ Be sure to review the breaking changes before upgrading.
   ```python
   from microbench import MicroBench, FileOutput, RedisOutput
 
-  bench = MicroBench(outputs=[
-      FileOutput('/home/user/results.jsonl'),
-      RedisOutput('microbench:mykey', host='redis-host', port=6379),
-  ])
+  bench = MicroBench(
+      outputs=[
+          FileOutput('/home/user/results.jsonl'),
+          RedisOutput('microbench:mykey', host='redis-host', port=6379),
+      ]
+  )
   ```
 
   `get_results()` delegates to the first sink that supports reading back
@@ -395,9 +399,11 @@ Be sure to review the breaking changes before upgrading.
   ```python
   from microbench import MicroBenchRedis
 
+
   class RedisBench(MicroBenchRedis):
       redis_connection = {'host': 'localhost', 'port': 6379}
       redis_key = 'microbench:mykey'
+
 
   bench = RedisBench()
   ```
@@ -406,8 +412,9 @@ Be sure to review the breaking changes before upgrading.
   ```python
   from microbench import MicroBench, RedisOutput
 
-  bench = MicroBench(outputs=[RedisOutput('microbench:mykey',
-                                           host='localhost', port=6379)])
+  bench = MicroBench(
+      outputs=[RedisOutput('microbench:mykey', host='localhost', port=6379)]
+  )
   ```
 
 - **`LiveStream` updated for v2 record schema**: field references updated from

--- a/README.md
+++ b/README.md
@@ -146,15 +146,17 @@ from microbench import MicroBench
 
 bench = MicroBench(outfile='/home/user/results.jsonl', experiment='baseline')
 
+
 @bench
 def my_function(n):
     return sum(range(n))
 
+
 my_function(1_000_000)
 
-results = bench.get_results()              # list of dicts — no extra dependencies
+results = bench.get_results()  # list of dicts — no extra dependencies
 results = bench.get_results(format='df')  # pandas DataFrame
-bench.summary()                           # quick stats printout
+bench.summary()  # quick stats printout
 ```
 
 Each call produces one record. With `get_results(flat=True)` the record looks
@@ -183,17 +185,19 @@ like:
 from microbench import MicroBench, MBFunctionCall, MBHostInfo, MBSlurmInfo
 import numpy, pandas, time
 
+
 class MyBench(MicroBench, MBFunctionCall, MBHostInfo, MBSlurmInfo):
     outfile = '/home/user/my-benchmarks.jsonl'
-    capture_versions = (numpy, pandas)   # record live module versions
-    env_vars = ('CUDA_VISIBLE_DEVICES',) # capture env vars as env.<NAME>
+    capture_versions = (numpy, pandas)  # record live module versions
+    env_vars = ('CUDA_VISIBLE_DEVICES',)  # capture env vars as env.<NAME>
 
-benchmark = MyBench(experiment='run-1', iterations=3,
-                    duration_counter=time.monotonic)
+
+benchmark = MyBench(experiment='run-1', iterations=3, duration_counter=time.monotonic)
+
 
 @benchmark
-def myfunction(arg1, arg2):
-    ...
+def myfunction(arg1, arg2): ...
+
 
 myfunction(x, y)
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -279,6 +279,7 @@ Read the results:
 
 ```python
 from microbench import FileOutput
+
 df = FileOutput('/scratch/user/results.jsonl').get_results(flat=True, format='df')
 df['total_duration'] = df['call.durations'].apply(sum)
 df.groupby('slurm.job_id')['total_duration'].describe()
@@ -444,6 +445,7 @@ Read results back from Redis with Python:
 
 ```python
 import redis, json
+
 client = redis.StrictRedis(host='redis.example.com')
 records = [json.loads(r) for r in client.lrange('bench:results', 0, -1)]
 ```
@@ -452,6 +454,7 @@ Or via microbench's `RedisOutput.get_results()`:
 
 ```python
 from microbench import RedisOutput
+
 results = RedisOutput('bench:results', host='redis.example.com').get_results()
 ```
 
@@ -548,15 +551,19 @@ Analyse with `get_results()`:
 
 ```python
 from microbench import FileOutput
+
 results = FileOutput('results.jsonl').get_results()
 
 # Flatten all samples for the first iteration across all records
 import pandas
-samples = pandas.DataFrame([
-    s
-    for r in results
-    for s in r['call']['monitor'][0]   # [0] = first iteration
-])
+
+samples = pandas.DataFrame(
+    [
+        s
+        for r in results
+        for s in r['call']['monitor'][0]  # [0] = first iteration
+    ]
+)
 samples['rss_mb'] = samples['rss_bytes'] / 1024 / 1024
 print(samples[['timestamp', 'cpu_percent', 'rss_mb']])
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,9 +46,11 @@ from microbench import MicroBench
 
 bench = MicroBench()
 
+
 @bench
 def my_function(x):
-    return x ** 2
+    return x**2
+
 
 my_function(42)
 ```
@@ -57,7 +59,7 @@ By default results are captured into an in-memory buffer. Read them back as
 a list of dicts:
 
 ```python
-results = bench.get_results()          # list of dicts — no extra dependencies
+results = bench.get_results()  # list of dicts — no extra dependencies
 results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
@@ -87,21 +89,22 @@ Every record contains these fields automatically (all nested under `mb` or `call
 Here's an extended example to give you an idea of real-world usage.
 
 ```python
-from microbench import MicroBench, MBFunctionCall, \
-    MBHostInfo, MBSlurmInfo
+from microbench import MicroBench, MBFunctionCall, MBHostInfo, MBSlurmInfo
 import numpy, pandas, time
+
 
 class MyBench(MicroBench, MBFunctionCall, MBHostInfo, MBSlurmInfo):
     outfile = '/home/user/my-benchmarks.jsonl'
     capture_versions = (numpy, pandas)
     env_vars = ('CUDA_VISIBLE_DEVICES',)
 
-benchmark = MyBench(experiment='run-1', iterations=3,
-                    duration_counter=time.monotonic)
+
+benchmark = MyBench(experiment='run-1', iterations=3, duration_counter=time.monotonic)
+
 
 @benchmark
-def myfunction(arg1, arg2):
-    ...
+def myfunction(arg1, arg2): ...
+
 
 myfunction(x, y)
 ```
@@ -153,13 +156,14 @@ object per line). Read them back with pandas:
 
 ```python
 import pandas
+
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 ```
 
 Or via `get_results()`, which works regardless of the output destination:
 
 ```python
-results = bench.get_results()              # list of dicts — no extra dependencies
+results = bench.get_results()  # list of dicts — no extra dependencies
 results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
@@ -173,6 +177,7 @@ bench.summary()
 
 # or pass any list of result dicts:
 from microbench import summary
+
 summary(bench.get_results())
 ```
 
@@ -196,7 +201,7 @@ Use `flat=True` to flatten nested fields (e.g. `slurm`, `git`,
 into pandas or a spreadsheet:
 
 ```python
-results = bench.get_results(flat=True)          # list of flat dicts
+results = bench.get_results(flat=True)  # list of flat dicts
 results = bench.get_results(format='df', flat=True)  # flat DataFrame
 # 'call' dict becomes: call.name, call.durations, call.start_time, ...
 # 'slurm' dict becomes: slurm.job_id, slurm.cpus_on_node, ...
@@ -213,8 +218,10 @@ section of a script:
 ```python
 from microbench import MicroBench, MBHostInfo
 
+
 class MyBench(MicroBench, MBHostInfo):
     outfile = '/home/user/results.jsonl'
+
 
 bench = MyBench(experiment='run-1')
 
@@ -256,9 +263,11 @@ process exits — no restructuring of the script is required:
 ```python
 from microbench import MicroBench, MBHostInfo, MBSlurmInfo
 
+
 class MyBench(MicroBench, MBHostInfo, MBSlurmInfo):
     outfile = '/scratch/results.jsonl'
     capture_optional = True  # recommended: don't let a failed capture abort exit
+
 
 bench = MyBench(experiment='baseline')
 bench.record_on_exit('simulation')

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,9 +26,11 @@ from microbench import MicroBench
 
 bench = MicroBench(outfile='results.jsonl')
 
+
 @bench
 def my_function(n):
     return sum(range(n))
+
 
 my_function(1_000_000)
 ```

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -120,10 +120,12 @@ contain `N` entries per named phase:
 ```python
 bench = MicroBench(iterations=3)
 
+
 @bench
 def pipeline():
     with bench.time('step'):
         ...
+
 
 pipeline()
 # call.timings → [{"name": "step", ...}, {"name": "step", ...}, {"name": "step", ...}]
@@ -159,6 +161,7 @@ analysis:
 
 ```python
 import pandas
+
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 
 # Records where the call raised
@@ -177,6 +180,7 @@ a class attribute to catch failures instead and record them in
 
 ```python
 from microbench import MicroBench, MBNvidiaSmi, MBCondaPackages
+
 
 class MyBench(MicroBench, MBNvidiaSmi, MBCondaPackages):
     capture_optional = True  # missing nvidia-smi or conda won't abort the run
@@ -217,20 +221,25 @@ To handle custom types, subclass `JSONEncoder`:
 import microbench as mb
 from igraph import Graph
 
+
 class MyEncoder(mb.JSONEncoder):
     def default(self, o):
         if isinstance(o, Graph):
             return str(o)
         return super().default(o)
 
+
 class MyBench(mb.MicroBench, mb.MBReturnValue):
     pass
 
+
 bench = MyBench(json_encoder=MyEncoder)
+
 
 @bench
 def make_graph():
     return Graph(2, ((0, 1), (0, 2)))
+
 
 make_graph()  # no warning
 ```
@@ -250,11 +259,13 @@ running in the same Python process:
 ```python
 from microbench.livestream import LiveStream
 
+
 class MyStream(LiveStream):
     def process_alert(self, data):
         if sum(data.get('call', {}).get('durations', [])) > 10.0:
             host = data.get('host', {}).get('hostname', 'unknown')
-            print(f"Slow call on {host}: {data['call']['durations']}")
+            print(f'Slow call on {host}: {data["call"]["durations"]}')
+
 
 stream = MyStream('/home/user/results.jsonl')
 # ... runs in background while your job continues ...
@@ -270,6 +281,7 @@ your benchmark job writes to the file:
 from microbench.livestream import LiveStream
 import time
 
+
 class Watcher(LiveStream):
     def filter(self, data):
         # Only show records from GPU nodes
@@ -279,7 +291,8 @@ class Watcher(LiveStream):
         name = data.get('call', {}).get('name', '?')
         host = data.get('host', {}).get('hostname', '?')
         durs = data.get('call', {}).get('durations', [])
-        print(f"{name} | {host} | {durs}")
+        print(f'{name} | {host} | {durs}')
+
 
 stream = Watcher('/home/user/results.jsonl')
 try:
@@ -314,7 +327,9 @@ import pandas
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 
 # Compare the environment of the slowest and fastest calls
-results_flat = pandas.DataFrame(FileOutput('/home/user/results.jsonl').get_results(flat=True))
+results_flat = pandas.DataFrame(
+    FileOutput('/home/user/results.jsonl').get_results(flat=True)
+)
 slowest = results_flat.loc[results_flat['call.durations'].apply(sum).idxmax()]
 fastest = results_flat.loc[results_flat['call.durations'].apply(sum).idxmin()]
 

--- a/docs/user-guide/async.md
+++ b/docs/user-guide/async.md
@@ -13,14 +13,20 @@ from microbench import MicroBench
 
 bench = MicroBench()
 
+
 @bench
 async def fetch_data(url):
     # e.g. await httpx.AsyncClient().get(url)
     await asyncio.sleep(0.01)
     return {'rows': 42}
 
+
 asyncio.run(fetch_data('https://example.com/api'))
-print(bench.get_results(format='df', flat=True)[['call.name', 'call.start_time', 'call.durations']])
+print(
+    bench.get_results(format='df', flat=True)[
+        ['call.name', 'call.start_time', 'call.durations']
+    ]
+)
 ```
 
 The wrapper is a true `async def`, so you can `await` it, pass it to
@@ -40,9 +46,11 @@ from microbench import MicroBench
 
 bench = MicroBench()
 
+
 async def main():
     async with bench.arecord('data_load'):
         await asyncio.sleep(0.01)
+
 
 asyncio.run(main())
 print(bench.get_results())
@@ -75,11 +83,12 @@ function raises `NotImplementedError` at decoration time:
 class Bench(MicroBench, MBLineProfiler):
     pass
 
+
 bench = Bench()
 
+
 @bench  # raises NotImplementedError immediately
-async def my_coroutine():
-    ...
+async def my_coroutine(): ...
 ```
 
 Use a synchronous wrapper function if you need line profiling, or remove

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -32,6 +32,7 @@ the variable is unset it is recorded as `null`:
 ```python
 from microbench import MicroBench
 
+
 class MyBench(MicroBench):
     env_vars = ('MY_VAR', 'ANOTHER_VAR')
 ```

--- a/docs/user-guide/extending.md
+++ b/docs/user-guide/extending.md
@@ -12,6 +12,7 @@ class MBMachineType:
 
     def capture_machine_type(self, bm_data):
         import platform
+
         bm_data['machine_type'] = platform.machine()
 
 
@@ -41,6 +42,7 @@ class MBMachineType:
 
     def capture_machine_type(self, bm_data):
         import platform
+
         bm_data['machine_type'] = platform.machine()
 ```
 
@@ -50,6 +52,7 @@ To expose configurable attributes as CLI flags, add a `cli_args` list of
 
 ```python
 from microbench import CLIArg
+
 
 class MBOutputDir:
     """Record the output directory for this run."""
@@ -96,6 +99,7 @@ dictionary that will be serialised as the result record.
 ```python
 from microbench import MicroBench
 import platform
+
 
 class MyBench(MicroBench):
     def capture_machine_type(self, bm_data):

--- a/docs/user-guide/mixins.md
+++ b/docs/user-guide/mixins.md
@@ -41,6 +41,7 @@ Combine any number of mixins with `MicroBench` via multiple inheritance:
 ```python
 from microbench import MicroBench, MBHostInfo
 
+
 class MyBench(MicroBench, MBHostInfo):
     pass
 ```
@@ -89,14 +90,18 @@ function as `args` (list) and `kwargs` (dict):
 ```python
 from microbench import MicroBench, MBFunctionCall
 
+
 class Bench(MicroBench, MBFunctionCall):
     pass
 
+
 bench = Bench()
+
 
 @bench
 def add(a, b):
     return a + b
+
 
 add(1, b=2)
 # record contains: {"call": {"args": [1], "kwargs": {"b": 2}}, ...}
@@ -109,14 +114,18 @@ Captures the return value of the decorated function as `return_value`:
 ```python
 from microbench import MicroBench, MBReturnValue
 
+
 class Bench(MicroBench, MBReturnValue):
     pass
 
+
 bench = Bench()
+
 
 @bench
 def compute(n):
     return sum(range(n))
+
 
 compute(100)
 # record contains: {"call": {"return_value": 4950}, ...}
@@ -136,6 +145,7 @@ is installed) CPU core counts and total RAM.
 
 ```python
 from microbench import MicroBench, MBHostInfo
+
 
 class Bench(MicroBench, MBHostInfo):
     pass
@@ -162,14 +172,18 @@ the standard library — no extra dependencies required.
 ```python
 from microbench import MicroBench, MBPeakMemory
 
+
 class Bench(MicroBench, MBPeakMemory):
     pass
 
+
 bench = Bench()
+
 
 @bench
 def process(data):
     return sorted(data)
+
 
 process(list(range(1_000_000, 0, -1)))
 # record contains: {"call": {"peak_memory_bytes": 8056968}, ...}
@@ -198,8 +212,10 @@ an empty dict.
 ```python
 from microbench import MicroBench, MBSlurmInfo
 
+
 class Bench(MicroBench, MBSlurmInfo):
     pass
+
 
 bench = Bench()
 ```
@@ -239,8 +255,10 @@ environment, `loaded_modules` is an empty dict.
 ```python
 from microbench import MicroBench, MBLoadedModules
 
+
 class Bench(MicroBench, MBLoadedModules):
     pass
+
 
 bench = Bench()
 ```
@@ -273,8 +291,10 @@ Captures the absolute path of the working directory at benchmark time into `call
 ```python
 from microbench import MicroBench, MBWorkingDir
 
+
 class Bench(MicroBench, MBWorkingDir):
     pass
+
 
 bench = Bench()
 ```
@@ -304,8 +324,10 @@ container — the number that determines your benchmark's resource budget.
 ```python
 from microbench import MicroBench, MBSlurmInfo, MBCgroupLimits
 
+
 class Bench(MicroBench, MBSlurmInfo, MBCgroupLimits):
     pass
+
 
 bench = Bench()
 ```
@@ -366,14 +388,18 @@ On platforms where the stdlib `resource` module is unavailable, the
 ```python
 from microbench import MicroBench, MBResourceUsage
 
+
 class Bench(MicroBench, MBResourceUsage):
     pass
 
+
 bench = Bench()
+
 
 @bench
 def work():
     return list(range(1_000_000))
+
 
 work()
 ```
@@ -516,6 +542,7 @@ Captures the current git repo, commit hash, branch name, and dirty flag
 ```python
 from microbench import MicroBench, MBGitInfo
 
+
 class Bench(MicroBench, MBGitInfo):
     pass
 ```
@@ -568,8 +595,10 @@ enclosed code is run.
 ```python
 from microbench import MicroBench, MBFileHash
 
+
 class Bench(MicroBench, MBFileHash):
     pass
+
 
 bench = Bench()
 ```
@@ -591,6 +620,7 @@ scripts from a scratch directory). Use absolute paths to be safe:
 import os
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 class Bench(MicroBench, MBFileHash):
     hash_files = [
@@ -620,7 +650,7 @@ algorithm from Python's [`hashlib`](https://docs.python.org/3/library/hashlib.ht
 ```python
 class Bench(MicroBench, MBFileHash):
     hash_files = ['large_model_weights.bin']
-    hash_algorithm = 'md5'   # faster for large files
+    hash_algorithm = 'md5'  # faster for large files
 ```
 
 Any algorithm name accepted by `hashlib.new()` works: `'sha256'` (default),
@@ -662,6 +692,7 @@ namespace:
 from microbench import MicroBench, MBGlobalPackages
 import numpy, pandas
 
+
 class Bench(MicroBench, MBGlobalPackages):
     pass
 ```
@@ -699,7 +730,7 @@ A single `conda` dict with three keys:
 
 ```python
 class Bench(MicroBench, MBCondaPackages):
-    include_builds = True    # include build string (default: True)
+    include_builds = True  # include build string (default: True)
     include_channels = False  # include channel name (default: False)
 ```
 
@@ -710,6 +741,7 @@ class. Results are stored in `python.loaded_packages`:
 
 ```python
 import numpy, pandas
+
 
 class Bench(MicroBench):
     capture_versions = (numpy, pandas)
@@ -737,6 +769,7 @@ attributes — power draw, temperature, utilisation, etc. — set `nvidia_attrib
 ```python
 from microbench import MicroBench, MBNvidiaSmi
 
+
 class GpuBench(MicroBench, MBNvidiaSmi):
     nvidia_attributes = ('gpu_name', 'memory.total', 'power.draw', 'temperature.gpu')
 ```
@@ -763,12 +796,12 @@ By default all installed GPUs are captured. To restrict to a subset, set
 
 ```python
 class GpuBench(MicroBench, MBNvidiaSmi):
-    nvidia_gpus = ('GPU-abc123def456',)   # single GPU by UUID
+    nvidia_gpus = ('GPU-abc123def456',)  # single GPU by UUID
 ```
 
 ```python
 class GpuBench(MicroBench, MBNvidiaSmi):
-    nvidia_gpus = (0, 1)   # first two GPUs by index
+    nvidia_gpus = (0, 1)  # first two GPUs by index
 ```
 
 Omit `nvidia_gpus` entirely to capture all GPUs.
@@ -788,10 +821,13 @@ Captures a line-by-line timing profile of the decorated function using
 ```python
 from microbench import MicroBench, MBLineProfiler
 
+
 class Bench(MicroBench, MBLineProfiler):
     pass
 
+
 bench = Bench()
+
 
 @bench
 def my_function():
@@ -799,6 +835,7 @@ def my_function():
     for i in range(1000000):
         acc += i
     return acc
+
 
 my_function()
 

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -72,6 +72,7 @@ launching and cleaning up the background thread automatically.
 ```python
 from microbench import MicroBench
 
+
 class MyBench(MicroBench):
     monitor_interval = 90  # seconds between samples (default: 60)
 
@@ -80,7 +81,9 @@ class MyBench(MicroBench):
         mem = process.memory_full_info()
         return {'rss': mem.rss, 'vms': mem.vms}
 
+
 bench = MyBench()
+
 
 @bench
 def my_function():
@@ -116,9 +119,7 @@ returns:
 class MyBench(MicroBench):
     @staticmethod
     def monitor(process):
-        return process.as_dict(attrs=[
-            'cpu_percent', 'memory_info', 'num_threads'
-        ])
+        return process.as_dict(attrs=['cpu_percent', 'memory_info', 'num_threads'])
 ```
 
 ### Notes

--- a/docs/user-guide/output.md
+++ b/docs/user-guide/output.md
@@ -86,6 +86,7 @@ from microbench import MicroBench
 # As a constructor argument
 bench = MicroBench(outfile='/home/user/results.jsonl')
 
+
 # Or as a class attribute
 class MyBench(MicroBench):
     outfile = '/home/user/results.jsonl'
@@ -106,13 +107,15 @@ sessions or testing:
 ```python
 bench = MicroBench()
 
+
 @bench
 def my_function():
     pass
 
+
 my_function()
 
-results = bench.get_results()              # list of dicts
+results = bench.get_results()  # list of dicts
 results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
@@ -125,10 +128,12 @@ are mutually exclusive.
 ```python
 from microbench import MicroBench, FileOutput, RedisOutput
 
-bench = MicroBench(outputs=[
-    FileOutput('/home/user/results.jsonl'),
-    RedisOutput('microbench:mykey', host='redis-host', port=6379),
-])
+bench = MicroBench(
+    outputs=[
+        FileOutput('/home/user/results.jsonl'),
+        RedisOutput('microbench:mykey', host='redis-host', port=6379),
+    ]
+)
 ```
 
 `get_results()` reads from the first sink that supports it. The `format` and
@@ -143,17 +148,19 @@ available, such as on cloud or HPC clusters. Requires
 ```python
 from microbench import MicroBench, RedisOutput
 
-bench = MicroBench(outputs=[
-    RedisOutput('microbench:mykey', host='redis-host', port=6379)
-])
+bench = MicroBench(
+    outputs=[RedisOutput('microbench:mykey', host='redis-host', port=6379)]
+)
+
 
 @bench
 def my_function():
     pass
 
+
 my_function()
 
-results = bench.get_results()              # list of dicts
+results = bench.get_results()  # list of dicts
 results = bench.get_results(format='df')  # pandas DataFrame
 ```
 
@@ -175,10 +182,14 @@ bench = MicroBench(outputs=[HttpOutput('https://example.com/events')])
 Add authentication headers:
 
 ```python
-bench = MicroBench(outputs=[HttpOutput(
-    'https://api.example.com/benchmarks',
-    headers={'Authorization': 'Bearer my-secret-token'},
-)])
+bench = MicroBench(
+    outputs=[
+        HttpOutput(
+            'https://api.example.com/benchmarks',
+            headers={'Authorization': 'Bearer my-secret-token'},
+        )
+    ]
+)
 ```
 
 Override `format_payload()` to customize the body shape (e.g. for Slack):
@@ -187,10 +198,12 @@ Override `format_payload()` to customize the body shape (e.g. for Slack):
 import json
 from microbench import HttpOutput
 
+
 class SlackOutput(HttpOutput):
     def format_payload(self, record):
         name = record.get('call', {}).get('name', '?')
         return json.dumps({'text': f'Benchmark `{name}` finished.'}).encode()
+
 
 bench = MicroBench(outputs=[SlackOutput('https://hooks.slack.com/services/...')])
 ```
@@ -205,9 +218,11 @@ Subclass `Output` and implement `write` to send results anywhere:
 ```python
 from microbench import MicroBench, Output
 
+
 class MyOutput(Output):
     def write(self, bm_json_str):
         send_to_my_system(bm_json_str)
+
 
 bench = MicroBench(outputs=[MyOutput()])
 ```
@@ -217,11 +232,12 @@ bench = MicroBench(outputs=[MyOutput()])
 Read results back via `get_results()`:
 
 ```python
-results = bench.get_results()              # list of dicts — no extra dependencies
+results = bench.get_results()  # list of dicts — no extra dependencies
 results = bench.get_results(format='df')  # pandas DataFrame
 
 # or read directly with pandas:
 import pandas
+
 results = pandas.read_json('/home/user/results.jsonl', lines=True)
 ```
 
@@ -246,5 +262,6 @@ The module-level `summary()` accepts any list of result dicts:
 
 ```python
 from microbench import summary
+
 summary(bench.get_results())
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,8 @@ inline-quotes = "single"
 [tool.ruff.lint.per-file-ignores]
 # pandas is imported to test that its version is captured in global packages
 "tests/globals_capture.py" = ["F401"]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.16.3",
+]


### PR DESCRIPTION
Update the pre-commit hook and add ruff as a uv dev dependency, both pinned to the latest release. CI's ruff-action was already on the latest tag.

Reformat all files with the new ruff version, which now also formats Python code blocks embedded in Markdown fences.